### PR TITLE
fix: plan1 schedule timezone (옵션 A · split.ts user TZ aware)

### DIFF
--- a/app/actions/schedules.ts
+++ b/app/actions/schedules.ts
@@ -55,6 +55,7 @@ async function loadUserState(
   schedules: Schedule[];
   workingHours: Record<string, WorkingHours>;
   defaultWH: {startMin: number; endMin: number};
+  userTz: string;
 }> {
   // Track 1.5 phase 3 fix (2026-04-29): ownership SELECT + loadState 3 SELECT 을 1 batch 로
   // 통합. cross-continent RTT × 2 (ownership 700ms + loadState 700ms = 1400ms) → RTT × 1 (~700ms)
@@ -87,7 +88,8 @@ async function loadUserState(
           endMin: settingsRow[0].defaultWorkingHoursEndMin
         }
       : {startMin: 540, endMin: 1080};
-    return {schedules: scheduleRows.map(rowToDomain), workingHours, defaultWH};
+    const userTz = settingsRow[0]?.userTz ?? 'Asia/Seoul';
+    return {schedules: scheduleRows.map(rowToDomain), workingHours, defaultWH, userTz};
   }
 
   // ownership 검증 불요 (completeSchedule · updateSchedule categoryId 미변경)
@@ -112,11 +114,13 @@ async function loadUserState(
         endMin: settingsRow[0].defaultWorkingHoursEndMin
       }
     : {startMin: 540, endMin: 1080}; // 09:00~18:00 default
+  const userTz = settingsRow[0]?.userTz ?? 'Asia/Seoul';
 
   return {
     schedules: scheduleRows.map(rowToDomain),
     workingHours,
-    defaultWH
+    defaultWH,
+    userTz
   };
 }
 
@@ -236,7 +240,7 @@ export async function createSchedule(input: {
     };
     const originals = state.schedules.filter(s => !s.splitFrom);
     const merged = [...originals, newSchedule];
-    const split = splitByWorkingHours(merged, state.workingHours, state.defaultWH);
+    const split = splitByWorkingHours(merged, state.workingHours, state.defaultWH, state.userTz);
     const existingIds = new Set(state.schedules.map(s => s.id));
     await syncSchedules(user.id, existingIds, split);
     return split;
@@ -282,7 +286,7 @@ export async function updateSchedule(input: {
     const cascaded = cascade(metaPatched, input.id, newStartAt, newDuration);
 
     // split 가 deterministic ID 로 part 재생성 (idempotent — Critical #1).
-    const split = splitByWorkingHours(cascaded, state.workingHours, state.defaultWH);
+    const split = splitByWorkingHours(cascaded, state.workingHours, state.defaultWH, state.userTz);
     const existingIds = new Set(state.schedules.map(s => s.id));
     await syncSchedules(user.id, existingIds, split);
     return split;
@@ -329,7 +333,7 @@ export async function completeSchedule(input: {
         : s
     );
 
-    const split = splitByWorkingHours(cascaded, state.workingHours, state.defaultWH);
+    const split = splitByWorkingHours(cascaded, state.workingHours, state.defaultWH, state.userTz);
     const existingIds = new Set(state.schedules.map(s => s.id));
     await syncSchedules(user.id, existingIds, split);
     return split;

--- a/app/actions/settings.ts
+++ b/app/actions/settings.ts
@@ -40,7 +40,10 @@ function rowToDomain(row: typeof plan1Settings.$inferSelect): AppSettings {
       startMin: row.defaultWorkingHoursStartMin,
       endMin: row.defaultWorkingHoursEndMin
     },
-    userTz: row.userTz,
+    // 옵션 A 가드 (PLAN1-SCHEDULE-VERIFY · 2026-05-04) — schema mismatch 또는 column 부재
+    // 환경에서 fall-back. NOT NULL DEFAULT 'Asia/Seoul' 박혀있어 정상 환경에선 무관하지만
+    // Neon ephemeral branch source mismatch / migration timing race 시 안전 layer.
+    userTz: row.userTz ?? 'Asia/Seoul',
     pinnedActiveId: row.pinnedActiveId
   };
 }

--- a/app/actions/settings.ts
+++ b/app/actions/settings.ts
@@ -27,6 +27,7 @@ const DEFAULT_SETTINGS = {
   weeklyPanelHidden: false,
   defaultWorkingHoursStartMin: 540, // 09:00
   defaultWorkingHoursEndMin: 1080, // 18:00
+  userTz: 'Asia/Seoul',
   pinnedActiveId: null as string | null
 };
 
@@ -39,6 +40,7 @@ function rowToDomain(row: typeof plan1Settings.$inferSelect): AppSettings {
       startMin: row.defaultWorkingHoursStartMin,
       endMin: row.defaultWorkingHoursEndMin
     },
+    userTz: row.userTz,
     pinnedActiveId: row.pinnedActiveId
   };
 }
@@ -92,6 +94,7 @@ export async function updateSettings(
       dbPatch.defaultWorkingHoursStartMin = patch.defaultWorkingHours.startMin;
       dbPatch.defaultWorkingHoursEndMin = patch.defaultWorkingHours.endMin;
     }
+    if (patch.userTz !== undefined) dbPatch.userTz = patch.userTz;
     if (patch.pinnedActiveId !== undefined) dbPatch.pinnedActiveId = patch.pinnedActiveId;
 
     const [updated] = await db

--- a/app/actions/working-hours.ts
+++ b/app/actions/working-hours.ts
@@ -56,11 +56,12 @@ async function applySplitForUser(userId: string): Promise<void> {
         endMin: settingsRow[0].defaultWorkingHoursEndMin
       }
     : {startMin: 540, endMin: 1080};
+  const userTz = settingsRow[0]?.userTz ?? 'Asia/Seoul';
 
   const before = scheduleRows.map(scheduleRowToDomain);
   // logic-critic Critical #1·#2: split input 은 원본만. 기존 part 는 split 가 deterministic ID 로 재생성.
   const originals = before.filter(s => !s.splitFrom);
-  const after = splitByWorkingHours(originals, workingHours, defaultWH);
+  const after = splitByWorkingHours(originals, workingHours, defaultWH, userTz);
 
   const beforeIds = new Set(before.map(s => s.id));
   const afterIds = new Set(after.map(s => s.id));

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -132,6 +132,9 @@ export const plan1Settings = plan1Schema.table('settings', {
   weeklyPanelHidden: boolean('weekly_panel_hidden').$defaultFn(() => false).notNull(),
   defaultWorkingHoursStartMin: integer('default_working_hours_start_min').notNull(),
   defaultWorkingHoursEndMin: integer('default_working_hours_end_min').notNull(),
+  // 옵션 A (PLAN1-SCHEDULE-OPT-A · 2026-05-04) — user wall-clock TZ. split.ts user TZ aware 인자.
+  // Vercel iad1 (UTC) ↔ user KST 충돌 fall-back 차단. IANA TZ name (e.g. 'Asia/Seoul' · 'America/Los_Angeles').
+  userTz: text('user_tz').notNull().default('Asia/Seoul'),
   pinnedActiveId: text('pinned_active_id').references((): AnyPgColumn => plan1Schedules.id, {
     onDelete: 'set null'
   }),

--- a/lib/domain/split.day-boundary.test.ts
+++ b/lib/domain/split.day-boundary.test.ts
@@ -42,15 +42,17 @@ describe('splitByWorkingHours — day boundary BVA', () => {
     else delete process.env.TZ;
   });
 
-  it('1. KST 23:30 + 30min → fittable 0 → 다음날 09:00 single part', () => {
+  it('1. KST 23:30 + 30min → fittable=0 → roll forward 다음날 09:00 (split 아님)', () => {
     const startAt = kstMs(2026, 5, 4, 23, 30);
     const sched = mkSchedule('db-1', startAt, 30);
     const result = splitByWorkingHours([sched], {}, DEFAULT_WH);
 
-    const part = result.find(s => s.splitFrom === 'db-1');
-    expect(part).toBeDefined();
-    expect(part!.startAt).toBe(kstMs(2026, 5, 5, 9));
-    expect(part!.durationMin).toBe(30);
+    // 2026-04-30 fix: startAt 이 WH endMin 이후 → roll forward (split 아닌 reschedule)
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('db-1');
+    expect(result[0].splitFrom).toBeUndefined();
+    expect(result[0].startAt).toBe(kstMs(2026, 5, 5, 9));
+    expect(result[0].durationMin).toBe(30);
   });
 
   it('2. KST 17:30 + 60min (정확히 wh.endMin 와 일치) → split 안 일어남', () => {

--- a/lib/domain/split.day-boundary.test.ts
+++ b/lib/domain/split.day-boundary.test.ts
@@ -1,0 +1,102 @@
+/**
+ * splitByWorkingHours — day boundary 처리 회귀 catch
+ *
+ * 환원 근거: tests/qa-gate/models/schedule-tz.txt § 2 day boundary triplet (3-way)
+ * BVA: 입력시각 0/23:30/23:59, duration 30/60/600, wh end 900/1080/1320
+ *
+ * 본 spec 은 server TZ KST 가정 (옵션 D 박힌 prod 시뮬)
+ */
+
+import {describe, it, expect, beforeAll, afterAll} from 'vitest';
+import {splitByWorkingHours} from './split';
+import type {Schedule} from './types';
+
+function mkSchedule(id: string, startAt: number, durationMin: number): Schedule {
+  return {
+    id,
+    title: id,
+    categoryId: 'cat-default',
+    startAt,
+    durationMin,
+    timerType: 'countup',
+    status: 'pending',
+    createdAt: 0,
+    updatedAt: 0
+  };
+}
+
+function kstMs(y: number, m: number, d: number, h: number, mm = 0): number {
+  return Date.UTC(y, m - 1, d, h - 9, mm, 0, 0);
+}
+
+const DEFAULT_WH = {startMin: 540, endMin: 1080};
+
+describe('splitByWorkingHours — day boundary BVA', () => {
+  let originalTZ: string | undefined;
+  beforeAll(() => {
+    originalTZ = process.env.TZ;
+    process.env.TZ = 'Asia/Seoul';
+  });
+  afterAll(() => {
+    if (originalTZ) process.env.TZ = originalTZ;
+    else delete process.env.TZ;
+  });
+
+  it('1. KST 23:30 + 30min → fittable 0 → 다음날 09:00 single part', () => {
+    const startAt = kstMs(2026, 5, 4, 23, 30);
+    const sched = mkSchedule('db-1', startAt, 30);
+    const result = splitByWorkingHours([sched], {}, DEFAULT_WH);
+
+    const part = result.find(s => s.splitFrom === 'db-1');
+    expect(part).toBeDefined();
+    expect(part!.startAt).toBe(kstMs(2026, 5, 5, 9));
+    expect(part!.durationMin).toBe(30);
+  });
+
+  it('2. KST 17:30 + 60min (정확히 wh.endMin 와 일치) → split 안 일어남', () => {
+    const startAt = kstMs(2026, 5, 4, 17, 30);
+    const sched = mkSchedule('db-2', startAt, 30);
+    const result = splitByWorkingHours([sched], {}, DEFAULT_WH);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].splitFrom).toBeUndefined();
+    expect(result[0].startAt).toBe(startAt);
+  });
+
+  it('3. KST 17:30 + 31min (wh.endMin 1분 초과) → split 유발', () => {
+    const startAt = kstMs(2026, 5, 4, 17, 30);
+    const sched = mkSchedule('db-3', startAt, 31);
+    const result = splitByWorkingHours([sched], {}, DEFAULT_WH);
+
+    // 원본 fittable = 30, part = 1
+    expect(result.length).toBeGreaterThanOrEqual(2);
+    const original = result.find(s => s.id === 'db-3');
+    const part = result.find(s => s.splitFrom === 'db-3');
+    expect(original?.durationMin).toBe(30);
+    expect(part?.durationMin).toBe(1);
+    expect(part?.startAt).toBe(kstMs(2026, 5, 5, 9));
+  });
+
+  it('4. KST 00:30 + 60min (자정 직후) → 시작 시각 그대로 유지 (working hours 시작 전이지만 endMin 검사만)', () => {
+    const startAt = kstMs(2026, 5, 4, 0, 30);
+    const sched = mkSchedule('db-4', startAt, 60);
+    const result = splitByWorkingHours([sched], {}, DEFAULT_WH);
+
+    // 현재 split.ts 는 endMin > wh.endMin 만 검사 — startMin < wh.startMin 은 무시
+    // 즉 00:30 + 60min = 01:30 → 1080 안 → 그대로 통과
+    expect(result).toHaveLength(1);
+    expect(result[0].startAt).toBe(startAt);
+  });
+
+  it('5. KST 09:00 + 600min (10시간) → fittable 540 → 다음날 09:00 으로 60min 이월', () => {
+    const startAt = kstMs(2026, 5, 4, 9);
+    const sched = mkSchedule('db-5', startAt, 600);
+    const result = splitByWorkingHours([sched], {}, DEFAULT_WH);
+
+    const original = result.find(s => s.id === 'db-5');
+    const part = result.find(s => s.splitFrom === 'db-5');
+    expect(original?.durationMin).toBe(540); // 09:00 ~ 18:00 정확 fit
+    expect(part?.durationMin).toBe(60); // 다음날 60분
+    expect(part?.startAt).toBe(kstMs(2026, 5, 5, 9));
+  });
+});

--- a/lib/domain/split.timezone.test.ts
+++ b/lib/domain/split.timezone.test.ts
@@ -101,20 +101,19 @@ describe('splitByWorkingHours — TZ race fall-back regression', () => {
     expect(result[0].startAt).toBe(startAt);
   });
 
-  it('4. day boundary KST 23:30 + 60min schedule → server TZ KST 시 day boundary 정확', () => {
+  it('4. day boundary KST 23:30 + 60min schedule → fittable=0 → roll forward 다음날 09:00', () => {
     // KST 5/4 23:30 + 60min = KST 5/5 00:30
     // server TZ KST 시: dateKey = '2026-05-04' (시작 기준), minutesOfDay = 1410
     // wh.endMin = 1080 → endMin = 1470 > 1080 → split 유발
-    // fittable = max(0, 1080 - 1410) = 0 → next day 9:00 으로 이동
+    // fittable = max(0, 1080 - 1410) = 0 → roll forward (split 아닌 reschedule · 2026-04-30 fix)
     const startAt = kstWallClockMs(2026, 5, 4, 23, 30);
     const sched = mkSchedule('s-tz-4', startAt, 60);
     const result = splitByWorkingHours([sched], {}, DEFAULT_WH);
 
-    // split 결과: original (시작 23:30 fittable 0 → 빈 part 안 남김) + part dayIndex=1 (5/5 09:00)
-    // 검증: part 의 startAt 이 KST 5/5 09:00 ms 와 정확 일치
-    const expectedNextDay = kstWallClockMs(2026, 5, 5, 9);
-    const part = result.find(s => s.splitFrom === 's-tz-4');
-    expect(part).toBeDefined();
-    expect(part!.startAt).toBe(expectedNextDay);
+    // 단일 원본 schedule + startAt 만 다음날 09:00 KST 으로 이동 (split_from 없음 · FK 안전)
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('s-tz-4');
+    expect(result[0].splitFrom).toBeUndefined();
+    expect(result[0].startAt).toBe(kstWallClockMs(2026, 5, 5, 9));
   });
 });

--- a/lib/domain/split.timezone.test.ts
+++ b/lib/domain/split.timezone.test.ts
@@ -1,0 +1,120 @@
+/**
+ * splitByWorkingHours — server TZ vs user TZ 충돌 회귀 catch
+ *
+ * 사고: 2026-05-04 prod 사용자 KST 입력 → 14:00 KST fall-back. root cause:
+ *   - Vercel iad1 (UTC) + TZ env 부재 → server local TZ = UTC
+ *   - lib/domain/split.ts 의 dateKeyOf·minutesOfDay·dayStartMs·addDaysMs 가
+ *     server-local Date API 사용 (timezone-naive)
+ *   - 사용자 KST 07:00 입력 ms = UTC 22:00 (전날) → server 가 dateKey 를
+ *     UTC 전날로 잘못 lookup → wh miss → next-day wh.startMin fall-back
+ *
+ * 본 spec 은 옵션 D (vercel.json TZ=Asia/Seoul) 적용 전 red.
+ * 옵션 D 적용 후 spec 1·2 green.
+ * 옵션 A (user TZ aware) 적용 후 spec 3 (PST 사용자) 도 green.
+ *
+ * 환원 근거: tests/qa-gate/models/schedule-tz.txt § 1 timezone race triplet (3-way)
+ */
+
+import {describe, it, expect, beforeAll, afterAll} from 'vitest';
+import {splitByWorkingHours} from './split';
+import type {Schedule, WorkingHours} from './types';
+
+function mkSchedule(id: string, startAt: number, durationMin: number): Schedule {
+  return {
+    id,
+    title: id,
+    categoryId: 'cat-default',
+    startAt,
+    durationMin,
+    timerType: 'countup',
+    status: 'pending',
+    createdAt: 0,
+    updatedAt: 0
+  };
+}
+
+// 사용자 wall-clock 시각 (KST = UTC+9) → epoch ms 명시 변환
+// system TZ 와 무관하게 정확한 ms 산출 — Date.UTC 후 KST offset 차감
+function kstWallClockMs(y: number, m: number, d: number, h: number, mm = 0): number {
+  return Date.UTC(y, m - 1, d, h - 9, mm, 0, 0);
+}
+
+// 같은 패턴 PST 사용자 (UTC-8)
+function pstWallClockMs(y: number, m: number, d: number, h: number, mm = 0): number {
+  return Date.UTC(y, m - 1, d, h + 8, mm, 0, 0);
+}
+
+const DEFAULT_WH = {startMin: 540, endMin: 1080}; // 09:00~18:00
+
+describe('splitByWorkingHours — TZ race fall-back regression', () => {
+  // 옵션 D 검증 — server TZ KST 강제 시 정상 처리
+  // (vitest 실행 시점 process.env.TZ 가 결정. 옵션 D 적용 후 vercel.json TZ=Asia/Seoul)
+  let originalTZ: string | undefined;
+
+  beforeAll(() => {
+    originalTZ = process.env.TZ;
+    // 본 spec 은 server TZ KST 가정 — 옵션 D 박힌 prod 환경 시뮬
+    process.env.TZ = 'Asia/Seoul';
+  });
+
+  afterAll(() => {
+    if (originalTZ) process.env.TZ = originalTZ;
+    else delete process.env.TZ;
+  });
+
+  it('1. KST 사용자 07:00 입력 → server TZ KST 일 때 startAt 변동 없음 (옵션 D 검증)', () => {
+    const startAt = kstWallClockMs(2026, 5, 4, 7);
+    const sched = mkSchedule('s-tz-1', startAt, 60);
+    const result = splitByWorkingHours([sched], {}, DEFAULT_WH);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('s-tz-1');
+    // 사용자가 입력한 정확한 ms 가 그대로 — fall-back 없음
+    expect(result[0].startAt).toBe(startAt);
+    expect(result[0].splitFrom).toBeUndefined();
+  });
+
+  it('2. KST 사용자 06:00 + working hours 06:00-15:00 (custom) → fall-back 안 일어남', () => {
+    const startAt = kstWallClockMs(2026, 5, 4, 6);
+    const sched = mkSchedule('s-tz-2', startAt, 60);
+    // 사용자가 KST 기준 5/4 wh 를 06:00-15:00 (custom) 으로 설정
+    const wh: Record<string, WorkingHours> = {
+      '2026-05-04': {date: '2026-05-04', startMin: 360, endMin: 900}
+    };
+    const result = splitByWorkingHours([sched], wh, {startMin: 360, endMin: 900});
+
+    expect(result).toHaveLength(1);
+    expect(result[0].startAt).toBe(startAt);
+    expect(result[0].splitFrom).toBeUndefined();
+  });
+
+  it('3. PST 사용자 (옵션 A 후 통과) — server KST + user PST → user wall-clock 기준 처리', () => {
+    // 사용자 PST 09:00 = UTC 17:00 = KST 02:00 (다음날)
+    const startAt = pstWallClockMs(2026, 5, 4, 9);
+    const sched = mkSchedule('s-tz-3', startAt, 60);
+    const result = splitByWorkingHours([sched], {}, DEFAULT_WH);
+
+    // 옵션 A 박기 전: server KST 기준 dateKey/minutesOfDay 처리 → KST 02:00 으로 인식 → wh miss → fall-back
+    // 옵션 A 박은 후: user TZ 인자 받아 PST 기준 → 09:00 정상 처리 → fall-back 없음
+    // 본 spec 은 옵션 A 검증용 — 현재는 fail 예상 (TODO: 옵션 A 박은 후 .skip 제거)
+    expect(result).toHaveLength(1);
+    expect(result[0].startAt).toBe(startAt);
+  });
+
+  it('4. day boundary KST 23:30 + 60min schedule → server TZ KST 시 day boundary 정확', () => {
+    // KST 5/4 23:30 + 60min = KST 5/5 00:30
+    // server TZ KST 시: dateKey = '2026-05-04' (시작 기준), minutesOfDay = 1410
+    // wh.endMin = 1080 → endMin = 1470 > 1080 → split 유발
+    // fittable = max(0, 1080 - 1410) = 0 → next day 9:00 으로 이동
+    const startAt = kstWallClockMs(2026, 5, 4, 23, 30);
+    const sched = mkSchedule('s-tz-4', startAt, 60);
+    const result = splitByWorkingHours([sched], {}, DEFAULT_WH);
+
+    // split 결과: original (시작 23:30 fittable 0 → 빈 part 안 남김) + part dayIndex=1 (5/5 09:00)
+    // 검증: part 의 startAt 이 KST 5/5 09:00 ms 와 정확 일치
+    const expectedNextDay = kstWallClockMs(2026, 5, 5, 9);
+    const part = result.find(s => s.splitFrom === 's-tz-4');
+    expect(part).toBeDefined();
+    expect(part!.startAt).toBe(expectedNextDay);
+  });
+});

--- a/lib/domain/split.ts
+++ b/lib/domain/split.ts
@@ -2,29 +2,71 @@ import type { Schedule, WorkingHours } from './types'
 
 const NS = 60_000
 
-function dateKeyOf(ms: number): string {
-  const d = new Date(ms)
-  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
+// 옵션 A — user TZ aware Date helper (Intl.DateTimeFormat 기반).
+// server local TZ (Vercel iad1 = UTC) 와 무관하게 user TZ 기준 wall-clock day key + minutes-of-day 산출.
+//
+// 사고: 2026-05-04 prod 사용자 KST 07:00 입력 → 14:00 fall-back. root cause:
+//   - Vercel iad1 default UTC + TZ env reserved (변경 불가)
+//   - server-TZ-naive Date API → user wall-clock day boundary 잘못 인식
+//   - line 74-83 fittable=0 분기 가 다음 날 wh.startMin 으로 roll forward → fall-back
+// 해결: user TZ 인자를 splitByWorkingHours signature 에 추가. settings.userTz 에서 주입.
+//
+// DST 안전성: Asia/Seoul 은 DST 없음. 다중 사용자 SaaS 시 America/Los_Angeles 같은 DST TZ 에선
+// dayStartMs 가 dayStart 의 24h 차이가 23h/25h 가 될 수 있어 addDaysMs 가 dayStartMs 으로 재정렬.
+
+function getDateParts(
+  ms: number,
+  timeZone: string
+): { year: number; month: number; day: number; hour: number; minute: number } {
+  const fmt = new Intl.DateTimeFormat('en-US', {
+    timeZone,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+  })
+  const parts = fmt.formatToParts(new Date(ms))
+  const get = (t: string) => Number(parts.find((p) => p.type === t)?.value ?? 0)
+  // hour12=false 일부 환경에서 자정이 '24' 로 나올 수 있음 → 0 normalize
+  const rawHour = get('hour')
+  return {
+    year: get('year'),
+    month: get('month'),
+    day: get('day'),
+    hour: rawHour === 24 ? 0 : rawHour,
+    minute: get('minute'),
+  }
 }
 
-function minutesOfDay(ms: number): number {
-  const d = new Date(ms)
-  return d.getHours() * 60 + d.getMinutes()
+function dateKeyOf(ms: number, timeZone: string): string {
+  const { year, month, day } = getDateParts(ms, timeZone)
+  return `${year}-${String(month).padStart(2, '0')}-${String(day).padStart(2, '0')}`
 }
 
-function dayStartMs(ms: number): number {
-  const d = new Date(ms)
-  d.setHours(0, 0, 0, 0)
-  return d.getTime()
+function minutesOfDay(ms: number, timeZone: string): number {
+  const { hour, minute } = getDateParts(ms, timeZone)
+  return hour * 60 + minute
 }
 
-function addDaysMs(ms: number, days: number): number {
-  const d = new Date(ms)
-  d.setDate(d.getDate() + days)
-  return d.getTime()
+function dayStartMs(ms: number, timeZone: string): number {
+  // user TZ 의 wall-clock 00:00 의 epoch ms — 단순 minute-of-day 차감
+  return ms - minutesOfDay(ms, timeZone) * NS
 }
 
-function whFor(dateKey: string, workingHours: Record<string, WorkingHours>, defaultWH: { startMin: number; endMin: number }): { startMin: number; endMin: number } {
+function addDaysMs(ms: number, days: number, timeZone: string): number {
+  // user TZ wall-clock day 단위 이동. DST 안전 (dayStartMs 재정렬)
+  const start = dayStartMs(ms, timeZone)
+  const approx = start + days * 24 * 60 * NS
+  return dayStartMs(approx, timeZone)
+}
+
+function whFor(
+  dateKey: string,
+  workingHours: Record<string, WorkingHours>,
+  defaultWH: { startMin: number; endMin: number }
+): { startMin: number; endMin: number } {
   const entry = workingHours[dateKey]
   if (entry) return { startMin: entry.startMin, endMin: entry.endMin }
   return { startMin: defaultWH.startMin, endMin: defaultWH.endMin }
@@ -39,7 +81,8 @@ function makePartId(baseId: string, dayIndex: number): string {
 export function splitByWorkingHours(
   schedules: Schedule[],
   workingHours: Record<string, WorkingHours>,
-  defaultWH: { startMin: number; endMin: number }
+  defaultWH: { startMin: number; endMin: number },
+  userTz: string = 'Asia/Seoul'
 ): Schedule[] {
   const done = schedules.filter((s) => s.status === 'done')
   // queue 진입 시 dayIndex 추적 (원본 = 0, 첫 part = 1, 두번째 = 2, ...)
@@ -59,9 +102,9 @@ export function splitByWorkingHours(
   while (queue.length > 0 && iter < 5000) {
     const { schedule: s, dayIndex } = queue.shift() as QueueItem
     iter++
-    const dateKey = dateKeyOf(s.startAt)
+    const dateKey = dateKeyOf(s.startAt, userTz)
     const wh = whFor(dateKey, workingHours, defaultWH)
-    const startMin = minutesOfDay(s.startAt)
+    const startMin = minutesOfDay(s.startAt, userTz)
     const endMin = startMin + s.durationMin
     if (endMin <= wh.endMin) {
       out.push(s)
@@ -71,9 +114,12 @@ export function splitByWorkingHours(
     // 2026-04-30 fix: startAt 이 WH endMin 이후면 fittable=0. 원본을 emit 안 한 채 part 만 emit 하면
     // part.split_from 가 존재하지 않는 원본 ID 를 가리켜 FK violation (Track 2 C-3 1차 PR 검증에서 노출).
     // → 원본 자체를 다음 날 WH 시작 시각으로 roll forward (split 아닌 reschedule). dayIndex=0 유지 (part 아님).
+    //
+    // 2026-05-04 옵션 A 보강: rollDayMs 를 user TZ wall-clock 다음날 00:00 으로 산출 →
+    // server TZ UTC 환경에서도 user TZ 기준 정확한 다음날 wh 매칭.
     if (fittable === 0) {
-      const rollDayMs = dayStartMs(addDaysMs(s.startAt, 1))
-      const rollDateKey = dateKeyOf(rollDayMs)
+      const rollDayMs = addDaysMs(s.startAt, 1, userTz)
+      const rollDateKey = dateKeyOf(rollDayMs, userTz)
       const rollWH = whFor(rollDateKey, workingHours, defaultWH)
       queue.push({
         schedule: { ...s, startAt: rollDayMs + rollWH.startMin * NS, updatedAt: Date.now() },
@@ -84,8 +130,8 @@ export function splitByWorkingHours(
     out.push({ ...s, durationMin: fittable })
     const remain = s.durationMin - fittable
     if (remain <= 0) continue
-    const nextDayMs = dayStartMs(addDaysMs(s.startAt, 1))
-    const nextDateKey = dateKeyOf(nextDayMs)
+    const nextDayMs = addDaysMs(s.startAt, 1, userTz)
+    const nextDateKey = dateKeyOf(nextDayMs, userTz)
     const nextWH = whFor(nextDateKey, workingHours, defaultWH)
     const nextStartAt = nextDayMs + nextWH.startMin * NS
     const baseId = s.splitFrom ?? s.id

--- a/lib/domain/types.ts
+++ b/lib/domain/types.ts
@@ -24,5 +24,9 @@ export interface AppSettings {
   weekViewSpan: 1 | 2 | 3;
   weeklyPanelHidden: boolean;
   defaultWorkingHours: { startMin: number; endMin: number };
+  // 옵션 A (PLAN1-SCHEDULE-OPT-A · 2026-05-04) — user wall-clock TZ.
+  // splitByWorkingHours 의 day boundary + minutes-of-day 산출에 사용.
+  // server local TZ (Vercel iad1=UTC) 무관. IANA TZ name. default 'Asia/Seoul'.
+  userTz: string;
   pinnedActiveId?: ScheduleId | null;
 }

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -32,7 +32,8 @@ export const DEFAULT_SETTINGS: AppSettings = {
   theme: 'system',
   weekViewSpan: 1,
   weeklyPanelHidden: false,
-  defaultWorkingHours: {startMin: 540, endMin: 1080}
+  defaultWorkingHours: {startMin: 540, endMin: 1080},
+  userTz: 'Asia/Seoul'
 };
 
 // Stage 5 i18n: name='default' 영어 base. 표시 시 useCategoryDisplay() 가 name 매칭으로

--- a/scripts/qa/fix-schedule-tz-20260504.ts
+++ b/scripts/qa/fix-schedule-tz-20260504.ts
@@ -1,0 +1,102 @@
+#!/usr/bin/env tsx
+/**
+ * scripts/qa/fix-schedule-tz-20260504.ts
+ *
+ * 사고: 2026-05-04 prod 사용자 KST 입력 hour=7 등 → 14:00 KST fall-back.
+ * root cause: Vercel iad1 (UTC) + lib/domain/split.ts timezone-naive Date helper.
+ * 정공 fix: 옵션 A (split.ts user TZ aware · plan1 PR #40 + portal #25)
+ *
+ * 본 script 의 역할:
+ * - **read-only SELECT** — 의심 row 식별만. UPDATE 안 함
+ * - 사용자가 직접 UI 에서 수정 (가장 정공 — 사용자 의도 보존)
+ * - dev 또는 prod 환경 분기 (DATABASE_URL_UNPOOLED_<DEV|PROD>)
+ * - idempotent 실행 OK (read-only)
+ *
+ * 사용:
+ *   npm install -g tsx  # tsx 미설치 시
+ *   tsx scripts/qa/fix-schedule-tz-20260504.ts dev
+ *   tsx scripts/qa/fix-schedule-tz-20260504.ts prod
+ *
+ * 의심 row 기준:
+ * - createdAt 또는 updatedAt 이 2026-05-04 사고 발생 시점 (KST · 약 06:00 ~ 11:00) 안
+ * - startAt 의 KST hour 가 14 (= UTC 05:00 = 300 분)
+ * - status != 'done' (삭제 또는 완료된 row 는 영향 없음)
+ *
+ * 출력:
+ * - 의심 row 목록 (id · title · startAt KST · createdAt KST · status)
+ * - 사용자 manual fix 안내 (`/project/plan1/` UI 에서 모달 열어 hour 직접 수정)
+ *
+ * 보안:
+ * - DATABASE_URL_UNPOOLED_* 사용 (pooled URL 회피 — drizzle 권고)
+ * - read-only · UPDATE/DELETE 없음
+ * - 사용자 user_id filter (auth_user 경유) — 다른 user row 노출 안 함
+ */
+
+import {Client} from 'pg'
+
+const ENV = process.argv[2]
+if (ENV !== 'dev' && ENV !== 'prod') {
+  console.error('Usage: tsx scripts/qa/fix-schedule-tz-20260504.ts <dev|prod>')
+  process.exit(1)
+}
+
+const URL_VAR = ENV === 'dev' ? 'DATABASE_URL_UNPOOLED_DEV' : 'DATABASE_URL_UNPOOLED_PROD'
+const url = process.env[URL_VAR]
+if (!url) {
+  console.error(`${URL_VAR} not set. source ~/wiki-root/secrets/global.env first.`)
+  process.exit(1)
+}
+
+console.log(`──────────────────────────────────────────────────────`)
+console.log(`  Schedule TZ fall-back 의심 row SELECT (${ENV})`)
+console.log(`  Read-only · UPDATE 안 함`)
+console.log(`──────────────────────────────────────────────────────`)
+console.log()
+
+const client = new Client({connectionString: url})
+await client.connect()
+
+try {
+  // 사고 시간대 (KST 06:00 ~ 11:00 = UTC 21:00 전날 ~ 02:00 당일) + 14:00 KST start_at
+  const result = await client.query(`
+    SELECT
+      id,
+      title,
+      start_at AT TIME ZONE 'Asia/Seoul' AS kst_start,
+      created_at AT TIME ZONE 'Asia/Seoul' AS kst_created,
+      duration_min,
+      status,
+      split_from
+    FROM plan1.schedules
+    WHERE
+      EXTRACT(HOUR FROM start_at AT TIME ZONE 'Asia/Seoul') = 14
+      AND created_at > '2026-05-04 00:00:00 Asia/Seoul'::timestamptz
+      AND created_at < '2026-05-04 12:00:00 Asia/Seoul'::timestamptz
+      AND status != 'done'
+      AND split_from IS NULL
+    ORDER BY created_at DESC
+    LIMIT 50
+  `)
+
+  if (result.rows.length === 0) {
+    console.log('의심 row 없음. fall-back 발생 안 했거나 사용자가 이미 수정함.')
+  } else {
+    console.log(`의심 row ${result.rows.length} 건:\n`)
+    for (const r of result.rows) {
+      console.log(
+        `  id=${r.id}\n` +
+          `    title='${r.title}'\n` +
+          `    KST 시작=${r.kst_start.toISOString()}\n` +
+          `    KST 생성=${r.kst_created.toISOString()}\n` +
+          `    duration=${r.duration_min}분 status=${r.status} split_from=${r.split_from ?? 'null'}`
+      )
+      console.log()
+    }
+    console.log(
+      `\n수정 안내: cofounder.co.kr/project/plan1/ UI 에서 각 schedule 카드 클릭 → ` +
+        `편집 모달 → hour 시각 직접 수정 (옵션 A 적용 후 정상 작동)`
+    )
+  }
+} finally {
+  await client.end()
+}

--- a/tests/qa-gate/models/schedule-tz.txt
+++ b/tests/qa-gate/models/schedule-tz.txt
@@ -1,0 +1,43 @@
+# PICT model — schedule TZ fall-back 회귀 catch (PLAN1-SCHEDULE-BUG · 2026-05-04)
+#
+# 출처: wiki/shared/test-case-design-principles.md § 3.4 PICT 표준 형식
+# 환원 5단계 적용:
+#   1. 입력 도메인: schedule 등록·수정 시 timezone 처리 결함
+#   2. EP: server TZ {UTC, KST}, client TZ {KST, UTC, PST}, 입력 시각 {0시, 새벽, 점심, 저녁, 23시}
+#   3. BVA: day boundary 23:30 + 60min, working hours 시작/종료 boundary
+#   4. PICT pairwise: 변수 6개 → 2-way 약 30 케이스 (RPN 50-79 High)
+#   5. RPN filter: timezone race + day boundary = Critical → 3-way 강제 (구조)
+#
+# 변수 정의
+
+ServerTZ:        UTC, Asia/Seoul
+ClientTZ:        Asia/Seoul, UTC, America/Los_Angeles
+InputHour:       0, 6, 7, 9, 13, 18, 23
+InputMin:        0, 30, 59
+DurationMin:     30, 60, 600
+DefaultWHStart:  360, 540, 600
+DefaultWHEnd:    900, 1080, 1320
+Operation:       create, update-no-startat, update-with-startat
+ChainedToPrev:   false, true
+
+# Constraints (logically invalid combinations 제거)
+
+IF [DefaultWHStart] >= [DefaultWHEnd] THEN [DefaultWHStart] = 540, [DefaultWHEnd] = 1080;
+
+# Sub-models — 3-way 강제 영역 (RPN ≥ 80 Critical)
+
+# 1. timezone race triplet — server·client·입력시각 3축 (4/29 catch 한도 보존)
+{ ServerTZ, ClientTZ, InputHour } @ 3
+
+# 2. day boundary — 입력시각·duration·WH end 조합
+{ InputHour, DurationMin, DefaultWHEnd } @ 3
+
+# 3. update flow — operation·ServerTZ·ChainedToPrev (수정 시 14:00 회귀 catch)
+{ Operation, ServerTZ, ChainedToPrev } @ 3
+
+# 사용 절차:
+# 1. pict schedule-tz.txt > ../cases/schedule-tz.csv  (PICT 표준 도구)
+# 2. cases CSV → spec.ts 변환 (test-case-design-principles.md § 7 AI agent 워크플로우)
+# 3. lib/domain/split.timezone.test.ts (단위) + tests/qa-gate/schedule-time.spec.ts (mutation E2E)
+#
+# 주의: PICT binary 미설치 시 손으로 환원 — RPN ≥ 80 영역만 명시 케이스화

--- a/tests/qa-gate/schedule-add.spec.ts
+++ b/tests/qa-gate/schedule-add.spec.ts
@@ -121,4 +121,78 @@ test.describe('plan1 mutation E2E — A3 schedule 추가', () => {
     await expect(edit.heading).toBeHidden({timeout: SLA_COLD_MS});
     await expect(page.getByText(title)).toHaveCount(0, {timeout: 3_000});
   });
+
+  /**
+   * 14:00 fall-back 회귀 catch (PLAN1-SCHEDULE-OPT-A · 2026-05-04).
+   *
+   * 사고: prod 사용자 KST 입력 hour=7 → 등록 시각 14:00 fall-back. root cause:
+   *   - Vercel iad1 (UTC) + TZ env reserved → server local TZ = UTC
+   *   - lib/domain/split.ts 의 server-local Date helper → user wall-clock day boundary 잘못 인식
+   *   - line 74-83 fittable=0 분기 → 다음날 wh.startMin 으로 roll forward → user KST 기준 fall-back
+   *
+   * 옵션 A 적용 후 검증: hour=7 입력 → 등록 → edit 모달 round-trip 시 hour select value == 7
+   */
+  test('14:00 fall-back 회귀 catch — KST hour=7 입력 round-trip', async ({page}) => {
+    const title = `qa-tz-${Date.now()}`;
+    const catName = `cat-tz-${Date.now()}`;
+    const expectedHour = 7;
+
+    await page.goto('/project/plan1/');
+
+    // 카테고리 보장
+    await page.getByRole('button', {name: '카테고리'}).click();
+    const cat = dialogOf(page, /categories|카테고리/i);
+    await expect(cat.dialog).toBeVisible({timeout: 5_000});
+    await cat.dialog.getByRole('textbox').first().fill(catName);
+    await cat.dialog.getByRole('button', {name: '추가', exact: true}).click();
+    await expect(cat.dialog.getByText(catName)).toBeVisible({timeout: SLA_COLD_MS});
+    await cat.dialog.getByRole('button', {name: '닫기', exact: true}).click();
+    await expect(cat.dialog).toBeHidden({timeout: 3_000});
+
+    // 새 schedule 모달
+    const newBtn = page.getByRole('button', {name: '+ 새 스케줄'});
+    await expect(newBtn).toBeEnabled({timeout: 10_000});
+    await newBtn.click();
+
+    const sched = dialogOf(page, '새 스케줄');
+    await expect(sched.heading).toBeVisible({timeout: 5_000});
+    await sched.dialog.getByRole('textbox').first().fill(title);
+    // 내일 날짜 + hour=7 명시 set (defaultHour 무관) — fall-back 회귀 catch 핵심
+    const tomorrow = new Date(Date.now() + 86_400_000);
+    const tomorrowIso = `${tomorrow.getFullYear()}-${String(tomorrow.getMonth() + 1).padStart(2, '0')}-${String(tomorrow.getDate()).padStart(2, '0')}`;
+    await sched.dialog.locator('input[type="date"]').fill(tomorrowIso);
+    // hour select — 24개 option 중 '07시' (i18n hourSuffix 한국어)
+    await sched.dialog.locator('select').nth(1).selectOption(String(expectedHour));
+    await sched.dialog.locator('input[type="number"]').fill('30');
+    await sched.dialog.getByRole('button', {name: '추가', exact: true}).click();
+    await expect(sched.heading).toBeHidden({timeout: SLA_COLD_MS + 2_000});
+
+    // 카드 표시 — 다음 주로 넘어간 경우 toolbar
+    if (new Date().getDay() === 0) {
+      await page.locator('.fc-next-button').first().click();
+    }
+    await expect(page.getByText(title).first()).toBeVisible({timeout: 5_000});
+
+    // round-trip: card 클릭 → 편집 모달 → hour select value 검증
+    await page.getByText(title).first().click();
+    const edit = dialogOf(page, '스케줄 편집');
+    await expect(edit.heading).toBeVisible({timeout: 5_000});
+
+    const hourSelect = edit.dialog.locator('select').nth(1);
+    const actualHour = await hourSelect.inputValue();
+    expect(
+      Number(actualHour),
+      `KST hour=${expectedHour} 입력 → round-trip hour=${actualHour}. ` +
+        `14:00 fall-back 회귀 catch (PLAN1-SCHEDULE-OPT-A). ` +
+        `옵션 A 미적용 시 14 또는 다른 wh.startMin 으로 fall-back.`
+    ).toBe(expectedHour);
+
+    // cleanup
+    await edit.dialog.getByRole('button', {name: '삭제', exact: true}).click();
+    await edit.dialog
+      .getByRole('button', {name: '삭제 확인', exact: true})
+      .click();
+    await expect(edit.heading).toBeHidden({timeout: SLA_COLD_MS});
+    await expect(page.getByText(title)).toHaveCount(0, {timeout: 3_000});
+  });
 });

--- a/tests/qa-gate/schedule-edit.spec.ts
+++ b/tests/qa-gate/schedule-edit.spec.ts
@@ -119,4 +119,76 @@ test.describe('plan1 mutation E2E — A4 스케줄 편집', () => {
     await expect(cleanup.heading).toBeHidden({timeout: SLA_COLD_MS});
     await expect(page.getByText(title)).toHaveCount(0, {timeout: 3_000});
   });
+
+  /**
+   * 14:00 fall-back 회귀 catch — 수정 시 startAt 보존 (PLAN1-SCHEDULE-OPT-A · 2026-05-04).
+   *
+   * 사고: prod 사용자 schedule 수정 시도 → 수정 시도해도 14:00 으로 회귀.
+   * root cause: updateSchedule 도 splitByWorkingHours 거침 (createSchedule 동일 chain).
+   *
+   * 옵션 A 적용 후 검증: hour=7 schedule 등록 → 같은 schedule 수정 (제목만 변경) → hour 그대로 7
+   */
+  test('14:00 fall-back 회귀 catch — update 시 startAt 보존 (제목 변경만)', async ({page}) => {
+    const title = `qa-edit-tz-${Date.now()}`;
+    const newTitle = `${title}-edited`;
+    const catName = `cat-edit-tz-${Date.now()}`;
+    const expectedHour = 7;
+
+    await page.goto('/project/plan1/');
+
+    await page.getByRole('button', {name: '카테고리'}).click();
+    const cat = dialogOf(page, /categories|카테고리/i);
+    await expect(cat.dialog).toBeVisible({timeout: 5_000});
+    await cat.dialog.getByRole('textbox').first().fill(catName);
+    await cat.dialog.getByRole('button', {name: '추가', exact: true}).click();
+    await expect(cat.dialog.getByText(catName)).toBeVisible({timeout: SLA_COLD_MS});
+    await cat.dialog.getByRole('button', {name: '닫기', exact: true}).click();
+    await expect(cat.dialog).toBeHidden({timeout: 3_000});
+
+    await page.getByRole('button', {name: '+ 새 스케줄'}).click();
+    const sched = dialogOf(page, '새 스케줄');
+    await expect(sched.heading).toBeVisible({timeout: 5_000});
+    await sched.dialog.getByRole('textbox').first().fill(title);
+    const tomorrow = new Date(Date.now() + 86_400_000);
+    const tomorrowIso = `${tomorrow.getFullYear()}-${String(tomorrow.getMonth() + 1).padStart(2, '0')}-${String(tomorrow.getDate()).padStart(2, '0')}`;
+    await sched.dialog.locator('input[type="date"]').fill(tomorrowIso);
+    await sched.dialog.locator('select').nth(1).selectOption(String(expectedHour));
+    await sched.dialog.locator('input[type="number"]').fill('30');
+    await sched.dialog.getByRole('button', {name: '추가', exact: true}).click();
+    await expect(sched.heading).toBeHidden({timeout: SLA_COLD_MS + 2_000});
+
+    if (new Date().getDay() === 0) await page.locator('.fc-next-button').first().click();
+    await expect(page.getByText(title).first()).toBeVisible({timeout: 5_000});
+
+    // 카드 클릭 → 편집 모달 → title 만 수정 (startAt 패치 없음)
+    await page.getByText(title).first().click();
+    const edit = dialogOf(page, '스케줄 편집');
+    await expect(edit.heading).toBeVisible({timeout: 5_000});
+    const titleInput = edit.dialog.getByRole('textbox').first();
+    await titleInput.fill(newTitle);
+    await edit.dialog.getByRole('button', {name: '저장', exact: true}).click();
+    await expect(edit.heading).toBeHidden({timeout: SLA_COLD_MS + 2_000});
+
+    // round-trip: 새 제목 카드 클릭 → hour select 가 여전히 7 (14:00 회귀 catch)
+    await expect(page.getByText(newTitle).first()).toBeVisible({timeout: 5_000});
+    await page.getByText(newTitle).first().click();
+    const reopen = dialogOf(page, '스케줄 편집');
+    await expect(reopen.heading).toBeVisible({timeout: 5_000});
+    const hourSelect = reopen.dialog.locator('select').nth(1);
+    const actualHour = await hourSelect.inputValue();
+    expect(
+      Number(actualHour),
+      `update (제목 만 변경) 시 hour=${expectedHour} 보존 확인 → round-trip hour=${actualHour}. ` +
+        `14:00 fall-back 회귀 catch (PLAN1-SCHEDULE-OPT-A). ` +
+        `옵션 A 미적용 시 update 흐름의 splitByWorkingHours 가 fall-back 야기.`
+    ).toBe(expectedHour);
+
+    // cleanup
+    await reopen.dialog.getByRole('button', {name: '삭제', exact: true}).click();
+    await reopen.dialog
+      .getByRole('button', {name: '삭제 확인', exact: true})
+      .click();
+    await expect(reopen.heading).toBeHidden({timeout: SLA_COLD_MS});
+    await expect(page.getByText(newTitle)).toHaveCount(0, {timeout: 3_000});
+  });
 });


### PR DESCRIPTION
## 사고 원인
2026-05-04 prod 사용자 KST 입력 → 14:00 KST fall-back. root cause:
- Vercel `iad1` (UTC) + `TZ` env reserved (변경 불가)
- `lib/domain/split.ts` 의 4 helper (dateKeyOf · minutesOfDay · dayStartMs · addDaysMs) 가 server-local Date API 사용 → user wall-clock day boundary 잘못 인식
- line 74-83 `fittable=0` 분기 (2026-04-30 fix · roll forward) → 다음날 wh.startMin 으로 schedule 이동 → user KST 기준 fall-back 산출

## 옵션 A 적용
- `lib/domain/split.ts` 의 4 helper 를 `Intl.DateTimeFormat({timeZone})` 기반 user TZ aware 로 교체
- `splitByWorkingHours` signature 에 `userTz: string` 인자 추가 (기본값 `'Asia/Seoul'`)
- `lib/db/schema.ts` (mirror): `plan1Settings.userTz` 필드 추가 (master 는 portal 별 PR)
- `lib/domain/types.ts`: `AppSettings.userTz`
- `app/actions/{settings,schedules,working-hours}.ts`: 호출지점 + DB read/write
- `lib/store.ts`: DEFAULT_SETTINGS userTz 추가

## 테스트
- 단위: `lib/domain/split.timezone.test.ts` 4 spec + `lib/domain/split.day-boundary.test.ts` 5 spec — Mac KST 환경 25/25 green
- mutation E2E 보강: `tests/qa-gate/schedule-add.spec.ts` + `schedule-edit.spec.ts` — KST hour=7 round-trip 검증 test 추가
- TS error 1건 (`lib/ownership-guards.test.ts:77`) 사전 존재 (commit 6c5ebfb) — 본 PR 무관

## DB Migration
- portal 별 PR 에서 `plan1Settings.userTz` master 갱신
- portal dev DB 적용 ✅ (`bash scripts/db-push.sh dev` · ALTER TABLE plan1.settings ADD COLUMN user_tz text DEFAULT 'Asia/Seoul' NOT NULL)
- prod 적용은 대장 PROD-PUSH 게이트 (별)

## Vercel preview
자동 배포 trigger. preview URL 에서 KST 07:00 입력 → 14:00 fall-back 안 함 검증 의무.

## 회귀 catch
- 단위: split.timezone.test.ts spec 1·2·4 + split.day-boundary.test.ts spec 1·5
- E2E: schedule-add/edit spec 의 round-trip 검증 (mutation E2E CI 자동 실행)

## 관련 작업
- 본 PR + portal 별 PR (schema master)
- Stage 6 (migration script — 잘못 저장된 14:00 row 수동 fix · prod 적용 후)

🤖 Generated with [Claude Code](https://claude.com/claude-code)