### PR TITLE
test(qa-gate): A7 category-delete + A11 working-hours mutation SLA (B1 2차 · 단계 도입)

### DIFF
--- a/tests/qa-gate/category-delete.spec.ts
+++ b/tests/qa-gate/category-delete.spec.ts
@@ -1,0 +1,93 @@
+import {test, expect, Page} from '@playwright/test';
+
+/**
+ * plan1 mutation E2E gate — A7 카테고리 삭제 (RPN 32 Medium)
+ *
+ * 시나리오 (PICT model `category-delete.txt` happy path · no_schedule case):
+ *   - 카테고리 모달 진입
+ *   - 카테고리 1개 추가
+ *   - 같은 카테고리 삭제 버튼 1차 클릭 (armed → "confirm rm (0)" 라벨 변경)
+ *   - 2차 클릭 → 실제 삭제 mutation → SLA (warm < 3000ms)
+ *   - 카테고리 list 에서 사라진 것 확인
+ *
+ * 4/29 사고 catch 차이:
+ *   - schedule-add: createSchedule mutation
+ *   - schedule-edit: updateSchedule mutation
+ *   - category-delete: deleteCategory mutation — 다른 server action 경로 (cascade · cleanOrphans 호출 가능)
+ *
+ * SLA:
+ *   - warm  : < 3000ms
+ *   - cold  : < 5000ms
+ *
+ * 측정 출력 형식:
+ *   [qa-gate] category_delete_ms=NNN cold=true|false
+ *
+ * cleanup:
+ *   - 삭제 자체가 cleanup (사용 schedule 0건 case 라 orphan 없음)
+ */
+
+const SLA_WARM_MS = 3000;
+const SLA_COLD_MS = 5000;
+
+function dialogOf(page: Page, headingName: string | RegExp) {
+  const heading = page.getByRole('heading', {name: headingName});
+  const dialog = page.locator('div.max-w-md').filter({has: heading}).first();
+  return {heading, dialog};
+}
+
+test.describe('plan1 mutation E2E — A7 카테고리 삭제', () => {
+  test('카테고리 추가 → 삭제 (no_schedule case) → 응답 SLA', async ({page}) => {
+    const catName = `cat-del-${Date.now()}`;
+
+    // 0. 진입
+    await page.goto('/project/plan1/');
+
+    // 1. 카테고리 모달 진입
+    await page.getByRole('button', {name: '카테고리'}).click();
+    const cat = dialogOf(page, /categories|카테고리/i);
+    await expect(cat.dialog).toBeVisible({timeout: 5_000});
+
+    // 2. 카테고리 추가 (이번 spec 의 삭제 대상 사전 생성)
+    await cat.dialog.getByRole('textbox').first().fill(catName);
+    await cat.dialog.getByRole('button', {name: '추가', exact: true}).click();
+    await expect(cat.dialog.getByText(catName)).toBeVisible({timeout: SLA_COLD_MS});
+
+    // 3. 삭제 버튼 1차 클릭 (armed)
+    //    catName 이 포함된 li 행 안의 button (name=/rm/) 찾기
+    //    i18n category.removeButton = "rm"
+    const row = cat.dialog.locator('li').filter({hasText: catName});
+    await expect(row).toBeVisible({timeout: 3_000});
+    await row.getByRole('button', {name: 'rm', exact: true}).click();
+
+    // 4. armed 상태 — 라벨이 "confirm rm (0)" 으로 변경 (사용 schedule 0건)
+    //    i18n category.confirmRemoveLabel = "confirm rm ({count})"
+    const confirmBtn = row.getByRole('button', {name: /^confirm rm/});
+    await expect(confirmBtn).toBeVisible({timeout: 3_000});
+
+    // 5. 측정: 2차 클릭 → mutation 응답 → list 에서 사라짐
+    const startMs = Date.now();
+    await confirmBtn.click();
+    await expect(cat.dialog.getByText(catName)).toHaveCount(0, {
+      timeout: SLA_COLD_MS + 2_000,
+    });
+    const elapsedMs = Date.now() - startMs;
+
+    const isCold = elapsedMs > SLA_WARM_MS;
+    const threshold = isCold ? SLA_COLD_MS : SLA_WARM_MS;
+    console.log(
+      `[qa-gate] category_delete_ms=${elapsedMs} cold=${isCold} threshold=${threshold}`
+    );
+
+    // 6. SLA 게이트 (4/29 사고 catch 한도 보존)
+    expect(
+      elapsedMs,
+      `deleteCategory mutation 응답 ${elapsedMs}ms — ${
+        isCold ? 'cold' : 'warm'
+      } SLA ${threshold}ms 초과. cascade · cleanOrphans 영역 진단 필요.`
+    ).toBeLessThan(threshold);
+
+    // 7. 모달 닫기 (cleanup 자체 — 다른 spec 영향 없게)
+    await cat.dialog.getByRole('button', {name: '닫기', exact: true}).click();
+    await expect(cat.dialog).toBeHidden({timeout: 3_000});
+  });
+});

--- a/tests/qa-gate/category-delete.spec.ts
+++ b/tests/qa-gate/category-delete.spec.ts
@@ -6,9 +6,15 @@ import {test, expect, Page} from '@playwright/test';
  * 시나리오 (PICT model `category-delete.txt` happy path · no_schedule case):
  *   - 카테고리 모달 진입
  *   - 카테고리 1개 추가
- *   - 같은 카테고리 삭제 버튼 1차 클릭 (armed → "confirm rm (0)" 라벨 변경)
- *   - 2차 클릭 → 실제 삭제 mutation → SLA (warm < 3000ms)
+ *   - 같은 카테고리 삭제 버튼 1차 클릭 → **즉시 삭제 mutation** (CategoryManager.handleRemove
+ *     의 count === 0 분기 = armed 단계 skip · 정공 동작) → SLA (warm < 3000ms)
  *   - 카테고리 list 에서 사라진 것 확인
+ *
+ * 첫 시도 정직성 (2026-05-02):
+ *   - 1차 시도 가정 ("always armed → confirm 2차 클릭") = 환각.
+ *     CategoryManager.handleRemove 실측: scheduleCountByCat===0 이면 1차 즉시 삭제,
+ *     >0 이면 armed→confirm 2단계. PICT model no_schedule case 는 1차 즉시 삭제 정확.
+ *   - armed 단계 검증은 별도 spec (one_schedule 또는 many_schedules_50 case · 후속 PR).
  *
  * 4/29 사고 catch 차이:
  *   - schedule-add: createSchedule mutation
@@ -52,21 +58,18 @@ test.describe('plan1 mutation E2E — A7 카테고리 삭제', () => {
     await cat.dialog.getByRole('button', {name: '추가', exact: true}).click();
     await expect(cat.dialog.getByText(catName)).toBeVisible({timeout: SLA_COLD_MS});
 
-    // 3. 삭제 버튼 1차 클릭 (armed)
-    //    catName 이 포함된 li 행 안의 button (name=/rm/) 찾기
+    // 3. 삭제 버튼 측정: 1차 클릭 = 즉시 삭제 mutation (no_schedule case)
+    //    catName 이 포함된 li 행 안의 button (name="rm") 찾기
     //    i18n category.removeButton = "rm"
+    //    CategoryManager.handleRemove 의 count===0 분기 = armed 단계 skip · 1차 즉시 삭제
     const row = cat.dialog.locator('li').filter({hasText: catName});
     await expect(row).toBeVisible({timeout: 3_000});
-    await row.getByRole('button', {name: 'rm', exact: true}).click();
+    const rmBtn = row.getByRole('button', {name: 'rm', exact: true});
+    await expect(rmBtn).toBeVisible({timeout: 3_000});
 
-    // 4. armed 상태 — 라벨이 "confirm rm (0)" 으로 변경 (사용 schedule 0건)
-    //    i18n category.confirmRemoveLabel = "confirm rm ({count})"
-    const confirmBtn = row.getByRole('button', {name: /^confirm rm/});
-    await expect(confirmBtn).toBeVisible({timeout: 3_000});
-
-    // 5. 측정: 2차 클릭 → mutation 응답 → list 에서 사라짐
+    // 4. 측정: 1차 click → mutation 응답 → list 에서 사라짐
     const startMs = Date.now();
-    await confirmBtn.click();
+    await rmBtn.click();
     await expect(cat.dialog.getByText(catName)).toHaveCount(0, {
       timeout: SLA_COLD_MS + 2_000,
     });

--- a/tests/qa-gate/working-hours.spec.ts
+++ b/tests/qa-gate/working-hours.spec.ts
@@ -1,0 +1,86 @@
+import {test, expect, Page} from '@playwright/test';
+
+/**
+ * plan1 mutation E2E gate — A11 working hours 설정 (RPN 40 Medium)
+ *
+ * 시나리오 (PICT model `working-hours.txt` happy path · single mode · all_within case):
+ *   - "업무시간" 버튼 클릭 → WorkingHoursEditor 모달
+ *   - single mode · future unique date (1년 후 + random offset)
+ *   - startTime / endTime 변경
+ *   - 저장 click → setWorkingHours mutation → SLA (warm < 3000ms)
+ *   - 모달 닫힘 확인
+ *
+ * 4/29 사고 catch 차이:
+ *   - createSchedule / updateSchedule / deleteCategory 와 다른 server action 경로
+ *   - working-hours mutation 은 split 재계산 발동 가능 (다른 schedule 영향)
+ *
+ * SLA:
+ *   - warm  : < 3000ms
+ *   - cold  : < 5000ms
+ *
+ * 측정 출력 형식:
+ *   [qa-gate] working_hours_ms=NNN cold=true|false
+ *
+ * cleanup 정직성:
+ *   - 매 spec 마다 unique future date (1년 후 + random) 사용 → orphan 1 row 누적 (PR 1 run 당 1 row)
+ *   - 영향 작음 (working_hours 테이블만 · prod DB 다른 테이블 무관)
+ *   - 정공 cleanup 은 default 복원이지만 default 모름 — 보류 (옵션 A 채택)
+ */
+
+const SLA_WARM_MS = 3000;
+const SLA_COLD_MS = 5000;
+
+function dialogOf(page: Page, headingName: string | RegExp) {
+  const heading = page.getByRole('heading', {name: headingName});
+  const dialog = page.locator('div.max-w-md').filter({has: heading}).first();
+  return {heading, dialog};
+}
+
+test.describe('plan1 mutation E2E — A11 working hours', () => {
+  test('working hours 설정 (single · future unique date) → 응답 SLA', async ({page}) => {
+    // 0. 진입
+    await page.goto('/project/plan1/');
+
+    // 1. "업무시간" 버튼 클릭 → WorkingHoursEditor
+    //    i18n nav.workingHours = "업무시간"
+    await page.getByRole('button', {name: '업무시간', exact: true}).click();
+    const wh = dialogOf(page, /working hours/i);
+    await expect(wh.dialog).toBeVisible({timeout: 5_000});
+
+    // 2. single mode default · future unique date 설정
+    //    1년 후 + random 30 days offset → orphan 누적 영향 최소
+    const futureDays = 365 + Math.floor(Math.random() * 30);
+    const futureMs = Date.now() + futureDays * 86_400_000;
+    const futureDate = new Date(futureMs);
+    const futureIso = `${futureDate.getFullYear()}-${String(
+      futureDate.getMonth() + 1
+    ).padStart(2, '0')}-${String(futureDate.getDate()).padStart(2, '0')}`;
+    await wh.dialog.locator('input[type="date"]').fill(futureIso);
+
+    // 3. startTime / endTime 변경 (10:00 → 18:00 — qa-bot default 와 다른 값으로 mutation 보장)
+    const timeInputs = wh.dialog.locator('input[type="time"]');
+    await timeInputs.nth(0).fill('10:00');
+    await timeInputs.nth(1).fill('18:00');
+
+    // 4. 측정: 저장 click → 모달 닫힘
+    //    i18n common.save = "저장"
+    const startMs = Date.now();
+    await wh.dialog.getByRole('button', {name: '저장', exact: true}).click();
+    await expect(wh.heading).toBeHidden({timeout: SLA_COLD_MS + 2_000});
+    const elapsedMs = Date.now() - startMs;
+
+    const isCold = elapsedMs > SLA_WARM_MS;
+    const threshold = isCold ? SLA_COLD_MS : SLA_WARM_MS;
+    console.log(
+      `[qa-gate] working_hours_ms=${elapsedMs} cold=${isCold} threshold=${threshold} date=${futureIso}`
+    );
+
+    // 5. SLA 게이트 (4/29 사고 catch 한도 보존)
+    expect(
+      elapsedMs,
+      `setWorkingHours mutation 응답 ${elapsedMs}ms — ${
+        isCold ? 'cold' : 'warm'
+      } SLA ${threshold}ms 초과. split 재계산 · sequential await loop 영역 진단 필요.`
+    ).toBeLessThan(threshold);
+  });
+});


### PR DESCRIPTION
## Summary
B1 2차 PR — 단순 UI mutation 2 spec 추가.

근거:
- `wiki/projects/plan1/risk-matrix.md` A7 RPN 32 · A11 RPN 40 (Medium)
- `wiki/shared/test-case-design-principles.md` § 12.4
- 대장 "전부다 순차진행" 결정 (2026-05-02)

신설:
- `tests/qa-gate/category-delete.spec.ts` — A7 deleteCategory mutation SLA (cascade·cleanOrphans 영역)
- `tests/qa-gate/working-hours.spec.ts` — A11 setWorkingHours mutation SLA (split 재계산 영역)

차이 (기존 spec 과):
- schedule-add (createSchedule · PR #16) / schedule-edit (updateSchedule · PR #18) / **category-delete (deleteCategory) · working-hours (setWorkingHours)** — 4 mutation 경로 모두 별도 SLA 검증

## Test plan
- [x] gitleaks pre-commit 통과
- [ ] Vercel preview deploy
- [ ] qa-mutation-e2e workflow 통과 (4 spec 동시 실행)
- [ ] semgrep / dependabot 통과
- [ ] Neon ephemeral cleanup

## 첫 시도 정직성 (실측 후 수정 패턴)
- A7: 카테고리 row locator (`li.filter({hasText: catName})`) 환각 가능성 — CI 첫 run 에서 실측 후 수정
- A11: working hours single mode default · time input order (start/end) 추정 — fail 시 fix
- A11 cleanup 정직성: future unique date orphan 누적 옵션 A 채택 (PR run 당 1 row · 영향 작음)

## 후속 PR (별도 · 순차)
- PR #20: A9 cascade-bump + A10 즉시 완료 (ActiveTimer 활성화 흐름 신중 설계)
- PR #21: A1 로그인 fresh (Better Auth rate limit)
- PR #22: mutation-e2e.spec.ts → schedule-add.spec.ts rename

🤖 Generated with [Claude Code](https://claude.com/claude-code)