### PR TITLE
fix(plan1): SignInPrompt CTA URL 정정 (PLAN1-SIGNIN-URL-FIX-20260505)

### DIFF
--- a/components/SignInPrompt.tsx
+++ b/components/SignInPrompt.tsx
@@ -2,17 +2,22 @@
 
 /**
  * PLAN1-LOGIN-START-OPT-20260504 #5 — 로그인 안 된 상태 UX.
+ * PLAN1-SIGNIN-URL-FIX-20260505 — CTA URL 정정 (`/project/sign-in` 404 → `/project` 홈)
  *
  * 진입 흐름:
  *   1. plan1 GET /project/plan1 (no cookie · no session)
- *   2. middleware.ts authRedirectIfMissingJwt → portal /api/cofounder/refresh-jwt?return=...
- *   3. portal session 없음 → portal /project/sign-in?return=... 으로 redirect
- *   4. 사용자 로그인 안 함 → 다시 plan1 진입 시 store.init() 가 ServerActionError('serverError.unauthorized') throw
- *   5. PlanApp 가 store.errorKey === 'serverError.unauthorized' 분기 → 본 컴포넌트 노출
+ *   2. middleware fire X 또는 store.init() server action → unauthorized throw
+ *   3. PlanApp 가 store.errorKey === 'serverError.unauthorized' 분기 → 본 컴포넌트 노출
+ *   4. 사용자 "로그인하기" 클릭 → portal `/project` 홈 (SignInButton + Google OAuth)
  *
  * UX:
  *   - "로그인이 필요합니다" + 설명 + CTA "로그인하기" 버튼
- *   - CTA → portal sign-in URL 로 이동 (return 에 현재 plan1 URL 보존)
+ *   - CTA → portal 홈 (`/project`) — return param 은 현 portal sign-in 흐름 (Better Auth Google OAuth)
+ *     이 callbackURL='/project' 으로 hard-coded → return 보존 후속 PR 영역 (portal SignInButton 변경)
+ *
+ * 사용자 후속 흐름:
+ *   - portal 홈 SignInButton 클릭 → Google OAuth → callback `/project` → 수동 plan1 다시 진입
+ *   - return param 자동 redirect 는 portal SignInButton 변경 별 PR (`PLAN1-SIGNIN-RETURN-PARAM`)
  *
  * portal_base 결정:
  *   - production: `https://cofounder.co.kr`
@@ -29,10 +34,14 @@ export function SignInPrompt() {
 
   function handleSignIn() {
     if (typeof window === 'undefined') return;
+    // PLAN1-SIGNIN-URL-FIX-20260505: portal 홈 (`/project`) 으로 redirect.
+    // 기존 `/project/sign-in` 페이지는 portal 에 미존재 → 404. portal 홈에 SignInButton 컴포넌트 +
+    // Better Auth Google OAuth 가 sign-in entry point.
+    // return param 보존은 별 PR (portal SignInButton 변경 영역).
     const currentUrl = window.location.href;
-    const signInUrl = new URL(`${PORTAL_ORIGIN}/project/sign-in`);
-    signInUrl.searchParams.set('return', currentUrl);
-    window.location.href = signInUrl.toString();
+    const portalHome = new URL(`${PORTAL_ORIGIN}/project`);
+    portalHome.searchParams.set('return', currentUrl);
+    window.location.href = portalHome.toString();
   }
 
   return (


### PR DESCRIPTION
## Summary
SignInPrompt "로그인하기" CTA 클릭 시 portal `/project/sign-in?return=...` 진입 → **404 Not Found** 회귀 fix.

portal 홈 (`/project`) 의 SignInButton + Better Auth Google OAuth 가 실제 sign-in entry point — 별도 sign-in 페이지 미존재. CTA URL `/project/sign-in` → `/project` 정정.

## 변경
- `components/SignInPrompt.tsx` — handleSignIn redirect URL 정정 + 주석 갱신

## 사용자 flow (post-fix)
1. plan1 unauthorized → SignInPrompt 노출
2. "로그인하기" 클릭 → portal 홈 (`/project`)
3. portal SignInButton → Google OAuth → callback `/project`
4. 수동 plan1 다시 진입 (return param 자동 redirect 는 별 PR `PLAN1-SIGNIN-RETURN-PARAM`)

## 연관 PR
- portal: https://github.com/horaeng0506/cofounder-portal/pull/new/fix/portal-signin-url-20260505 (refresh-jwt route.ts 동일 fix)

## Test plan
- [ ] CI green (mutation E2E 회귀 X)
- [ ] production verify — 대장 직접 SignInPrompt 클릭 → portal 홈 도달 (404 X)

🤖 Generated with [Claude Code](https://claude.com/claude-code)