### PR TITLE
fix(qa-gate): a11y spec newBtn enabled wait (PLAN1-MAIN-REGRESSION-FIX)

### DIFF
--- a/tests/qa-gate/a11y.spec.ts
+++ b/tests/qa-gate/a11y.spec.ts
@@ -70,8 +70,15 @@ test.describe('plan1 a11y baseline', () => {
     await catModal.getByRole('button', {name: /^닫기$|^Close$/i}).click();
     await expect(catModal).toBeHidden({timeout: 3_000});
 
-    // 새 스케줄 모달 열기
-    await page.getByRole('button', {name: /\+ (새 스케줄|New schedule)/i}).click();
+    // 새 스케줄 모달 열기 — newBtn enabled wait 명시 (PLAN1-MAIN-REGRESSION-FIX · 2026-05-05).
+    // 본 spec 는 카테고리 추가 후 + 새 스케줄 button 즉시 click 했지만 button 의 enabled 조건은
+    // canOpenNew = loaded && categories.length > 0 (PlanApp.tsx:180). store.init() 의 Promise.all
+    // (listSchedules·listCategories·getSettings) 적재 race 또는 catModal 닫는 시점 timing 으로
+    // button 14× retry disabled 된 채 click timeout 가능. schedule-add·schedule-edit spec 는 이미
+    // toBeEnabled wait 박혀있어 PASS. a11y spec 만 누락 → main run 25354381073 fail.
+    const newBtn = page.getByRole('button', {name: /\+ (새 스케줄|New schedule)/i});
+    await expect(newBtn).toBeEnabled({timeout: 10_000});
+    await newBtn.click();
     await expect(page.getByRole('heading', {name: /새 스케줄|New schedule/i})).toBeVisible({
       timeout: 5_000
     });


### PR DESCRIPTION
## 배경
main HEAD `e0ac9057` mutation E2E run 25354381073 회귀 — `+ 새 스케줄` button disabled timeout (`a11y.spec.ts:59`). 본 사이클 (PR #42 workingHours 폐기) 무관 입증.

## 진단
- a11y spec line 73-74: catModal 닫고 즉시 + 새 스케줄 button click → race fail
- newBtn 의 enabled 조건 = `canOpenNew = loaded && categories.length > 0` (`PlanApp.tsx:180`)
- store.init() Promise.all 적재 race 또는 catModal 닫는 시점 timing 으로 button 14× retry disabled
- **schedule-add·schedule-edit·cascade-bump·instant-complete·category-delete·login-fresh PASS** — 본 사이클 코드 영향 0
- a11y spec 만 `toBeEnabled` wait 누락 → 본 회귀

## fix
`tests/qa-gate/a11y.spec.ts` line 73-74 — `newBtn.toBeEnabled({timeout: 10_000})` wait 추가 후 click.

## 별 영역 (본 PR 제외 — m2 후속)
- auth-flake C1 (4.6s · SLA <3000ms 초과)
- auth-flake C3 (final URL `cofounder.co.kr/project/plan1` · sign-in redirect 미동작)
- prod self-heal redirect 회귀 — m2 PLAN1-AUTH-MIDDLEWARE-DEEP 후속 영역

## 검증
새 mutation E2E run 시 a11y modal spec PASS 예상.

🤖 Generated with [Claude Code](https://claude.com/claude-code)