### PR TITLE
chore(qa): qa-bot prod DB orphan cleanup 1회성 스크립트

### DIFF
--- a/scripts/qa/cleanup-qa-bot-orphans.sh
+++ b/scripts/qa/cleanup-qa-bot-orphans.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# qa-bot 계정의 plan1.schedules · plan1.categories orphan rows cleanup wrapper.
+# dev/prod 환경 분리 + dry-run/apply 모드 + prod 입력 게이트.
+#
+# 사용:
+#   bash scripts/qa/cleanup-qa-bot-orphans.sh dev dry-run    # default · 안전
+#   bash scripts/qa/cleanup-qa-bot-orphans.sh dev apply
+#   bash scripts/qa/cleanup-qa-bot-orphans.sh prod dry-run
+#   bash scripts/qa/cleanup-qa-bot-orphans.sh prod apply     # 'PROD-CLEANUP' 입력 필요
+#
+# 동작:
+#   - secrets/global.env 에서 DATABASE_URL_UNPOOLED_<ENV>·QA_TEST_USER_EMAIL 주입
+#   - Neon branch host 출력
+#   - apply mode: prod 시 'PROD-CLEANUP' 정확 입력 받아야 진행
+#   - tsx 로 scripts/qa/cleanup-qa-bot-orphans.ts 실행 (idempotent)
+#
+# 근거: wiki/shared/qa-meta-policy.md § 12.2 · 거짓말 회복 2026-05-02
+
+set -euo pipefail
+
+ENV="${1:-}"
+MODE="${2:-dry-run}"
+
+case "$ENV" in
+  dev|prod) ;;
+  *) echo "Usage: $0 <dev|prod> <dry-run|apply>" >&2; exit 1 ;;
+esac
+
+case "$MODE" in
+  dry-run|apply) ;;
+  *) echo "Usage: $0 <dev|prod> <dry-run|apply>" >&2; exit 1 ;;
+esac
+
+SECRETS="$HOME/wiki-root/secrets/global.env"
+[ -f "$SECRETS" ] || { echo "secrets not found: $SECRETS" >&2; exit 1; }
+
+set -a
+# shellcheck disable=SC1090
+source "$SECRETS"
+set +a
+
+if [ "$ENV" = "dev" ]; then
+  TARGET_VAR="DATABASE_URL_UNPOOLED_DEV"
+else
+  TARGET_VAR="DATABASE_URL_UNPOOLED_PROD"
+fi
+
+URL="${!TARGET_VAR:-}"
+[ -n "$URL" ] || { echo "$TARGET_VAR not set in $SECRETS" >&2; exit 1; }
+
+HOST=$(echo "$URL" | grep -oE 'ep-[a-z0-9-]+' | head -1)
+
+echo
+echo "──────────────────────────────────────────────────────"
+echo "  qa-bot orphan cleanup — env: $ENV · mode: $MODE"
+echo "  Neon branch         : $HOST"
+echo "  Target email        : ${QA_TEST_USER_EMAIL:-qa-bot@cofounder.co.kr}"
+echo "  scope               : plan1.schedules + plan1.categories WHERE user_id = qa-bot"
+echo "──────────────────────────────────────────────────────"
+echo
+
+if [ "$MODE" = "apply" ] && [ "$ENV" = "prod" ]; then
+  echo "⚠️  PRODUCTION DELETE. 같은 Neon project · Production branch 입니다."
+  echo "    qa-bot 계정만 영향 (사용자 영향 0)."
+  echo
+  read -r -p "진행하려면 정확히 'PROD-CLEANUP' 를 입력: " confirm
+  if [ "$confirm" != "PROD-CLEANUP" ]; then
+    echo "취소됨." >&2
+    exit 1
+  fi
+fi
+
+DATABASE_URL_UNPOOLED="$URL" CLEANUP_MODE="$MODE" exec npx tsx scripts/qa/cleanup-qa-bot-orphans.ts

--- a/scripts/qa/cleanup-qa-bot-orphans.ts
+++ b/scripts/qa/cleanup-qa-bot-orphans.ts
@@ -1,0 +1,142 @@
+/**
+ * qa-bot 계정의 plan1.schedules · plan1.categories orphan rows cleanup (1회성).
+ *
+ * 배경:
+ *   - mutation E2E PR #20 1·2·3차 fail 시점 cleanup step 도달 X → qa-bot prod DB schedule 5+ 누적
+ *   - 새 PR 의 spec cleanup 정상 — history 잔존만 미처리
+ *   - 사용자 영향 0 (qa-bot 계정만 · 다른 사용자 불가시)
+ *
+ * 안전:
+ *   - dry-run default · apply 시 명시적 'PROD-CLEANUP' 게이트 (wrapper)
+ *   - plan1 schema.ts 의 user 테이블 query 금지 정책 → raw SQL 직접 SELECT id FROM "user" WHERE email
+ *   - drizzle-orm/neon-http db.batch([...]) atomic transaction (BEGIN; ...; COMMIT;)
+ *   - cascade: plan1_schedules.category_id FK ON DELETE CASCADE → categories DELETE 만으로 schedules 자동 정리
+ *     단 FK direction 가 schedules → categories 라 categories 먼저 DELETE 하면 schedules cascade
+ *     반대로 schedules 먼저 DELETE 후 categories 도 OK
+ *
+ * 실행:
+ *   bash scripts/qa/cleanup-qa-bot-orphans.sh dev dry-run
+ *   bash scripts/qa/cleanup-qa-bot-orphans.sh dev apply
+ *   bash scripts/qa/cleanup-qa-bot-orphans.sh prod dry-run
+ *   bash scripts/qa/cleanup-qa-bot-orphans.sh prod apply   # 'PROD-CLEANUP' 입력 필요
+ *
+ * idempotent: 다시 실행해도 0건 처리 후 정상 종료.
+ */
+
+import {drizzle} from 'drizzle-orm/neon-http';
+import {neon} from '@neondatabase/serverless';
+import {eq} from 'drizzle-orm';
+import {plan1Schedules, plan1Categories} from '../../lib/db/schema';
+
+const QA_BOT_EMAIL_DEFAULT = 'qa-bot@cofounder.co.kr';
+
+async function main() {
+  const mode = (process.env.CLEANUP_MODE ?? 'dry-run') as 'dry-run' | 'apply';
+  const email = process.env.QA_TEST_USER_EMAIL ?? QA_BOT_EMAIL_DEFAULT;
+  const connectionString = process.env.DATABASE_URL_UNPOOLED;
+
+  if (!connectionString) {
+    throw new Error('DATABASE_URL_UNPOOLED not set (wrapper must inject env-specific URL)');
+  }
+  if (mode !== 'dry-run' && mode !== 'apply') {
+    throw new Error(`CLEANUP_MODE must be 'dry-run' or 'apply', got: ${mode}`);
+  }
+
+  const client = neon(connectionString);
+  const db = drizzle({client});
+
+  console.log(`\n[cleanup-qa-bot-orphans] mode: ${mode} · email: ${email}`);
+
+  // plan1 schema.ts 의 user 테이블 query 금지 정책 (server actions 영역) — 단 cleanup 은 1회성·email→id 만 필요
+  // → neon raw client 로 직접 SELECT (drizzle ORM 우회)
+  const userRows =
+    (await client`SELECT id FROM "user" WHERE email = ${email} LIMIT 1`) as Array<{id: string}>;
+
+  if (userRows.length === 0) {
+    console.log(`[cleanup-qa-bot-orphans] user not found (email=${email}). 종료.`);
+    return;
+  }
+
+  const userId = userRows[0].id;
+  console.log(`[cleanup-qa-bot-orphans] user_id: ${userId}`);
+
+  const schedulesBefore = await db
+    .select({
+      id: plan1Schedules.id,
+      title: plan1Schedules.title,
+      createdAt: plan1Schedules.createdAt
+    })
+    .from(plan1Schedules)
+    .where(eq(plan1Schedules.userId, userId));
+
+  const categoriesBefore = await db
+    .select({
+      id: plan1Categories.id,
+      name: plan1Categories.name,
+      createdAt: plan1Categories.createdAt
+    })
+    .from(plan1Categories)
+    .where(eq(plan1Categories.userId, userId));
+
+  console.log(
+    `\n[cleanup-qa-bot-orphans] BEFORE: schedules=${schedulesBefore.length} · categories=${categoriesBefore.length}`
+  );
+
+  if (schedulesBefore.length > 0) {
+    console.log('\n--- schedules (BEFORE) ---');
+    schedulesBefore.forEach(r =>
+      console.log(`  ${r.id} · ${r.title} · ${r.createdAt.toISOString()}`)
+    );
+  }
+  if (categoriesBefore.length > 0) {
+    console.log('\n--- categories (BEFORE) ---');
+    categoriesBefore.forEach(r =>
+      console.log(`  ${r.id} · ${r.name} · ${r.createdAt.toISOString()}`)
+    );
+  }
+
+  if (schedulesBefore.length === 0 && categoriesBefore.length === 0) {
+    console.log('\n[cleanup-qa-bot-orphans] orphan 0건. idempotent 종료.');
+    return;
+  }
+
+  if (mode === 'dry-run') {
+    console.log(
+      `\n[cleanup-qa-bot-orphans] DRY-RUN — 실제 삭제 X. apply 모드로 재실행하면 위 row 삭제.`
+    );
+    return;
+  }
+
+  console.log('\n[cleanup-qa-bot-orphans] APPLY — db.batch atomic DELETE 실행...');
+
+  await db.batch([
+    db.delete(plan1Schedules).where(eq(plan1Schedules.userId, userId)),
+    db.delete(plan1Categories).where(eq(plan1Categories.userId, userId))
+  ]);
+
+  const schedulesAfter = await db
+    .select({id: plan1Schedules.id})
+    .from(plan1Schedules)
+    .where(eq(plan1Schedules.userId, userId));
+  const categoriesAfter = await db
+    .select({id: plan1Categories.id})
+    .from(plan1Categories)
+    .where(eq(plan1Categories.userId, userId));
+
+  console.log(
+    `\n[cleanup-qa-bot-orphans] AFTER: schedules=${schedulesAfter.length} · categories=${categoriesAfter.length}`
+  );
+
+  if (schedulesAfter.length === 0 && categoriesAfter.length === 0) {
+    console.log('[cleanup-qa-bot-orphans] APPLY 성공 — 모든 orphan 정리 완료.');
+  } else {
+    throw new Error(
+      `cleanup 후에도 잔존: schedules=${schedulesAfter.length} · categories=${categoriesAfter.length}`
+    );
+  }
+}
+
+main().catch(err => {
+  console.error('[cleanup-qa-bot-orphans] ERROR:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- `scripts/qa/cleanup-qa-bot-orphans.{ts,sh}` 신설 — qa-bot prod DB 누적 orphan rows cleanup 1회성 스크립트
- prod dry-run 결과 categories **38 row 누적** 발견 (2026-04-29 ~ 2026-05-02 · schedules cleanup 정상 · categories cleanup 결함)
- 대장 명시 승인 (Discord 'PROD-CLEANUP') 후 apply 실행 → 38 → 0 검증 완료
- idempotent 검증 통과 (재실행 시 0건)

## 안전 가드
- dry-run default · apply 시 'PROD-CLEANUP' 정확 입력 필요 (interactive read)
- plan1 schema.ts user 테이블 query 금지 정책 → neon raw client 직접 SELECT (uquery 우회)
- drizzle-orm/neon-http `db.batch` atomic transaction (BEGIN; ...; COMMIT;)
- 사용자 영향 0 (qa-bot 계정만)

## 검증 결과 (Studio · 2026-05-02)
| 단계 | 결과 |
|---|---|
| dev dry-run | 0건 (Neon ephemeral branch 자연 결과) |
| prod dry-run | schedules=0 · categories=38 |
| prod apply | atomic batch DELETE → AFTER 0/0 ✓ |
| prod idempotent | 재실행 0건 ✓ |

## Test plan
- [x] dev dry-run 검증
- [x] prod dry-run 검증
- [x] prod apply (대장 'PROD-CLEANUP' 명시 승인 후)
- [x] idempotent 검증 (재실행 0건)
- [ ] CI mutation E2E PR 게이트 통과 (스크립트는 manual run · CI 영향 X)

## 후속 (Phase B 범위 밖 · 별도 PR)
- spec afterEach categories cleanup 결함 8 spec 전수 점검 + cookie-cutter 표준
- Phase C (portal·copymaker1·router cookie-cutter) 와 같이 처리 예정

## 근거
- `wiki/shared/qa-meta-policy.md` § 12.2 후속 검토 영역
- `wiki/shared/saas-qa-gate-research-20260429.md` § 5

🤖 Generated with [Claude Code](https://claude.com/claude-code)