### PR TITLE
test(qa-gate): A9 cascade-bump + A10 instant-complete mutation SLA (B1 3차)

### DIFF
--- a/tests/qa-gate/cascade-bump.spec.ts
+++ b/tests/qa-gate/cascade-bump.spec.ts
@@ -51,7 +51,14 @@ test.describe('plan1 mutation E2E — A9 cascade-bump (Critical · 4/29 영역)'
     const title = `qa-bump-${Date.now()}`;
     const catName = `cat-bump-${Date.now()}`;
 
-    // 0. 진입
+    // 0. 진입 + clock fake (분 boundary race 회피)
+    //    1차 시도: clock fake 불요 (NewScheduleModal "now" 버튼 충분) — 환각
+    //    2차 실측: "now" click ~ "추가" click 사이 분 boundary 넘어가면 isFuture false →
+    //              startAt 이 1분 과거 → 추가 button disabled 또는 schedule active 윈도우 진입 실패
+    //    → page.clock.install 로 시간 freeze (분 boundary 0초) — 정공
+    const fixedTime = new Date();
+    fixedTime.setSeconds(0, 0);
+    await page.clock.install({time: fixedTime});
     await page.goto('/project/plan1/');
 
     // 1. 카테고리 보장

--- a/tests/qa-gate/cascade-bump.spec.ts
+++ b/tests/qa-gate/cascade-bump.spec.ts
@@ -73,10 +73,10 @@ test.describe('plan1 mutation E2E — A9 cascade-bump (Critical · 4/29 영역)'
     await expect(sched.heading).toBeVisible({timeout: 5_000});
     await sched.dialog.getByRole('textbox').first().fill(title);
 
-    // 3. "지금" 버튼 클릭 — date=오늘, hour·minute=현재 시각 자동 set
+    // 3. "now" 버튼 클릭 — date=오늘, hour·minute=현재 시각 자동 set
     //    minuteOptions useMemo 가 표준 boundary 외 분 dynamic 추가 → isFuture 통과
-    //    i18n schedule.buttonNow = "지금"
-    await sched.dialog.getByRole('button', {name: '지금', exact: true}).click();
+    //    i18n schedule.buttonNow = "now (시작을 지금으로)" — regex 로 i18n 변경 catch
+    await sched.dialog.getByRole('button', {name: /^now/}).click();
 
     // 4. duration 60min 입력 (단일 input[type=number] · ActiveTimer 윈도우 충분히 길게)
     await sched.dialog.locator('input[type="number"]').fill('60');

--- a/tests/qa-gate/cascade-bump.spec.ts
+++ b/tests/qa-gate/cascade-bump.spec.ts
@@ -1,0 +1,125 @@
+import {test, expect, Page} from '@playwright/test';
+
+/**
+ * plan1 mutation E2E gate — A9 타이머 bump (cascade 발동) — Critical RPN 80
+ *
+ * 4/29 5초 latency 사고 직접 영역. cross-region (Vercel iad1 ↔ Neon ap-southeast-1)
+ * × sequential await loop × cascade chain shift 결합 결함 catch.
+ *
+ * 시나리오 (PICT model `cascade-bump.txt` happy path · n_1 case · warm path):
+ *   - schedule 1개 추가 — "지금" 버튼 클릭 (현재 분 set · isFuture 통과 + 즉시 active 윈도우 진입)
+ *   - duration 60min · 추가 → ActiveTimer 즉시 표시
+ *   - `+30m` 버튼 클릭 → extendScheduleBy mutation (cascade 발동 가능 영역)
+ *   - SLA (warm < 3000ms / cold < 5000ms)
+ *   - cleanup: schedule 삭제
+ *
+ * ActiveTimer 활성화 흐름 (선코드 실측 · 2026-05-02):
+ *   - findActiveSchedules: status !== 'done' AND startAt <= now < startAt + durationMin*60000
+ *   - useNow: setInterval(1000) 1초 갱신 + Date.now() 직접 호출
+ *   - NewScheduleModal `setNowStart` 버튼: date=오늘 + hour·minute = 현재 시각 set
+ *   - minuteOptions useMemo: 표준 boundary 외 분도 dynamic 추가 ([0,10,20,23,30,40,50] 등)
+ *   - isFuture: Math.floor(startAt/60000) >= Math.floor(now/60000) — 같은 분이면 통과
+ *   - → "지금" 클릭 + 추가 → 같은 분 startAt schedule = 즉시 active (clock fake 불요 · 정공)
+ *
+ * 4/29 catch 차이 (다른 spec 과):
+ *   - schedule-add: createSchedule (insert)
+ *   - schedule-edit: updateSchedule (update)
+ *   - category-delete: deleteCategory
+ *   - working-hours: setWorkingHours
+ *   - **cascade-bump: extendScheduleBy (cascade chain shift 가능 — 4/29 직접 영역)**
+ *
+ * SLA 측정 출력 형식:
+ *   [qa-gate] cascade_bump_ms=NNN cold=true|false
+ *
+ * 첫 시도 정직성 (2026-05-02):
+ *   - 1차 시도 가정 "Playwright clock fake 로 ActiveTimer 활성화 우회" = 환각 / 과잉 설계
+ *   - 실측 후 단순화: NewScheduleModal "지금" 버튼이 isFuture 통과 + 즉시 active 둘 다 해결
+ *   - clock fake 없이 정공 동작
+ */
+
+const SLA_WARM_MS = 3000;
+const SLA_COLD_MS = 5000;
+
+function dialogOf(page: Page, headingName: string | RegExp) {
+  const heading = page.getByRole('heading', {name: headingName});
+  const dialog = page.locator('div.max-w-md').filter({has: heading}).first();
+  return {heading, dialog};
+}
+
+test.describe('plan1 mutation E2E — A9 cascade-bump (Critical · 4/29 영역)', () => {
+  test('schedule active (지금 시작) → +30m bump SLA + cleanup', async ({page}) => {
+    const title = `qa-bump-${Date.now()}`;
+    const catName = `cat-bump-${Date.now()}`;
+
+    // 0. 진입
+    await page.goto('/project/plan1/');
+
+    // 1. 카테고리 보장
+    await page.getByRole('button', {name: '카테고리'}).click();
+    const cat = dialogOf(page, /categories|카테고리/i);
+    await expect(cat.dialog).toBeVisible({timeout: 5_000});
+    await cat.dialog.getByRole('textbox').first().fill(catName);
+    await cat.dialog.getByRole('button', {name: '추가', exact: true}).click();
+    await expect(cat.dialog.getByText(catName)).toBeVisible({timeout: SLA_COLD_MS});
+    await cat.dialog.getByRole('button', {name: '닫기', exact: true}).click();
+    await expect(cat.dialog).toBeHidden({timeout: 3_000});
+
+    // 2. + 새 스케줄
+    const newBtn = page.getByRole('button', {name: '+ 새 스케줄'});
+    await expect(newBtn).toBeEnabled({timeout: 10_000});
+    await newBtn.click();
+
+    const sched = dialogOf(page, '새 스케줄');
+    await expect(sched.heading).toBeVisible({timeout: 5_000});
+    await sched.dialog.getByRole('textbox').first().fill(title);
+
+    // 3. "지금" 버튼 클릭 — date=오늘, hour·minute=현재 시각 자동 set
+    //    minuteOptions useMemo 가 표준 boundary 외 분 dynamic 추가 → isFuture 통과
+    //    i18n schedule.buttonNow = "지금"
+    await sched.dialog.getByRole('button', {name: '지금', exact: true}).click();
+
+    // 4. duration 60min 입력 (단일 input[type=number] · ActiveTimer 윈도우 충분히 길게)
+    await sched.dialog.locator('input[type="number"]').fill('60');
+
+    // 5. 추가 → schedule 생성 (즉시 active 윈도우 진입)
+    await sched.dialog.getByRole('button', {name: '추가', exact: true}).click();
+    await expect(sched.heading).toBeHidden({timeout: SLA_COLD_MS + 2_000});
+    await expect(page.getByText(title).first()).toBeVisible({timeout: 5_000});
+
+    // 6. ActiveTimer 표시 확인 — +30m 버튼 visible
+    //    (schedule.startAt <= now < startAt + 60min · 같은 분 안에 진입하면 active)
+    const bumpBtn = page.getByRole('button', {name: '+30m', exact: true});
+    await expect(bumpBtn).toBeVisible({timeout: 10_000});
+
+    // 7. 측정: +30m click → extendScheduleBy mutation → button 재 enabled
+    const startMs = Date.now();
+    await bumpBtn.click();
+    await expect(bumpBtn).toBeEnabled({timeout: SLA_COLD_MS + 2_000});
+    const elapsedMs = Date.now() - startMs;
+
+    const isCold = elapsedMs > SLA_WARM_MS;
+    const threshold = isCold ? SLA_COLD_MS : SLA_WARM_MS;
+    console.log(
+      `[qa-gate] cascade_bump_ms=${elapsedMs} cold=${isCold} threshold=${threshold}`
+    );
+
+    // 8. SLA 게이트 (4/29 사고 catch 한도 보존)
+    expect(
+      elapsedMs,
+      `extendScheduleBy mutation 응답 ${elapsedMs}ms — ${
+        isCold ? 'cold' : 'warm'
+      } SLA ${threshold}ms 초과. 4/29 cross-region × cascade chain shift × sequential await loop 영역 진단 필요.`
+    ).toBeLessThan(threshold);
+
+    // 9. cleanup — schedule 삭제 (orphan row 누적 차단)
+    await page.getByText(title).first().click();
+    const edit = dialogOf(page, '스케줄 편집');
+    await expect(edit.heading).toBeVisible({timeout: 5_000});
+    await edit.dialog.getByRole('button', {name: '삭제', exact: true}).click();
+    await edit.dialog
+      .getByRole('button', {name: '삭제 확인', exact: true})
+      .click();
+    await expect(edit.heading).toBeHidden({timeout: SLA_COLD_MS});
+    await expect(page.getByText(title)).toHaveCount(0, {timeout: 3_000});
+  });
+});

--- a/tests/qa-gate/cascade-bump.spec.ts
+++ b/tests/qa-gate/cascade-bump.spec.ts
@@ -53,13 +53,17 @@ test.describe('plan1 mutation E2E — A9 cascade-bump (Critical · 4/29 영역)'
 
     // 0. 진입 + clock fake (분 boundary race 회피)
     //    1차 시도: clock fake 불요 (NewScheduleModal "now" 버튼 충분) — 환각
-    //    2차 실측: "now" click ~ "추가" click 사이 분 boundary 넘어가면 isFuture false →
-    //              startAt 이 1분 과거 → 추가 button disabled 또는 schedule active 윈도우 진입 실패
-    //    → page.clock.install 로 시간 freeze (분 boundary 0초) — 정공
+    //    2차 실측: "now" click ~ "추가" click 사이 분 boundary 넘어가면 isFuture false → 추가 disabled
+    //    3차 fix: page.clock.install 으로 시간 freeze (분 boundary 0초)
+    //    4차 root cause (trace.zip 분석): clock.install 의 default 가 freeze → setInterval stop
+    //      → useNow (useSyncExternalStore subscribeNow) 의 1초 interval fire X → notify X
+    //      → SSR snapshot 0 → ActiveTimer idle 표시 → +30m 버튼 visible X (PR #20 1·2·3차 fail root cause)
+    //    Fix: clock 2초 fastForward → setInterval 첫 fire → notify → re-render → active 인식
     const fixedTime = new Date();
     fixedTime.setSeconds(0, 0);
     await page.clock.install({time: fixedTime});
     await page.goto('/project/plan1/');
+    await page.clock.fastForward(2000);
 
     // 1. 카테고리 보장
     await page.getByRole('button', {name: '카테고리'}).click();

--- a/tests/qa-gate/instant-complete.spec.ts
+++ b/tests/qa-gate/instant-complete.spec.ts
@@ -37,10 +37,14 @@ test.describe('plan1 mutation E2E — A10 instant-complete (High · cascade 영�
     const catName = `cat-cmp-${Date.now()}`;
 
     // 0. 진입 + clock fake (분 boundary race 회피 — cascade-bump.spec.ts 와 동일 패턴)
+    //    4차 root cause (trace.zip 분석): clock.install default freeze → setInterval stop
+    //      → useNow notify X → SSR snapshot 0 → ActiveTimer idle → complete 버튼 visible X
+    //    Fix: clock 2초 fastForward → setInterval 첫 fire → re-render → active 인식
     const fixedTime = new Date();
     fixedTime.setSeconds(0, 0);
     await page.clock.install({time: fixedTime});
     await page.goto('/project/plan1/');
+    await page.clock.fastForward(2000);
 
     // 1. 카테고리 보장
     await page.getByRole('button', {name: '카테고리'}).click();

--- a/tests/qa-gate/instant-complete.spec.ts
+++ b/tests/qa-gate/instant-complete.spec.ts
@@ -36,7 +36,10 @@ test.describe('plan1 mutation E2E — A10 instant-complete (High · cascade 영�
     const title = `qa-cmp-${Date.now()}`;
     const catName = `cat-cmp-${Date.now()}`;
 
-    // 0. 진입
+    // 0. 진입 + clock fake (분 boundary race 회피 — cascade-bump.spec.ts 와 동일 패턴)
+    const fixedTime = new Date();
+    fixedTime.setSeconds(0, 0);
+    await page.clock.install({time: fixedTime});
     await page.goto('/project/plan1/');
 
     // 1. 카테고리 보장

--- a/tests/qa-gate/instant-complete.spec.ts
+++ b/tests/qa-gate/instant-complete.spec.ts
@@ -57,7 +57,8 @@ test.describe('plan1 mutation E2E — A10 instant-complete (High · cascade 영�
     const sched = dialogOf(page, '새 스케줄');
     await expect(sched.heading).toBeVisible({timeout: 5_000});
     await sched.dialog.getByRole('textbox').first().fill(title);
-    await sched.dialog.getByRole('button', {name: '지금', exact: true}).click();
+    // i18n schedule.buttonNow = "now (시작을 지금으로)" — regex 로 i18n 변경 catch
+    await sched.dialog.getByRole('button', {name: /^now/}).click();
     await sched.dialog.locator('input[type="number"]').fill('60');
     await sched.dialog.getByRole('button', {name: '추가', exact: true}).click();
     await expect(sched.heading).toBeHidden({timeout: SLA_COLD_MS + 2_000});

--- a/tests/qa-gate/instant-complete.spec.ts
+++ b/tests/qa-gate/instant-complete.spec.ts
@@ -1,0 +1,106 @@
+import {test, expect, Page} from '@playwright/test';
+
+/**
+ * plan1 mutation E2E gate — A10 즉시 완료 (! complete · cascade 발동) — RPN 64 High
+ *
+ * 4/29 catch 영역 인접 (cascade 발동 mutation 경로 — A9 cascade-bump 와 같은 chain):
+ *   - completeSchedule(active.id, Date.now()) — status='done' + cascade 가능
+ *   - actualDurationMin 기록 + 다음 chained schedule 의 startAt shift 가능 (cascade)
+ *
+ * 시나리오 (PICT model `instant-complete.txt` happy path · during case · warm path):
+ *   - schedule 1개 추가 — "지금" 시작 + duration 60min (active 윈도우 진입)
+ *   - ActiveTimer 의 "complete" 버튼 클릭 → completeSchedule mutation
+ *   - SLA (warm < 3000ms / cold < 5000ms)
+ *   - cleanup: 완료된 schedule 삭제 (status='done' 도 카드 클릭 → 편집 모달 → 삭제 가능)
+ *
+ * 4/29 catch 차이 (다른 spec 과):
+ *   - cascade-bump (A9): extendScheduleBy (durationMin 변경 → cascade)
+ *   - **instant-complete (A10): completeSchedule (status='done' → cascade)**
+ *   - 둘 다 cascade 영역이지만 mutation 경로 다름 (extend vs complete)
+ *
+ * SLA 측정 출력 형식:
+ *   [qa-gate] instant_complete_ms=NNN cold=true|false
+ */
+
+const SLA_WARM_MS = 3000;
+const SLA_COLD_MS = 5000;
+
+function dialogOf(page: Page, headingName: string | RegExp) {
+  const heading = page.getByRole('heading', {name: headingName});
+  const dialog = page.locator('div.max-w-md').filter({has: heading}).first();
+  return {heading, dialog};
+}
+
+test.describe('plan1 mutation E2E — A10 instant-complete (High · cascade 영역)', () => {
+  test('schedule active (지금 시작) → complete 버튼 SLA + cleanup', async ({page}) => {
+    const title = `qa-cmp-${Date.now()}`;
+    const catName = `cat-cmp-${Date.now()}`;
+
+    // 0. 진입
+    await page.goto('/project/plan1/');
+
+    // 1. 카테고리 보장
+    await page.getByRole('button', {name: '카테고리'}).click();
+    const cat = dialogOf(page, /categories|카테고리/i);
+    await expect(cat.dialog).toBeVisible({timeout: 5_000});
+    await cat.dialog.getByRole('textbox').first().fill(catName);
+    await cat.dialog.getByRole('button', {name: '추가', exact: true}).click();
+    await expect(cat.dialog.getByText(catName)).toBeVisible({timeout: SLA_COLD_MS});
+    await cat.dialog.getByRole('button', {name: '닫기', exact: true}).click();
+    await expect(cat.dialog).toBeHidden({timeout: 3_000});
+
+    // 2. + 새 스케줄 — "지금" 시작 + duration 60min
+    const newBtn = page.getByRole('button', {name: '+ 새 스케줄'});
+    await expect(newBtn).toBeEnabled({timeout: 10_000});
+    await newBtn.click();
+
+    const sched = dialogOf(page, '새 스케줄');
+    await expect(sched.heading).toBeVisible({timeout: 5_000});
+    await sched.dialog.getByRole('textbox').first().fill(title);
+    await sched.dialog.getByRole('button', {name: '지금', exact: true}).click();
+    await sched.dialog.locator('input[type="number"]').fill('60');
+    await sched.dialog.getByRole('button', {name: '추가', exact: true}).click();
+    await expect(sched.heading).toBeHidden({timeout: SLA_COLD_MS + 2_000});
+    await expect(page.getByText(title).first()).toBeVisible({timeout: 5_000});
+
+    // 3. ActiveTimer "complete" 버튼 표시 확인
+    //    i18n timer.buttonComplete = "complete"
+    const completeBtn = page.getByRole('button', {name: 'complete', exact: true});
+    await expect(completeBtn).toBeVisible({timeout: 10_000});
+
+    // 4. 측정: complete click → completeSchedule mutation → ActiveTimer idle 전환
+    //    (active schedule 가 status='done' 으로 변경 → findActiveSchedules 결과 빈 배열 → idle 표시)
+    const startMs = Date.now();
+    await completeBtn.click();
+    // mutation 완료 신호: ActiveTimer 가 idle 로 전환되거나 또는 다음 active 가 표시
+    //    단순화: idle 메시지 (i18n timer.idleEmpty = "idle · 진행 중 스케줄 없음") 표시 또는
+    //    complete 버튼 사라짐
+    await expect(completeBtn).toBeHidden({timeout: SLA_COLD_MS + 2_000});
+    const elapsedMs = Date.now() - startMs;
+
+    const isCold = elapsedMs > SLA_WARM_MS;
+    const threshold = isCold ? SLA_COLD_MS : SLA_WARM_MS;
+    console.log(
+      `[qa-gate] instant_complete_ms=${elapsedMs} cold=${isCold} threshold=${threshold}`
+    );
+
+    // 5. SLA 게이트 (4/29 사고 catch 한도 보존)
+    expect(
+      elapsedMs,
+      `completeSchedule mutation 응답 ${elapsedMs}ms — ${
+        isCold ? 'cold' : 'warm'
+      } SLA ${threshold}ms 초과. cascade chain shift × sequential await loop 영역 진단 필요.`
+    ).toBeLessThan(threshold);
+
+    // 6. cleanup — 완료된 schedule 삭제 (status='done' 도 카드 클릭 → 편집 모달 가능)
+    await page.getByText(title).first().click();
+    const edit = dialogOf(page, '스케줄 편집');
+    await expect(edit.heading).toBeVisible({timeout: 5_000});
+    await edit.dialog.getByRole('button', {name: '삭제', exact: true}).click();
+    await edit.dialog
+      .getByRole('button', {name: '삭제 확인', exact: true})
+      .click();
+    await expect(edit.heading).toBeHidden({timeout: SLA_COLD_MS});
+    await expect(page.getByText(title)).toHaveCount(0, {timeout: 3_000});
+  });
+});


### PR DESCRIPTION
## Summary
B1 3차 PR — Critical RPN 영역 (cascade) 2 spec 추가.

근거:
- `wiki/projects/plan1/risk-matrix.md` A9 RPN 80 Critical · A10 RPN 64 High
- `wiki/shared/test-case-design-principles.md` § 12.4
- 대장 "전부다 순차진행" 결정

신설:
- `tests/qa-gate/cascade-bump.spec.ts` — A9 extendScheduleBy (cascade · 4/29 직접 영역)
- `tests/qa-gate/instant-complete.spec.ts` — A10 completeSchedule (status='done' · cascade)

## ActiveTimer 활성화 흐름 (선코드 실측 후 단순화)
1차 시도 가정: "Playwright clock fake 로 시간 우회" — 과잉 설계 / 환각
실측 후: NewScheduleModal "지금" 버튼이 isFuture 통과 + 즉시 active 둘 다 해결.
- minuteOptions useMemo 가 표준 boundary 외 분도 dynamic 추가 (line 178)
- isFuture: Math.floor(startAt/60000) >= Math.floor(now/60000) — 같은 분이면 통과
- → "지금" 클릭 + 추가 → 같은 분 startAt schedule = 즉시 ActiveTimer 활성화

## 4/29 catch mutation 경로 매트릭스 (전체 6 spec · 본 PR 머지 후)
- schedule-add: createSchedule
- schedule-edit: updateSchedule
- category-delete: deleteCategory
- working-hours: setWorkingHours
- **cascade-bump: extendScheduleBy (4/29 직접 영역)**
- **instant-complete: completeSchedule (cascade)**

## Test plan
- [x] gitleaks pre-commit 통과
- [ ] Vercel preview deploy
- [ ] qa-mutation-e2e workflow (6 spec 동시 실행)
- [ ] semgrep / dependabot
- [ ] Neon ephemeral cleanup

## 첫 시도 정직성
- "지금" 버튼 + minuteOptions dynamic 추가가 isFuture 통과 가정 — CI 첫 run 에서 실측 후 보강 가능
- ActiveTimer 의 "+30m" / "complete" 버튼 selector 정확성 (i18n key `timer.buttonComplete=complete`) — fail 시 fix
- complete 후 카드의 status='done' 표시가 "삭제" 버튼 그대로 유지하는지 — fail 시 cleanup 흐름 보강

## 후속 PR (별도)
- PR #21: A1 로그인 fresh
- PR #22: mutation-e2e.spec.ts → schedule-add.spec.ts rename

🤖 Generated with [Claude Code](https://claude.com/claude-code)