### PR TITLE
feat(qa): Dependabot + Semgrep OSS baseline (Phase 1 S2)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,38 @@
+# Dependabot — Phase 1 S2 (2026-04-30)
+# 근거: wiki/shared/qa-strategy-research-20260430.md § Phase 1.3
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Seoul"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+    labels:
+      - "dependencies"
+    groups:
+      # patch + minor 일괄 묶음 — PR noise 감소
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Seoul"
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: "chore(ci)"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "github-actions"

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,0 +1,37 @@
+# Semgrep OSS SAST — Phase 1 S2 (2026-04-30)
+#
+# 근거: wiki/shared/qa-strategy-research-20260430.md § Phase 1.4
+# 정책:
+#   - PR 마다 + 주 1회 schedule scan (push: main 트리거 일단 제외 — Phase 1 안정화 후 추가)
+#   - --severity ERROR --error: ERROR 레벨만 fail. WARNING/INFO 는 출력만 (baseline)
+#   - --config auto: 언어 자동 감지 + 적합 ruleset (Next.js · React · TypeScript · 보안)
+#   - SEMGREP_APP_TOKEN 없음 (OSS 모드)
+
+name: Semgrep OSS
+
+on:
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '0 0 * * 0'  # 매주 일요일 00:00 UTC (월요일 09:00 KST)
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: semgrep-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  semgrep:
+    name: Scan (OSS)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    container:
+      image: semgrep/semgrep
+    if: (github.actor != 'dependabot[bot]')
+    steps:
+      - uses: actions/checkout@v5
+      - name: Semgrep scan
+        run: semgrep scan --config auto --severity ERROR --error


### PR DESCRIPTION
## Summary
- `.github/dependabot.yml`: npm + github-actions 주 1회 (월요일 09:00 KST · group minor+patch)
- `.github/workflows/semgrep.yml`: Semgrep OSS PR + 주 1회 schedule · `--severity ERROR --error`

## 정책 근거
- `wiki/shared/qa-strategy-research-20260430.md` § Phase 1.3·1.4 (D3 대장 승인)

## Phase 1 baseline 모드
- Semgrep `ERROR` 만 fail (WARNING/INFO 출력만) — 첫 도입에서 baseline 잡고 Phase 2 strict mode
- Dependabot 첫 PR 들은 머지 후 별도 검토

## Test plan
- [x] CI Semgrep scan 통과 (ERROR 0)
- [ ] Dependabot 활성 확인 (Insights → Dependency graph)

🤖 Generated with [Claude Code](https://claude.com/claude-code)