### PR TITLE
test(qa-gate): schedule-edit A4 mutation SLA (B1 1차 · 단계 도입)

### DIFF
--- a/tests/qa-gate/schedule-edit.spec.ts
+++ b/tests/qa-gate/schedule-edit.spec.ts
@@ -1,0 +1,115 @@
+import {test, expect, Page} from '@playwright/test';
+
+/**
+ * plan1 mutation E2E gate — A4 스케줄 편집 (RPN 48 Medium)
+ *
+ * 시나리오 (PICT model `edit-schedule.txt` happy path):
+ *   - schedule 1개 추가 (내일 · 30분)
+ *   - 카드 클릭 → 편집 모달 → durationMin 30 → 60
+ *   - 저장 → 모달 닫힘 → SLA (warm < 3000ms)
+ *   - 카드 표시 확인 + cleanup 삭제
+ *
+ * 4/29 사고 회귀 catch:
+ *   - cross-region RTT (5초 latency) → updateSchedule mutation SLA 초과 시 fail
+ *   - cascade 발동 회귀 → durationMin 변경 시 다른 chained schedule 영향 (PBT 단위 검증 + E2E SLA 측정)
+ *
+ * 차이 (mutation-e2e.spec.ts schedule-add 와):
+ *   - schedule-add: 새 schedule 생성 mutation (createSchedule)
+ *   - schedule-edit: 기존 schedule update mutation (updateSchedule) — 4/29 사고 같은 cascade·sequential await loop 가능 영역
+ *
+ * SLA:
+ *   - warm  : < 3000ms
+ *   - cold  : < 5000ms
+ *
+ * 측정 출력 형식 (parseable):
+ *   [qa-gate] schedule_edit_ms=NNN cold=true|false
+ */
+
+const SLA_WARM_MS = 3000;
+const SLA_COLD_MS = 5000;
+
+function dialogOf(page: Page, headingName: string | RegExp) {
+  const heading = page.getByRole('heading', {name: headingName});
+  const dialog = page.locator('div.max-w-md').filter({has: heading}).first();
+  return {heading, dialog};
+}
+
+test.describe('plan1 mutation E2E — A4 스케줄 편집', () => {
+  test('schedule 편집 (durationMin 30→60) → 응답 SLA + cleanup', async ({page}) => {
+    const title = `qa-edit-${Date.now()}`;
+    const catName = `cat-edit-${Date.now()}`;
+
+    // 0. 진입
+    await page.goto('/project/plan1/');
+
+    // 1. 카테고리 보장
+    await page.getByRole('button', {name: '카테고리'}).click();
+    const cat = dialogOf(page, /categories|카테고리/i);
+    await expect(cat.dialog).toBeVisible({timeout: 5_000});
+    await cat.dialog.getByRole('textbox').first().fill(catName);
+    await cat.dialog.getByRole('button', {name: '추가', exact: true}).click();
+    await expect(cat.dialog.getByText(catName)).toBeVisible({timeout: SLA_COLD_MS});
+    await cat.dialog.getByRole('button', {name: '닫기', exact: true}).click();
+    await expect(cat.dialog).toBeHidden({timeout: 3_000});
+
+    // 2. + 새 스케줄 (편집 대상 사전 생성)
+    const newBtn = page.getByRole('button', {name: '+ 새 스케줄'});
+    await expect(newBtn).toBeEnabled({timeout: 10_000});
+    await newBtn.click();
+
+    const sched = dialogOf(page, '새 스케줄');
+    await expect(sched.heading).toBeVisible({timeout: 5_000});
+    await sched.dialog.getByRole('textbox').first().fill(title);
+    const tomorrow = new Date(Date.now() + 86_400_000);
+    const tomorrowIso = `${tomorrow.getFullYear()}-${String(tomorrow.getMonth() + 1).padStart(2, '0')}-${String(tomorrow.getDate()).padStart(2, '0')}`;
+    await sched.dialog.locator('input[type="date"]').fill(tomorrowIso);
+    await sched.dialog.locator('input[type="number"]').fill('30');
+    await sched.dialog.getByRole('button', {name: '추가', exact: true}).click();
+    await expect(sched.heading).toBeHidden({timeout: SLA_COLD_MS + 2_000});
+    await expect(page.getByText(title).first()).toBeVisible({timeout: 5_000});
+
+    // 3. 카드 클릭 → 편집 모달 열림
+    await page.getByText(title).first().click();
+    const edit = dialogOf(page, '스케줄 편집');
+    await expect(edit.heading).toBeVisible({timeout: 5_000});
+
+    // 4. durationMin 30 → 60 변경
+    //    NewScheduleModal 의 input[type="number"] 가 durationMin 단일 필드 (i18n 'durationMin' 라벨)
+    await edit.dialog.locator('input[type="number"]').fill('60');
+
+    // 5. 측정: 저장 click → 모달 닫힘
+    //    편집 모드에서 버튼 라벨이 '저장' (i18n: t.modal.save = "저장" · 신규 모드 'add' 와 구분)
+    const startMs = Date.now();
+    await edit.dialog.getByRole('button', {name: '저장', exact: true}).click();
+    await expect(edit.heading).toBeHidden({timeout: SLA_COLD_MS + 2_000});
+    const elapsedMs = Date.now() - startMs;
+
+    const isCold = elapsedMs > SLA_WARM_MS;
+    const threshold = isCold ? SLA_COLD_MS : SLA_WARM_MS;
+    console.log(
+      `[qa-gate] schedule_edit_ms=${elapsedMs} cold=${isCold} threshold=${threshold}`
+    );
+
+    // 6. SLA 게이트 (4/29 사고 catch 한도 보존 — `dev-process.md` § mutation E2E 가드)
+    expect(
+      elapsedMs,
+      `updateSchedule mutation 응답 ${elapsedMs}ms — ${
+        isCold ? 'cold' : 'warm'
+      } SLA ${threshold}ms 초과. 4/29 cross-region latency 패턴 회귀 가능성. cascade·sequential await loop 영역 진단 필요.`
+    ).toBeLessThan(threshold);
+
+    // 7. 카드 표시 확인 (편집 후 schedule 여전히 존재)
+    await expect(page.getByText(title).first()).toBeVisible({timeout: 5_000});
+
+    // 8. cleanup — schedule 삭제 (orphan row 누적 차단)
+    await page.getByText(title).first().click();
+    const cleanup = dialogOf(page, '스케줄 편집');
+    await expect(cleanup.heading).toBeVisible({timeout: 5_000});
+    await cleanup.dialog.getByRole('button', {name: '삭제', exact: true}).click();
+    await cleanup.dialog
+      .getByRole('button', {name: '삭제 확인', exact: true})
+      .click();
+    await expect(cleanup.heading).toBeHidden({timeout: SLA_COLD_MS});
+    await expect(page.getByText(title)).toHaveCount(0, {timeout: 3_000});
+  });
+});


### PR DESCRIPTION
## Summary
plan1 mutation E2E 8 spec 확장 (B1) 의 1차 PR. 첫 시도라 차근차근 — schedule-edit A4 1 spec 만 + CI 검증 후 후속 PR.

근거:
- `wiki/projects/plan1/risk-matrix.md` A4 RPN 48 Medium
- `wiki/shared/test-case-design-principles.md` § 12.4 plan1 mutation E2E 8 spec 확장
- 대장 "차근차근 첫 시도" 결정 (2026-05-02)

신설:
- `tests/qa-gate/schedule-edit.spec.ts` — A4 편집 mutation SLA (warm 3000ms / cold 5000ms)

차이 (기존 `mutation-e2e.spec.ts` schedule-add 와):
- schedule-add: createSchedule mutation (이미 박힘)
- schedule-edit: updateSchedule mutation — 4/29 cross-region latency · cascade · sequential await loop 회귀 catch 영역 (다른 mutation 경로)

## Test plan
- [x] gitleaks pre-commit 통과
- [ ] Vercel preview deploy
- [ ] qa-mutation-e2e workflow 통과 (schedule-add + schedule-edit 둘 다 SLA 안)
- [ ] semgrep / dependabot 통과
- [ ] Neon ephemeral cleanup

## 후속 PR (별도)
- A1 로그인 (Better Auth · 보안 영역)
- A7 카테고리 삭제 (cascade 영향)
- A9 cascade-bump (Critical RPN 80 · 4/29 사고 직접 영역 — ActiveTimer 활성화 흐름 신중하게)
- A10 즉시 완료 (cascade 함께)
- A11 working hours (split 재계산)
- `mutation-e2e.spec.ts` → `schedule-add.spec.ts` rename (의도 명확화)

## 첫 시도 정직성
- selector·assertion 환각 가능성 — CI 첫 run 에서 실측 후 보강
- prod DB qa-bot rate limit — 동시 실행 conflict 발생 시 sequential 강제 검토
- 편집 모드 버튼 라벨 '저장' 추정 (NewScheduleModal i18n `t.modal.save`) — CI fail 시 실제 라벨 확인 후 수정

🤖 Generated with [Claude Code](https://claude.com/claude-code)