### PR TITLE
feat(qa): TruffleHog server-side secret scan (D 옵션 cookie-cutter)

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,0 +1,43 @@
+# TruffleHog server-side secret scan — Phase 1 S4 보강 (2026-05-01)
+#
+# 근거: wiki/shared/qa-strategy-research-20260430.md § Phase 1.2
+# 정책 (D 옵션):
+#   - GitHub Push Protection 미지원 (Free private repo 제한) → server-side 보완재
+#   - gitleaks pre-commit (client-side · 4 머신) + TruffleHog CI (server-side · 매 push) 조합
+#   - --only-verified flag: 진짜 작동 token 만 alert (활성 검증 · false positive 0 가까움)
+#   - 발견 시 즉시 PR fail / push 시 main 차단 (branch protection 결합 시)
+
+name: TruffleHog Secret Scan
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: trufflehog-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  trufflehog:
+    name: Scan
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Run TruffleHog
+        uses: trufflesecurity/trufflehog@main
+        with:
+          base: ${{ github.event.repository.default_branch }}
+          head: HEAD
+          # --only-verified: 활성 token 만 (HTTP request 로 실제 verify)
+          # --fail: finding 발견 시 exit 1 → CI fail
+          extra_args: --only-verified --fail

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -39,5 +39,6 @@ jobs:
           base: ${{ github.event.repository.default_branch }}
           head: HEAD
           # --only-verified: 활성 token 만 (HTTP request 로 실제 verify)
-          # --fail: finding 발견 시 exit 1 → CI fail
-          extra_args: --only-verified --fail
+          # NOTE: trufflesecurity/trufflehog action default 가 이미 --fail 이라
+          # extra_args 에 --fail 추가하면 중복 에러 ("flag 'fail' cannot be repeated")
+          extra_args: --only-verified


### PR DESCRIPTION
## Summary
- `.github/workflows/secret-scan.yml`: TruffleHog server-side secret scan
- 매 push:main + PR 마다 자동 — `--only-verified --fail` (활성 token 만 alert · false positive 0 가까움)

## 정책 근거
- `wiki/shared/qa-strategy-research-20260430.md` § Phase 1.2
- D 옵션 (대장 2026-05-01 승인) — GitHub Push Protection Free private repo 미지원 → server-side 보완재
- gitleaks pre-commit (client-side · 4 머신) + TruffleHog CI (server-side · 매 push) 조합

🤖 Generated with [Claude Code](https://claude.com/claude-code)