### PR TITLE
chore: @fast-check/vitest devDep 제거 (미사용)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,6 @@
       },
       "devDependencies": {
         "@axe-core/playwright": "^4.11.2",
-        "@fast-check/vitest": "^0.4.1",
         "@playwright/test": "^1.59.1",
         "@stryker-mutator/core": "^9.6.1",
         "@stryker-mutator/vitest-runner": "^9.6.1",
@@ -1244,29 +1243,6 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
-    "node_modules/@fast-check/vitest": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@fast-check/vitest/-/vitest-0.4.1.tgz",
-      "integrity": "sha512-OX6TecB+ZzRfPc49jcPChcV1cf5aDu77CdDU8liecWVam7eD7mPvJNP50b9bBSTxVoGN5wzxrX9PIcCnqgC8bg==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/dubzzz"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fast-check"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "fast-check": "^3.0.0 || ^4.0.0"
-      },
-      "peerDependencies": {
-        "vitest": "^4.1.0"
       }
     },
     "node_modules/@fastify/otel": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
   },
   "devDependencies": {
     "@axe-core/playwright": "^4.11.2",
-    "@fast-check/vitest": "^0.4.1",
     "@playwright/test": "^1.59.1",
     "@stryker-mutator/core": "^9.6.1",
     "@stryker-mutator/vitest-runner": "^9.6.1",


### PR DESCRIPTION
Step 12 reference 후속. cascade.pbt.test.ts 는 fc.assert + fc.property 직접 사용 — @fast-check/vitest 의 test.prop 패턴 미도입. 4 sub-project 동일 — 의존성 단순화.

별도 회귀 (devDep 제거와 무관):
- lib/domain/cascade.pbt.test.ts invariant 3 가 fast-check random seed 분포에 따라 발견 (Property failed after 82 tests · expected 60000 to be +0)
- main 에 이미 있던 잠재 결함 — 별도 PR 후속 (qa-pending 등재 예정)

검증: grep @fast-check/vitest 0건 · grep test.prop 0건