### PR TITLE
fix(qa): F4 — cascade.pbt.test.ts invariant 3 spec logic 회귀 fix

### DIFF
--- a/lib/domain/cascade.pbt.test.ts
+++ b/lib/domain/cascade.pbt.test.ts
@@ -74,6 +74,11 @@ describe('cascade — Property-Based Testing (1000 runs · invariants)', () => {
   })
 
   it('invariant 3: chainedToPrev=false 첫 발견 후 chain 끊김 (그 이후 schedule 들은 shift 안 됨)', () => {
+    // ⚠️ 검증 시점 주의: cascade 는 **shift 전 mutated 의 active sort** 로 chain 판정.
+    //   shift 후 startAt 변경으로 result sort 결과가 다를 수 있음 (특히 동일 startAt 의 schedule 이 stable sort 결과 mutated 와 result 에서 다른 위치).
+    //   → spec 도 mutated (shift 전) sort 기준으로 chain 판정 의무. result sort 기준 검증은 false positive 발생.
+    //   배경: F4 회귀 (PR fix/plan1-cascade-pbt-invariant3-spec-logic · 2026-05-03)
+    //         counter-example: 3 schedule 모두 startAt=0, target chained=false, s-1 chained=true, s-2 chained=false
     fc.assert(
       fc.property(arbSchedules(10), fc.integer({ min: -120, max: 120 }), (schedules, deltaMin) => {
         const target = schedules[0]
@@ -81,25 +86,56 @@ describe('cascade — Property-Based Testing (1000 runs · invariants)', () => {
         const newDur = target.durationMin + deltaMin
         if (newDur < 1) return
 
+        const origEnd = target.startAt + target.durationMin * NS
+        const newEnd = newStart + newDur * NS
+        const delta = newEnd - origEnd
+
         const result = cascade(schedules, target.id, newStart, newDur)
 
-        // active 만 정렬 (cascade 의 동일 로직)
-        const active = result.filter(s => s.status !== 'done').sort((a, b) => a.startAt - b.startAt)
-        const editedIdx = active.findIndex(s => s.id === target.id)
+        // mutated (shift 전) 의 active sort — cascade source 와 동일 로직
+        const mutated = schedules.map(s =>
+          s.id === target.id ? { ...s, startAt: newStart, durationMin: newDur } : s
+        )
+        const mutatedActive = mutated
+          .filter(s => s.status !== 'done')
+          .sort((a, b) => a.startAt - b.startAt)
+        const editedIdx = mutatedActive.findIndex(s => s.id === target.id)
         if (editedIdx === -1) return
 
-        // 첫 unchained schedule 이후의 모든 schedule 은 원본과 startAt 동일해야 함
+        // editedIdx+1 부터 첫 unchained 직전까지: shifted (startAt = original + delta)
+        // 첫 unchained 부터 끝까지: unshifted (startAt = original)
         let chainBroken = false
-        for (let i = editedIdx + 1; i < active.length; i++) {
-          if (!active[i].chainedToPrev) chainBroken = true
+        for (let i = editedIdx + 1; i < mutatedActive.length; i++) {
+          if (!mutatedActive[i].chainedToPrev) chainBroken = true
+          const original = schedules.find(s => s.id === mutatedActive[i].id)!
+          const after = result.find(s => s.id === mutatedActive[i].id)!
           if (chainBroken) {
-            const original = schedules.find(s => s.id === active[i].id)!
-            expect(active[i].startAt).toBe(original.startAt)
+            expect(after.startAt).toBe(original.startAt)
+          } else {
+            expect(after.startAt).toBe(original.startAt + delta)
           }
         }
       }),
-      { numRuns: 500 }
+      { numRuns: 1000 }
     )
+  })
+
+  it('invariant 3 회귀 case (F4 · seed -658135282): 동일 startAt + chained=false target 의 chain 판정', () => {
+    // 회귀 차단 가드 (F4 catch — `wiki/projects/plan1/qa-pending.md` § 1)
+    // 모든 schedule startAt=0 (stable sort 의존) · target s-0 chained=false · s-1 chained=true · s-2 chained=false
+    const schedules: Schedule[] = [
+      { title: '', startAt: 0, durationMin: 1, timerType: 'countup', status: 'pending', chainedToPrev: false, id: 's-0' as ScheduleId, categoryId: 'cat-1', createdAt: 0, updatedAt: 0 },
+      { title: '', startAt: 0, durationMin: 1, timerType: 'countup', status: 'pending', chainedToPrev: true,  id: 's-1' as ScheduleId, categoryId: 'cat-1', createdAt: 0, updatedAt: 0 },
+      { title: '', startAt: 0, durationMin: 1, timerType: 'countup', status: 'pending', chainedToPrev: false, id: 's-2' as ScheduleId, categoryId: 'cat-1', createdAt: 0, updatedAt: 0 },
+    ]
+    const result = cascade(schedules, 's-0' as ScheduleId, 0, 2) // delta = +1*NS
+    const s0 = result.find(s => s.id === 's-0')!
+    const s1 = result.find(s => s.id === 's-1')!
+    const s2 = result.find(s => s.id === 's-2')!
+    expect(s0.startAt).toBe(0)        // target startAt 변경 X
+    expect(s0.durationMin).toBe(2)    // target dur 변경됨
+    expect(s1.startAt).toBe(NS)       // mutated sort i=1 chained=true → shift +60000
+    expect(s2.startAt).toBe(0)        // mutated sort i=2 chained=false → break · unshifted
   })
 
   it('invariant 4: done 상태 schedule 은 shift 영향 받지 않음', () => {


### PR DESCRIPTION
## Root cause
**Category**: 분기 동작 환각 + 단순화 자체 환각

기존 spec 의 `result.active.sort` 가 cascade source 의 `mutated.active.sort` 와 다른 결과 반환 가능. 동일 startAt 의 schedule 들이 stable sort 의존인데, shift 후 startAt 변경 → result sort 결과 변동. spec 이 result sort 기준으로 chainBroken 판정 → cascade 의 의도와 분기 → false positive.

## Counter-example (seed -658135282 · shrunk 21)
- s-0(start=0, chained=false, target) · s-1(start=0, chained=true) · s-2(start=0, chained=false)
- delta=+60000ms
- cascade mutated sort: [s-0, s-1, s-2] (stable) → s-1 shift, s-2 break
- result: s-0(0), s-1(60000), s-2(0)
- spec result sort: [s-0(0), s-2(0), s-1(60000)] — s-1 뒤로 이동
- spec editedIdx=0 · i=1(s-2 chained=false → chainBroken=true) · i=2(s-1 chained=true → 검증 chainBroken=true → expected 60000 to be 0) ❌

## Fix
- invariant 3 재작성 — **mutated (shift 전) sort 기준** 으로 chain 판정
- mutatedActive[editedIdx+1...] 첫 unchained 직전까지 shifted (`startAt = original + delta`)
- 첫 unchained 부터 끝까지 unshifted (`startAt = original`)
- numRuns 500 → 1000 (Critical RPN 80 영역 강도 ↑)

## 회귀 차단 가드
- 동일 startAt + chained=false target 단위 test (seed -658135282 케이스 직접 박힘)
- 향후 같은 분기 회귀 시 1차 catch

## 검증
- `npx vitest run lib/domain/cascade.pbt.test.ts`: 6 tests passed (5 invariants + 1 unit · 245ms)
- 10회 반복 실행: **10/10 rc=0** (이전 fix 전: 1-2/10 fail · random seed reproduce)
- `npm test` 전체: 49 tests passed (7 files · 회귀 0)

## RPN
cascade Critical RPN 80 영역. invariant 3 fix 후 RPN 영향 X (cover 영역 그대로 + 회귀 가드 추가).

## 관련
- closes #31
- `wiki/projects/plan1/qa-pending.md` § 1 F4 (8 항목)
- `wiki/projects/plan1/risk-matrix.md` § 3 cascade
- `wiki/shared/llm-coding-traps.md` § 1 분기 동작 환각

🤖 Generated with [Claude Code](https://claude.com/claude-code)