### PR TITLE
chore(qa): F6 옵션 A — auth.setup cookie inject + Neon prefix (--force 제외)

### DIFF
--- a/.github/workflows/qa-mutation-e2e.yml
+++ b/.github/workflows/qa-mutation-e2e.yml
@@ -65,7 +65,9 @@ jobs:
           # cofounder-portal Neon project default branch = "production" (not "main").
           # 2026-04-30 verify: `neonctl branches list` → ['production', 'preview/perf/sin1-region', 'vercel-dev'].
           parent_branch: production
-          branch_name: pr-${{ github.event.pull_request.number }}
+          # repo prefix 박힘 — plan1·portal 같은 NEON_PROJECT_ID 라 같은 PR 번호 동시 발생 시
+          # branch 이름 conflict 회피 (cookie-cutter from portal Step 13.c PR #21).
+          branch_name: plan1-pr-${{ github.event.pull_request.number }}
           role: neondb_owner
           api_key: ${{ secrets.NEON_API_KEY }}
 
@@ -136,7 +138,7 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: `✅ **Mutation E2E gate passed**\n\n- Preview: ${previewUrl}\n- Neon branch: \`pr-${context.issue.number}\`\n- SLA: warm < 3000ms / cold < 5000ms\n\n자세한 측정값은 워크플로우 로그의 \`[qa-gate] schedule_add_ms=...\` 라인 참조.`
+              body: `✅ **Mutation E2E gate passed**\n\n- Preview: ${previewUrl}\n- Neon branch: \`plan1-pr-${context.issue.number}\`\n- SLA: warm < 3000ms / cold < 5000ms\n\n자세한 측정값은 워크플로우 로그의 \`[qa-gate] schedule_add_ms=...\` 라인 참조.`
             });
 
       - name: Comment PR result (failure)
@@ -148,7 +150,7 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: `❌ **Mutation E2E gate failed**\n\n- Neon branch: \`pr-${context.issue.number}\`\n- Playwright report 확인: Actions → ${context.workflow} → 이번 run → Artifacts\n\n4/29 5초 latency 사고와 같은 회귀 패턴일 수 있음. instrument 박고 phase 진단 필요.`
+              body: `❌ **Mutation E2E gate failed**\n\n- Neon branch: \`plan1-pr-${context.issue.number}\`\n- Playwright report 확인: Actions → ${context.workflow} → 이번 run → Artifacts\n\n4/29 5초 latency 사고와 같은 회귀 패턴일 수 있음. instrument 박고 phase 진단 필요.`
             });
 
   cleanup:
@@ -160,5 +162,5 @@ jobs:
         uses: neondatabase/delete-branch-action@v3
         with:
           project_id: ${{ secrets.NEON_PROJECT_ID }}
-          branch: pr-${{ github.event.pull_request.number }}
+          branch: plan1-pr-${{ github.event.pull_request.number }}
           api_key: ${{ secrets.NEON_API_KEY }}

--- a/tests/qa-gate/auth.setup.ts
+++ b/tests/qa-gate/auth.setup.ts
@@ -69,30 +69,38 @@ setup('authenticate qa-bot', async () => {
   });
 
   // 3.5 preview URL 대상일 때 — cofounder.co.kr 도메인 cookie 가 plan1 Vercel preview host
-  //     (예: plan1-xxx.vercel.app) 에 자동 전송 안 됨. preview host 에도 cofounder_jwt + NEXT_LOCALE
-  //     cookie 명시 inject. plan1 verifySession 은 cofounder_jwt 만 사용 (better-auth.session_token 무관).
+  //     (예: plan1-xxx.vercel.app) 에 자동 전송 안 됨. preview host 에 모든 cofounder.co.kr cookie
+  //     명시 inject (cookie-cutter from portal Step 13.c PR #21).
+  //
+  // 미래 server-side `auth.api.getSession()` 검증 spec 신설 시 better-auth.session_token 도
+  // 필요. 현 verify-session.ts 만 쓰는 spec 은 cofounder_jwt 만 필요하지만, cookie-cutter drift
+  // 차단 위해 모든 cookie inject (logic-critic 권고 반영).
+  //
+  // F6 옵션 A (2026-05-04): `vercel deploy --force` 는 분리 적용 안 함 (회귀 catch 후).
   const previewBaseUrl =
     process.env.PLAYWRIGHT_BASE_URL ?? 'https://cofounder.co.kr';
   const previewHost = new URL(previewBaseUrl).hostname;
   if (previewHost !== 'cofounder.co.kr' && !previewHost.endsWith('.cofounder.co.kr')) {
-    const jwtCookie = state.cookies.find(c => c.name === 'cofounder_jwt');
-    if (jwtCookie) {
+    const cofounderCookies = state.cookies.filter(c =>
+      c.domain === '.cofounder.co.kr' || c.domain === 'cofounder.co.kr'
+    );
+    for (const c of cofounderCookies) {
       state.cookies.push({
-        ...jwtCookie,
+        ...c,
         domain: previewHost,
-        sameSite: 'Lax'
-      });
-      state.cookies.push({
-        name: 'NEXT_LOCALE',
-        value: 'ko',
-        domain: previewHost,
-        path: '/',
-        expires: -1,
-        httpOnly: false,
-        secure: true,
         sameSite: 'Lax'
       });
     }
+    state.cookies.push({
+      name: 'NEXT_LOCALE',
+      value: 'ko',
+      domain: previewHost,
+      path: '/',
+      expires: -1,
+      httpOnly: false,
+      secure: true,
+      sameSite: 'Lax'
+    });
   }
 
   fs.mkdirSync(path.dirname(STORAGE_STATE_PATH), {recursive: true});


### PR DESCRIPTION
## Summary

PR #33 close 사후 F6 정공 진단 → 옵션 A (cookie inject + Neon prefix 만, `--force` 제외) 적용.

회귀 catch 가설 검증:
- **통과 시**: `vercel deploy --force` 가 PR #33 spec 회귀 원인 확정
- **fail 시**: auth.setup cookie inject 확장 자체가 회귀 원인 → PR close + F6 보류 유지

## 변경

### 적용 (PR #33 의 fix 1·2)
- `tests/qa-gate/auth.setup.ts`: cofounder.co.kr 도메인 의 모든 cookie (better-auth.session_token 포함) 를 preview host 에 inject (cookie-cutter from portal Step 13.c PR #21)
- `.github/workflows/qa-mutation-e2e.yml`: Neon `branch_name` `pr-N` → `plan1-pr-N` (portal `portal-pr-N` 와 분리 · 같은 NEON_PROJECT_ID conflict 회피)

### 분리 (PR #33 의 fix 3 — 이번 PR 에서 X)
- ❌ `vercel deploy --prebuilt --force` + URL grep + exit code 무시
  - F6 진단 결과 docs 미명시 anti-pattern 의심 (vercel CLI `--help`: `--force` default build cache 무시 + `--with-cache` 별도)
  - 분리 적용으로 fix 1·2 만의 영향 검증

## 근거

- F6 정공 진단: `wiki/projects/cofounder-portal/qa-pending.md` § 1 F6
- PR #33 fail 패턴 분석: SLA log 정상 (`schedule_add_ms=411`) → page reload 시 schedule title 안 보임 (DB write+read chain · cookie inject + `--force` 결합)
- portal vs plan1 spec 패턴 차이: portal 은 page reload SSR (DB read 없음) · plan1 은 server action create + page reload (DB write+read)

## Test plan

- [x] vitest 49/49 pass (로컬)
- [ ] CI mutation E2E gate — A3·A4·A7 (schedule-add · schedule-edit · category-delete-armed) 통과 여부

🤖 Generated with [Claude Code](https://claude.com/claude-code)