### PR TITLE
fix(auth): self-heal redirect on missing cofounder_jwt cookie

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -9,7 +9,9 @@ import {routing} from './i18n/routing';
 //   - 그 외 GET 페이지: cofounder_jwt cookie 부재 시 portal refresh-jwt 로 self-heal redirect (race condition fix)
 //   - 그 후 next-intl locale detect (쿠키 NEXT_LOCALE 기반, portal 와 동일 origin 쿠키 공유)
 //
-// Next.js 16 부터 file convention `middleware.ts` → `proxy.ts` 리네임 (nodejs runtime 고정 · edge 미지원).
+// Next.js 16 file convention: middleware.ts (nodejs runtime 고정 · edge 미지원).
+// PLAN1-AUTH-FLAKE-VERIFY (2026-05-04): proxy.ts → middleware.ts 환원. proxy.ts file convention 의
+// preview build 작동성 의심 (cookie 부재 redirect 미발동) → middleware.ts 정공 사용.
 
 const intlProxy = createIntlMiddleware(routing);
 
@@ -107,7 +109,7 @@ function authRedirectIfMissingJwt(request: NextRequest): NextResponse | null {
   return NextResponse.redirect(refreshUrl, {status: 302});
 }
 
-export function proxy(request: NextRequest) {
+export function middleware(request: NextRequest) {
   const {pathname} = request.nextUrl;
   // /api/** 경로: next-intl 우회 + POST 만 rate limit. GET 은 그대로 통과.
   // Stage 8 follow-up (2026-04-28): GET /api/health 가 intlProxy 통과 시 _not-found

--- a/middleware.ts
+++ b/middleware.ts
@@ -111,15 +111,29 @@ function authRedirectIfMissingJwt(request: NextRequest): NextResponse | null {
 
 export function middleware(request: NextRequest) {
   const {pathname} = request.nextUrl;
+  // PLAN1-AUTH-FLAKE-VERIFY 디버그 (2026-05-04): middleware fire 확인용.
+  // 검증 후 제거 예정.
+  const debugHeaders = new Headers();
+  debugHeaders.set('x-mw-fired', '1');
+  debugHeaders.set('x-mw-pathname', pathname);
+  debugHeaders.set(
+    'x-mw-cookie-jwt',
+    request.cookies.get('cofounder_jwt') ? 'present' : 'missing'
+  );
+  debugHeaders.set('x-mw-method', request.method);
   // /api/** 경로: next-intl 우회 + POST 만 rate limit. GET 은 그대로 통과.
   // Stage 8 follow-up (2026-04-28): GET /api/health 가 intlProxy 통과 시 _not-found
   // 매칭 → 404. localePrefix:'never' 라도 next-intl middleware 가 GET 라우팅에 개입.
   // /api/** 는 명시적으로 next-intl 우회.
   if (pathname.startsWith('/api/')) {
     if (request.method === 'POST' && rateLimited(request)) {
-      return new NextResponse('rate_limited', {status: 429});
+      const r = new NextResponse('rate_limited', {status: 429});
+      debugHeaders.forEach((v, k) => r.headers.set(k, v));
+      return r;
     }
-    return NextResponse.next();
+    const r = NextResponse.next();
+    debugHeaders.forEach((v, k) => r.headers.set(k, v));
+    return r;
   }
   // security-auditor MEDIUM: server action POST 도 rate limit. Next.js 14+ 는 server
   // action 호출을 `Next-Action` header 가진 POST 로 보냄 (페이지 경로에 직접 POST).
@@ -127,18 +141,27 @@ export function middleware(request: NextRequest) {
     request.method === 'POST' && request.headers.get('next-action') !== null;
   if (isServerActionPost) {
     if (rateLimited(request)) {
-      return new NextResponse('rate_limited', {status: 429});
+      const r = new NextResponse('rate_limited', {status: 429});
+      debugHeaders.forEach((v, k) => r.headers.set(k, v));
+      return r;
     }
     // server action POST 는 next-intl 라우팅 통과 필요 없음 (이미 locale prefixed
     // path 로 들어오면 server action handler 가 처리). 인증은 requireUser 가 처리.
-    return NextResponse.next();
+    const r = NextResponse.next();
+    debugHeaders.forEach((v, k) => r.headers.set(k, v));
+    return r;
   }
 
   // PLAN1-AUTH-FLAKE-EXEC (2026-05-04): GET 페이지 인증 self-heal.
   const authRedirect = authRedirectIfMissingJwt(request);
-  if (authRedirect) return authRedirect;
+  if (authRedirect) {
+    debugHeaders.forEach((v, k) => authRedirect.headers.set(k, v));
+    return authRedirect;
+  }
 
-  return intlProxy(request);
+  const intlResponse = intlProxy(request);
+  debugHeaders.forEach((v, k) => intlResponse.headers.set(k, v));
+  return intlResponse;
 }
 
 export const config = {

--- a/middleware.ts
+++ b/middleware.ts
@@ -111,29 +111,15 @@ function authRedirectIfMissingJwt(request: NextRequest): NextResponse | null {
 
 export function middleware(request: NextRequest) {
   const {pathname} = request.nextUrl;
-  // PLAN1-AUTH-FLAKE-VERIFY 디버그 (2026-05-04): middleware fire 확인용.
-  // 검증 후 제거 예정.
-  const debugHeaders = new Headers();
-  debugHeaders.set('x-mw-fired', '1');
-  debugHeaders.set('x-mw-pathname', pathname);
-  debugHeaders.set(
-    'x-mw-cookie-jwt',
-    request.cookies.get('cofounder_jwt') ? 'present' : 'missing'
-  );
-  debugHeaders.set('x-mw-method', request.method);
   // /api/** 경로: next-intl 우회 + POST 만 rate limit. GET 은 그대로 통과.
   // Stage 8 follow-up (2026-04-28): GET /api/health 가 intlProxy 통과 시 _not-found
   // 매칭 → 404. localePrefix:'never' 라도 next-intl middleware 가 GET 라우팅에 개입.
   // /api/** 는 명시적으로 next-intl 우회.
   if (pathname.startsWith('/api/')) {
     if (request.method === 'POST' && rateLimited(request)) {
-      const r = new NextResponse('rate_limited', {status: 429});
-      debugHeaders.forEach((v, k) => r.headers.set(k, v));
-      return r;
+      return new NextResponse('rate_limited', {status: 429});
     }
-    const r = NextResponse.next();
-    debugHeaders.forEach((v, k) => r.headers.set(k, v));
-    return r;
+    return NextResponse.next();
   }
   // security-auditor MEDIUM: server action POST 도 rate limit. Next.js 14+ 는 server
   // action 호출을 `Next-Action` header 가진 POST 로 보냄 (페이지 경로에 직접 POST).
@@ -141,27 +127,18 @@ export function middleware(request: NextRequest) {
     request.method === 'POST' && request.headers.get('next-action') !== null;
   if (isServerActionPost) {
     if (rateLimited(request)) {
-      const r = new NextResponse('rate_limited', {status: 429});
-      debugHeaders.forEach((v, k) => r.headers.set(k, v));
-      return r;
+      return new NextResponse('rate_limited', {status: 429});
     }
     // server action POST 는 next-intl 라우팅 통과 필요 없음 (이미 locale prefixed
     // path 로 들어오면 server action handler 가 처리). 인증은 requireUser 가 처리.
-    const r = NextResponse.next();
-    debugHeaders.forEach((v, k) => r.headers.set(k, v));
-    return r;
+    return NextResponse.next();
   }
 
   // PLAN1-AUTH-FLAKE-EXEC (2026-05-04): GET 페이지 인증 self-heal.
   const authRedirect = authRedirectIfMissingJwt(request);
-  if (authRedirect) {
-    debugHeaders.forEach((v, k) => authRedirect.headers.set(k, v));
-    return authRedirect;
-  }
+  if (authRedirect) return authRedirect;
 
-  const intlResponse = intlProxy(request);
-  debugHeaders.forEach((v, k) => intlResponse.headers.set(k, v));
-  return intlResponse;
+  return intlProxy(request);
 }
 
 export const config = {

--- a/proxy.ts
+++ b/proxy.ts
@@ -3,18 +3,24 @@ import {ipAddress} from '@vercel/functions';
 import createIntlMiddleware from 'next-intl/middleware';
 import {routing} from './i18n/routing';
 
-// 병합 proxy (Stage 1 · 2026-04-27 / Stage 8.C 리네임 · 2026-04-28):
+// 병합 proxy (Stage 1 · 2026-04-27 / Stage 8.C 리네임 · 2026-04-28 / PLAN1-AUTH-FLAKE-EXEC · 2026-05-04):
 //   - /api/** 로 시작하는 POST: in-memory rate limit (LIMIT=20/min · plan1 은 schedule CRUD 위주라 copymaker1 의 LLM 호출보다 한도 ↑)
-//   - 그 외 페이지 경로: next-intl locale detect (쿠키 NEXT_LOCALE 기반, portal 와 동일 origin 쿠키 공유)
+//   - server action POST: rate limit 후 통과 (auth 는 requireUser 에서)
+//   - 그 외 GET 페이지: cofounder_jwt cookie 부재 시 portal refresh-jwt 로 self-heal redirect (race condition fix)
+//   - 그 후 next-intl locale detect (쿠키 NEXT_LOCALE 기반, portal 와 동일 origin 쿠키 공유)
 //
 // Next.js 16 부터 file convention `middleware.ts` → `proxy.ts` 리네임 (nodejs runtime 고정 · edge 미지원).
-// copymaker1/middleware.ts 패턴 복제 + plan1-specific LIMIT 조정.
 
 const intlProxy = createIntlMiddleware(routing);
 
 const LIMIT = 20;
 const WINDOW_MS = 60_000;
 const store = new Map<string, {count: number; resetAt: number}>();
+
+// PLAN1-AUTH-FLAKE-EXEC (2026-05-04): portal refresh-jwt URL.
+// env override 가능 (preview/staging 분리). default = production cofounder.co.kr.
+const PORTAL_REFRESH_JWT_URL =
+  process.env.PORTAL_REFRESH_JWT_URL ?? 'https://cofounder.co.kr/project/api/cofounder/refresh-jwt';
 
 function getClientKey(request: NextRequest): string {
   // ship-gate security High (2026-04-28 · Stage 8.G):
@@ -52,6 +58,55 @@ function rateLimited(request: NextRequest): boolean {
   return false;
 }
 
+// PLAN1-AUTH-FLAKE-EXEC (2026-05-04): public URL 재구성.
+// router (cofounder-router/src/index.js:143-144) 가 x-forwarded-host / x-forwarded-proto 를 set.
+// request.nextUrl.host 는 Vercel internal host 라 그대로 return 에 넣으면 portal 이 화이트리스트
+// 검증에서 reject (cofounder.co.kr 아님). 사용자 실제 요청 URL 재구성 후 return param 사용.
+function getPublicRequestUrl(request: NextRequest): string {
+  const host =
+    request.headers.get('x-forwarded-host') ?? request.headers.get('host') ?? request.nextUrl.host;
+  const proto =
+    request.headers.get('x-forwarded-proto') ?? request.nextUrl.protocol.replace(':', '');
+  return `${proto}://${host}${request.nextUrl.pathname}${request.nextUrl.search}`;
+}
+
+// PLAN1-AUTH-FLAKE-EXEC (2026-05-04): cofounder_jwt cookie 부재 시 self-heal redirect.
+//
+// 흐름:
+//   1. plan1 GET 페이지 요청 (e.g. /project/plan1/dashboard)
+//   2. cofounder_jwt cookie 부재 검사
+//   3. 부재면 portal /api/cofounder/refresh-jwt?return=<원래 URL> 로 302 redirect
+//   4. portal 이 Better Auth session 검증 → 통과면 cookie set + 302 back to return
+//                                          → 미통과면 302 to /project/sign-in?return=...
+//   5. 사용자 plan1 재진입 시 cookie 존재 → 정상 동작
+//
+// 무한 루프 가드:
+//   - referer 헤더가 portal refresh-jwt 면 redirect 안 함 (portal 발급 실패한 직후 케이스)
+//   - 그 경우 plan1 page 그대로 렌더 → server action / route handler 가 unauthorized 처리
+//
+// 적용 범위:
+//   - GET 페이지 (HTML) 만 대상. /api/** · POST · server action 은 unaffected (UI 가 401 graceful 처리)
+//   - 첫 entry-point 만 redirect 발생. cookie 발급 후 navigation 은 자연스럽게 통과.
+function authRedirectIfMissingJwt(request: NextRequest): NextResponse | null {
+  if (request.method !== 'GET') return null;
+  const {pathname} = request.nextUrl;
+  if (pathname.startsWith('/api/')) return null;
+
+  const jwt = request.cookies.get('cofounder_jwt');
+  if (jwt) return null;
+
+  // 무한 루프 가드: portal refresh-jwt 에서 redirect 받아 돌아온 직후면 더 이상 redirect 안 함.
+  // 이 경우 portal session 도 없거나 cookie 발급 실패 — plan1 그대로 렌더하면 server action 단계에서
+  // ServerActionError('serverError.unauthorized') throw → 클라이언트가 sign-in CTA UI 표시.
+  const referer = request.headers.get('referer') ?? '';
+  const fromPortalRefresh = referer.includes('/project/api/cofounder/refresh-jwt');
+  if (fromPortalRefresh) return null;
+
+  const refreshUrl = new URL(PORTAL_REFRESH_JWT_URL);
+  refreshUrl.searchParams.set('return', getPublicRequestUrl(request));
+  return NextResponse.redirect(refreshUrl, {status: 302});
+}
+
 export function proxy(request: NextRequest) {
   const {pathname} = request.nextUrl;
   // /api/** 경로: next-intl 우회 + POST 만 rate limit. GET 은 그대로 통과.
@@ -73,9 +128,14 @@ export function proxy(request: NextRequest) {
       return new NextResponse('rate_limited', {status: 429});
     }
     // server action POST 는 next-intl 라우팅 통과 필요 없음 (이미 locale prefixed
-    // path 로 들어오면 server action handler 가 처리)
+    // path 로 들어오면 server action handler 가 처리). 인증은 requireUser 가 처리.
     return NextResponse.next();
   }
+
+  // PLAN1-AUTH-FLAKE-EXEC (2026-05-04): GET 페이지 인증 self-heal.
+  const authRedirect = authRedirectIfMissingJwt(request);
+  if (authRedirect) return authRedirect;
+
   return intlProxy(request);
 }
 

--- a/tests/qa-gate/auth-flake.spec.ts
+++ b/tests/qa-gate/auth-flake.spec.ts
@@ -1,0 +1,238 @@
+import {test, expect, request as playwrightRequest} from '@playwright/test';
+
+/**
+ * plan1 mutation E2E gate — PLAN1-AUTH-FLAKE-EXEC (2026-05-04)
+ *
+ * 사용자 보고 증상:
+ *   cofounder.co.kr/project/plan1 켜둔 채 일정 시간 지나면 로그인 풀림.
+ *   /project 경유 후 다시 plan1 진입 시도해도 첫 시도 실패.
+ *   /project 새로고침 후 재진입 시 로그인 됨.
+ *
+ * 원인 (3 layer):
+ *   1. JwtCookieRefresher (client) race condition — useEffect post-mount fetch 도중 navigation
+ *   2. cofounder_jwt 15min vs Better Auth session 7day lifetime 비대칭
+ *   3. cofounder-router host header rewrite → isProductionDomain=false → Secure: false (보조 결함)
+ *
+ * Fix:
+ *   - portal route ?return= query + host whitelist + 302 redirect + x-forwarded-host 우선 + 1h
+ *   - plan1 proxy.ts self-heal redirect (cookie 부재 시 portal refresh-jwt 로 redirect)
+ *   - 무한 루프 가드 (referer = portal refresh-jwt 면 redirect 안 함)
+ *
+ * 케이스 설계 (PICT 환원 5단계 — tests/qa-gate/models/auth-flake.txt):
+ *   RPN 80 Critical (인증=보안) → 3-way · 핵심 chain (CookieState × SessionState × EntryPath × RefererSource)
+ *   t-way 3 강제 + 수동 정의 C1~C6 보강.
+ *
+ * SLA: warm < 3000ms (mutation E2E 가드 표준 — dev-process.md § mutation E2E 가드)
+ *
+ * 적용 범위:
+ *   - GET 페이지 (HTML) 만 대상
+ *   - /api/** · server action POST 는 unaffected (UI 가 401 graceful 처리)
+ *
+ * 출력 형식:
+ *   [qa-gate] auth_flake_<case>_ms=NNN
+ */
+
+const SLA_WARM_MS = 3000;
+const PORTAL_BASE = process.env.PORTAL_BASE_URL ?? 'https://cofounder.co.kr';
+const PLAN1_BASE = process.env.PLAYWRIGHT_BASE_URL ?? 'https://cofounder.co.kr';
+const REFRESH_JWT_PATH = '/project/api/cofounder/refresh-jwt';
+
+test.describe('plan1 mutation E2E — AUTH-FLAKE-EXEC self-heal redirect', () => {
+  /**
+   * C1: cookie missing + session valid + deep link → 자동 갱신 + return URL 도달 (SLA <3000ms)
+   *
+   * - 가장 빈번한 사용자 시나리오 (15min idle 후 plan1 deep link)
+   * - 핵심 검증: race condition 제거 — portal 경유 없이도 plan1 가 자동 redirect
+   */
+  test('C1: cookie missing + session valid + deep link → self-heal redirect (SLA <3000ms)', async ({
+    page,
+    context
+  }) => {
+    // 사전 조건: storageState (auth.setup.ts) 의 better-auth session_token 존재 + cofounder_jwt 도 존재
+    // 강제로 cofounder_jwt 만 삭제 → "15min idle 후 cookie 만료" 시뮬레이션
+    const cookies = await context.cookies();
+    const sessionCookies = cookies.filter(c => c.name !== 'cofounder_jwt');
+    await context.clearCookies();
+    await context.addCookies(sessionCookies);
+
+    // 검증 — cookie 가 실제로 비었는지 확인
+    const beforeCookies = await context.cookies();
+    expect(
+      beforeCookies.find(c => c.name === 'cofounder_jwt'),
+      'C1 setup: cofounder_jwt 가 삭제되어야 함'
+    ).toBeUndefined();
+    expect(
+      beforeCookies.find(c => c.name.includes('better-auth')),
+      'C1 setup: Better Auth session 은 유지되어야 함'
+    ).toBeDefined();
+
+    // 측정: deep link 진입 → plan1 self-heal redirect → portal cookie set → return → plan1 page render
+    const startMs = Date.now();
+    await page.goto('/project/plan1/');
+    // qa-bot user header 표시 = JWT verify 통과 + SSR 완료
+    await expect(page.getByText(/qa-bot|QA Bot/i).first()).toBeVisible({timeout: SLA_WARM_MS});
+    const elapsedMs = Date.now() - startMs;
+
+    console.log(`[qa-gate] auth_flake_C1_self_heal_ms=${elapsedMs}`);
+
+    // SLA 검증
+    expect(
+      elapsedMs,
+      `C1 self-heal redirect ${elapsedMs}ms — SLA ${SLA_WARM_MS}ms 초과. portal redirect → cookie set → return URL 흐름 진단 필요.`
+    ).toBeLessThan(SLA_WARM_MS);
+
+    // 사후 검증 — cookie 가 다시 set 되었는지
+    const afterCookies = await context.cookies();
+    const newJwt = afterCookies.find(c => c.name === 'cofounder_jwt');
+    expect(newJwt, 'C1: portal refresh-jwt redirect 후 cofounder_jwt 가 재발급되어야 함').toBeDefined();
+  });
+
+  /**
+   * C3: cookie missing + session missing → portal sign-in 페이지 도달 (open redirect 차단 검증 X)
+   *
+   * - 사용자가 logout 후 plan1 deep link → sign-in 페이지로 redirect chain
+   * - 핵심 검증: portal session 미통과 시 sign-in 페이지로 graceful redirect (loop 방지)
+   */
+  test('C3: cookie missing + session missing → portal sign-in 도달', async ({
+    page,
+    context
+  }) => {
+    // 모든 cookie 삭제 (logout 시뮬레이션)
+    await context.clearCookies();
+
+    // deep link 진입
+    await page.goto('/project/plan1/', {waitUntil: 'domcontentloaded'});
+
+    // sign-in 페이지 도달 검증 — URL 또는 sign-in 폼 노출
+    // Better Auth sign-in 페이지 또는 portal 의 sign-in route — URL pattern 검사
+    const finalUrl = page.url();
+    const reachedSignIn =
+      finalUrl.includes('/sign-in') ||
+      finalUrl.endsWith('/project') ||
+      finalUrl.endsWith('/project/');
+
+    expect(
+      reachedSignIn,
+      `C3: cookie + session 둘 다 없으면 portal sign-in 또는 home 도달해야 함. final URL: ${finalUrl}`
+    ).toBe(true);
+
+    // plan1 page 직접 도달 안 했는지 (= 무한 루프 안 발생) 확인
+    expect(
+      finalUrl.includes('/project/plan1') && !finalUrl.includes('sign-in'),
+      `C3: plan1 page 직접 렌더되면 안 됨 (인증 필요). final URL: ${finalUrl}`
+    ).toBe(false);
+  });
+
+  /**
+   * C4: open redirect 차단 — `?return=https://evil.com` → portal home (whitelist reject)
+   *
+   * - 보안 검증 (RPN 80 Critical)
+   * - portal route 단위 — API request context 로 직접 호출 (full browser navigation 불요)
+   */
+  test('C4: open redirect 차단 — return=evil.com → portal home', async () => {
+    const ctx = await playwrightRequest.newContext({
+      baseURL: PORTAL_BASE,
+      // unauthenticated request — session 없음 (cookie set 흐름 진입 안 함)
+      extraHTTPHeaders: process.env.VERCEL_AUTOMATION_BYPASS_SECRET
+        ? {
+            'x-vercel-protection-bypass': process.env.VERCEL_AUTOMATION_BYPASS_SECRET,
+            'x-vercel-set-bypass-cookie': 'true'
+          }
+        : {}
+    });
+
+    // 검증 1: evil.com return → portal sign-in 또는 home 으로 redirect (evil.com 절대 도달 X)
+    // session 없으므로 401 응답 + return 있으면 sign-in 으로 redirect
+    const evilResp = await ctx.get(`${REFRESH_JWT_PATH}?return=https://evil.com/steal`, {
+      maxRedirects: 0
+    });
+
+    // session 없는 상태에서는 302 → sign-in 또는 401 응답
+    if (evilResp.status() === 302) {
+      const location = evilResp.headers()['location'] ?? '';
+      expect(
+        location.includes('evil.com'),
+        `C4: evil.com 으로 절대 redirect 되면 안 됨. Location: ${location}`
+      ).toBe(false);
+      // sign-in URL 의 return param 도 evil.com 이면 안 됨 (portal sign-in 안에서 도달)
+      expect(
+        location.includes('return=https%3A%2F%2Fevil.com') ||
+          location.includes('return=https://evil.com'),
+        `C4: sign-in return param 에 evil.com 포함되면 안 됨. Location: ${location}`
+      ).toBe(false);
+    } else {
+      // 401 인 경우는 OK (redirect 안 발생 = evil.com 도달 risk 0)
+      expect(evilResp.status(), `C4: 302 또는 401 예상 — 실제 ${evilResp.status()}`).toBe(401);
+    }
+
+    await ctx.dispose();
+  });
+
+  /**
+   * C5: 무한 루프 가드 — referer = portal refresh-jwt 면 plan1 proxy 가 redirect 안 함
+   *
+   * - portal 발급 실패 직후 케이스 (예: 외부 OAuth provider 다운)
+   * - plan1 page 그대로 렌더 → server action 단계 ServerActionError unauthorized → 클라이언트 sign-in CTA
+   */
+  test('C5: 무한 루프 가드 — referer portal refresh-jwt 면 redirect 안 함', async ({
+    context,
+    page
+  }) => {
+    // cookie 삭제
+    await context.clearCookies();
+
+    // referer 헤더를 portal refresh-jwt 로 set 한 채 plan1 진입
+    await page.setExtraHTTPHeaders({
+      referer: `${PORTAL_BASE}/project/api/cofounder/refresh-jwt`
+    });
+
+    // navigation — plan1 가 redirect 안 하면 200 또는 401 응답 (sign-in 페이지 redirect 안 함)
+    const response = await page.goto('/project/plan1/', {waitUntil: 'domcontentloaded'});
+
+    // 핵심 검증: portal refresh-jwt 로 다시 redirect 안 함 (= request URL 이 plan1 그대로 또는 portal sign-in)
+    const finalUrl = page.url();
+    const redirectedAgain = finalUrl.includes(REFRESH_JWT_PATH);
+    expect(
+      redirectedAgain,
+      `C5 무한 루프 가드 위반 — referer portal refresh-jwt 인 채 다시 portal redirect 발생. final URL: ${finalUrl}`
+    ).toBe(false);
+
+    // 응답 확인 — 200 (page render) 또는 sign-in 도달. 어느 쪽이든 무한 루프 X
+    if (response) {
+      expect(response.status(), `C5: response status valid 범위`).toBeLessThan(500);
+    }
+  });
+
+  /**
+   * C6 (정상 플로우): cookie present + session valid → redirect 없음 · plan1 직접 렌더
+   *
+   * - 회귀 차단: fix 가 정상 케이스 (cookie 있음) 의 동작을 깨뜨리지 않는지 검증
+   * - storageState (auth.setup.ts) 의 cookie 그대로 사용
+   */
+  test('C6 (정상): cookie present → redirect 없음 · plan1 직접 렌더', async ({page}) => {
+    // storageState 그대로 사용 — cofounder_jwt + better-auth session 모두 보존
+    const startMs = Date.now();
+    await page.goto('/project/plan1/');
+    await expect(page.getByText(/qa-bot|QA Bot/i).first()).toBeVisible({timeout: SLA_WARM_MS});
+    const elapsedMs = Date.now() - startMs;
+
+    console.log(`[qa-gate] auth_flake_C6_normal_ms=${elapsedMs}`);
+
+    // SLA — 정상 플로우는 self-heal 보다 빨라야 함
+    expect(
+      elapsedMs,
+      `C6 정상 플로우 ${elapsedMs}ms — redirect 없는 SSR 흐름이 SLA ${SLA_WARM_MS}ms 초과. 다른 회귀 의심.`
+    ).toBeLessThan(SLA_WARM_MS);
+
+    // URL 검증 — plan1 page 그대로 도달 (sign-in redirect 안 함)
+    const finalUrl = page.url();
+    expect(
+      finalUrl.includes('/project/plan1'),
+      `C6: plan1 page 직접 도달해야 함. final URL: ${finalUrl}`
+    ).toBe(true);
+    expect(
+      finalUrl.includes('sign-in') || finalUrl.includes(REFRESH_JWT_PATH),
+      `C6: redirect 없어야 함. final URL: ${finalUrl}`
+    ).toBe(false);
+  });
+});

--- a/tests/qa-gate/models/auth-flake.txt
+++ b/tests/qa-gate/models/auth-flake.txt
@@ -1,0 +1,46 @@
+# plan1 — auth flake (cookie 부재 self-heal redirect) — Critical RPN 80 (인증 = 보안)
+# PLAN1-AUTH-FLAKE-EXEC (2026-05-04)
+# t-way 3 (3-way · 인증=보안 영역 RPN ≥ 80 → NIST Server 89% catch)
+# 4 layer 결합 결함 (race + lifetime + host header + missing recovery) catch 의무
+
+# === 입력 변수 (사용자 보고 증상 + fix 대상 chain 핵심 차원) ===
+
+CookieState:      missing, expired, present
+SessionState:     valid, expired, missing
+EntryPath:        deep_link, portal_first
+RefererSource:    portal_refresh, other, none
+ReturnParam:      cofounder_host, evil_host, missing
+HttpMethod:       get_page, post_server_action
+
+# === Constraints ===
+
+# JWT cookie 가 있으면 portal session 도 valid (JWT 발급 prerequisite)
+IF [CookieState] = "present" THEN [SessionState] = "valid";
+
+# Server action POST 흐름은 redirect 안 함 (UI 가 401 graceful 처리)
+# Return param + open redirect 검증은 portal route 단위 — server action 흐름 외
+IF [HttpMethod] = "post_server_action" THEN [ReturnParam] = "missing";
+
+# RefererSource 는 plan1 proxy.ts 의 무한 루프 가드 검증 — get_page 만 의미
+IF [HttpMethod] = "post_server_action" THEN [RefererSource] = "none";
+
+# evil_host return 은 portal route 단위 검증만 — plan1 proxy 흐름 외
+IF [ReturnParam] = "evil_host" THEN [EntryPath] = "deep_link";
+
+# === 실행 옵션 ===
+# 전체 3-way 환원: pict auth-flake.txt /o:3
+# 핵심 chain (CookieState × SessionState × EntryPath × RefererSource) 자동 포함
+
+# === 핵심 cases (수동 정의 — PICT 출력 보강) ===
+# C1: missing × valid × deep_link × none × cofounder_host × get_page
+#     → portal redirect → cookie set → return 도달 (SLA < 2000ms)
+# C2: missing × valid × portal_first × none × missing × get_page
+#     → portal 의 JwtCookieRefresher 가 cookie set (서버 측 redirect 발동 안 함 — portal 페이지 자체)
+# C3: missing × missing × deep_link × none × cofounder_host × get_page
+#     → portal redirect → portal sign-in 페이지로 redirect
+# C4: missing × valid × deep_link × none × evil_host × get_page
+#     → portal whitelist reject → fallback to portal home (open redirect 차단)
+# C5: missing × any × deep_link × portal_refresh × any × get_page
+#     → 무한 루프 가드 — plan1 proxy 가 redirect 안 함 (next() 통과)
+# C6: present × valid × deep_link × none × missing × get_page
+#     → 정상 플로우 — redirect 없음 · plan1 page 직접 렌더


### PR DESCRIPTION
## Summary
- PLAN1-AUTH-FLAKE-EXEC (대장 권고 A · self-heal redirect)
- GET 페이지 진입 시 `cofounder_jwt` cookie 부재 → portal `/api/cofounder/refresh-jwt?return=<원래 URL>` 로 302 redirect
- 무한 루프 가드: referer 헤더가 portal refresh-jwt 면 redirect 안 함 (portal 발급 실패 케이스)
- `x-forwarded-host` / `x-forwarded-proto` 로 사용자 실제 요청 URL 재구성 (router 가 set)

## 컨텍스트
연관 portal PR: [horaeng0506/cofounder-portal#24](https://github.com/horaeng0506/cofounder-portal/pull/24)

증상: `cofounder.co.kr/project/plan1` 일정 시간 후 로그인 풀림. portal 경유 후에도 race condition 으로 첫 진입 실패. 원인 분석 + fix 계획: PLAN1-20260504-AUTH-FLAKE.

## 변경
- `proxy.ts` — `authRedirectIfMissingJwt()` 함수 추가 + GET 페이지 분기 진입 직전 호출
- env: `PORTAL_REFRESH_JWT_URL` (옵션) — preview/staging 분리용. default = production cofounder.co.kr

## 적용 범위
- GET 페이지 (HTML) 만 대상
- `/api/**` · server action POST 는 unaffected (UI 가 401 graceful 처리)

## Test plan
- [ ] plan1 Vercel preview deploy
- [ ] cookie 강제 삭제 후 deep link `/project/plan1/dashboard` → portal refresh-jwt redirect → cookie set → return URL 도달 (SLA <2000ms)
- [ ] cookie 만료 후 plan1 navigation → 자동 갱신
- [ ] 무한 루프 가드 — 인위적으로 portal refresh-jwt 가 cookie 없이 redirect 했을 때 plan1 가 다시 redirect 안 함
- [ ] open redirect 차단 (portal 측 PR 에서 검증)
- [ ] mutation E2E qa-gate spec 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)