### PR TITLE
feat(ui): 집중 보기 모드 button 그룹 (PLAN1-FOCUS-VIEW-UI-20260505)

### DIFF
--- a/components/PlanApp.tsx
+++ b/components/PlanApp.tsx
@@ -69,6 +69,9 @@ export function PlanApp() {
   const init = useAppStore(s => s.init);
   const weekViewSpan = useAppStore(s => s.settings.weekViewSpan);
   const weeklyPanelHidden = useAppStore(s => s.settings.weeklyPanelHidden);
+  // PLAN1-FOCUS-VIEW-UI-20260505 — 집중 보기 모드 UI input.
+  // null = 전체 보기 (0~24h) · 60·120·180·240 = 시계/timeline view 가 [now-N/2, now+N/2] 구간
+  const focusViewMin = useAppStore(s => s.settings.focusViewMin);
   const theme = useAppStore(s => s.settings.theme);
   const updateSettings = useAppStore(s => s.updateSettings);
   const schedules = useAppStore(s => s.schedules);
@@ -205,6 +208,15 @@ export function PlanApp() {
         : 'bg-panel text-txt border-line hover:bg-bg'
     }`;
 
+  // PLAN1-FOCUS-VIEW-UI-20260505 — focusViewMin 선택 button class.
+  // off (null) · 60·120·180·240 분 5개 선택지. spanButtonClass 와 동일 결.
+  const focusButtonClass = (val: number | null) =>
+    `px-2 py-1 text-xs rounded-none border transition-colors font-mono ${
+      focusViewMin === val
+        ? 'bg-ink text-bg border-ink'
+        : 'bg-panel text-txt border-line hover:bg-bg'
+    }`;
+
   const neutralBtn =
     'px-3 py-1 text-sm rounded-none border border-line bg-panel text-txt font-mono hover:bg-bg';
   const primaryBtn =
@@ -281,6 +293,46 @@ export function PlanApp() {
                 onClick={() => runMutation(updateSettings({theme: 'system'}), 'setTheme')}
               >
                 {t('nav.themeSystem')}
+              </button>
+            </div>
+            {/* PLAN1-FOCUS-VIEW-UI-20260505 — 집중 보기 모드 button 그룹.
+                null = 전체 보기 (0~24h · DailyTimeline default) · 60·120·180·240 분 = [now-N/2, now+N/2] 구간 */}
+            <div className="flex gap-1">
+              <button
+                type="button"
+                className={focusButtonClass(null)}
+                onClick={() => runMutation(updateSettings({focusViewMin: null}), 'setFocus')}
+                title={t('nav.focusOff')}
+              >
+                {t('nav.focusOff')}
+              </button>
+              <button
+                type="button"
+                className={focusButtonClass(60)}
+                onClick={() => runMutation(updateSettings({focusViewMin: 60}), 'setFocus')}
+              >
+                {t('nav.focus1h')}
+              </button>
+              <button
+                type="button"
+                className={focusButtonClass(120)}
+                onClick={() => runMutation(updateSettings({focusViewMin: 120}), 'setFocus')}
+              >
+                {t('nav.focus2h')}
+              </button>
+              <button
+                type="button"
+                className={focusButtonClass(180)}
+                onClick={() => runMutation(updateSettings({focusViewMin: 180}), 'setFocus')}
+              >
+                {t('nav.focus3h')}
+              </button>
+              <button
+                type="button"
+                className={focusButtonClass(240)}
+                onClick={() => runMutation(updateSettings({focusViewMin: 240}), 'setFocus')}
+              >
+                {t('nav.focus4h')}
               </button>
             </div>
             <button

--- a/lib/use-run-mutation.ts
+++ b/lib/use-run-mutation.ts
@@ -44,7 +44,8 @@ export type MutationContextKey =
   | 'pinActiveTimer'
   | 'setWeekSpan'
   | 'setTheme'
-  | 'toggleWeeklyPanel';
+  | 'toggleWeeklyPanel'
+  | 'setFocus';
 
 export function useRunMutation() {
   const t = useTranslations();

--- a/messages/ar.json
+++ b/messages/ar.json
@@ -63,7 +63,8 @@
     "removeCategory": "إزالة الفئة",
     "setTheme": "تعيين السمة",
     "setWeekSpan": "تعيين نطاق الأسبوع",
-    "toggleWeeklyPanel": "تبديل اللوحة الأسبوعية"
+    "toggleWeeklyPanel": "تبديل اللوحة الأسبوعية",
+    "setFocus": "set focus view"
   },
   "nav": {
     "categories": "الفئات",
@@ -76,7 +77,12 @@
     "weekSpan3": "3أ",
     "weeklyHide": "إخفاء الأسبوع",
     "weeklyShow": "إظهار الأسبوع",
-    "workingHours": "ساعات"
+    "workingHours": "ساعات",
+    "focusOff": "all",
+    "focus1h": "1h",
+    "focus2h": "2h",
+    "focus3h": "3h",
+    "focus4h": "4h"
   },
   "onboarding": {
     "addFirst": "إضافة أول جدول",

--- a/messages/de.json
+++ b/messages/de.json
@@ -63,7 +63,8 @@
     "removeCategory": "Kategorie entfernen",
     "setTheme": "Design festlegen",
     "setWeekSpan": "Wochenbereich festlegen",
-    "toggleWeeklyPanel": "Wochenpanel umschalten"
+    "toggleWeeklyPanel": "Wochenpanel umschalten",
+    "setFocus": "set focus view"
   },
   "nav": {
     "categories": "Kategorien",
@@ -76,7 +77,12 @@
     "weekSpan3": "3w",
     "weeklyHide": "Woche ausblenden",
     "weeklyShow": "Woche anzeigen",
-    "workingHours": "Stunden"
+    "workingHours": "Stunden",
+    "focusOff": "all",
+    "focus1h": "1h",
+    "focus2h": "2h",
+    "focus3h": "3h",
+    "focus4h": "4h"
   },
   "onboarding": {
     "addFirst": "ersten Zeitplan hinzufügen",

--- a/messages/en.json
+++ b/messages/en.json
@@ -39,7 +39,12 @@
     "themeDark": "dark",
     "themeSystem": "auto",
     "weeklyShow": "show week",
-    "weeklyHide": "hide week"
+    "weeklyHide": "hide week",
+    "focusOff": "all",
+    "focus1h": "1h",
+    "focus2h": "2h",
+    "focus3h": "3h",
+    "focus4h": "4h"
   },
   "common": {
     "cancel": "cancel",
@@ -73,7 +78,8 @@
     "pinActiveTimer": "pin active timer",
     "setWeekSpan": "set week span",
     "setTheme": "set theme",
-    "toggleWeeklyPanel": "toggle weekly panel"
+    "toggleWeeklyPanel": "toggle weekly panel",
+    "setFocus": "set focus view"
   },
   "onboarding": {
     "welcome": "No schedules yet",

--- a/messages/es.json
+++ b/messages/es.json
@@ -63,7 +63,8 @@
     "removeCategory": "eliminar categoría",
     "setTheme": "establecer tema",
     "setWeekSpan": "establecer lapso de semana",
-    "toggleWeeklyPanel": "alternar panel semanal"
+    "toggleWeeklyPanel": "alternar panel semanal",
+    "setFocus": "set focus view"
   },
   "nav": {
     "categories": "categorías",
@@ -76,7 +77,12 @@
     "weekSpan3": "3s",
     "weeklyHide": "ocultar semana",
     "weeklyShow": "mostrar semana",
-    "workingHours": "horas"
+    "workingHours": "horas",
+    "focusOff": "all",
+    "focus1h": "1h",
+    "focus2h": "2h",
+    "focus3h": "3h",
+    "focus4h": "4h"
   },
   "onboarding": {
     "addFirst": "agregar primer horario",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -63,7 +63,8 @@
     "removeCategory": "supprimer la catégorie",
     "setTheme": "définir le thème",
     "setWeekSpan": "définir intervalle de semaine",
-    "toggleWeeklyPanel": "basculer le panneau hebdomadaire"
+    "toggleWeeklyPanel": "basculer le panneau hebdomadaire",
+    "setFocus": "set focus view"
   },
   "nav": {
     "categories": "catégories",
@@ -76,7 +77,12 @@
     "weekSpan3": "3s",
     "weeklyHide": "masquer semaine",
     "weeklyShow": "afficher semaine",
-    "workingHours": "heures"
+    "workingHours": "heures",
+    "focusOff": "all",
+    "focus1h": "1h",
+    "focus2h": "2h",
+    "focus3h": "3h",
+    "focus4h": "4h"
   },
   "onboarding": {
     "addFirst": "ajouter le premier planning",

--- a/messages/hi.json
+++ b/messages/hi.json
@@ -63,7 +63,8 @@
     "removeCategory": "श्रेणी हटाएं",
     "setTheme": "थीम सेट करें",
     "setWeekSpan": "सप्ताह अवधि सेट करें",
-    "toggleWeeklyPanel": "साप्ताहिक पैनल टॉगल करें"
+    "toggleWeeklyPanel": "साप्ताहिक पैनल टॉगल करें",
+    "setFocus": "set focus view"
   },
   "nav": {
     "categories": "श्रेणियाँ",
@@ -76,7 +77,12 @@
     "weekSpan3": "3w",
     "weeklyHide": "सप्ताह छुपाएं",
     "weeklyShow": "सप्ताह दिखाएं",
-    "workingHours": "घंटे"
+    "workingHours": "घंटे",
+    "focusOff": "all",
+    "focus1h": "1h",
+    "focus2h": "2h",
+    "focus3h": "3h",
+    "focus4h": "4h"
   },
   "onboarding": {
     "addFirst": "पहला शेड्यूल जोड़ें",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -63,7 +63,8 @@
     "removeCategory": "カテゴリを削除",
     "setTheme": "テーマを設定",
     "setWeekSpan": "週の範囲を設定",
-    "toggleWeeklyPanel": "週間パネルを切り替え"
+    "toggleWeeklyPanel": "週間パネルを切り替え",
+    "setFocus": "set focus view"
   },
   "nav": {
     "categories": "カテゴリ",
@@ -76,7 +77,12 @@
     "weekSpan3": "3週間",
     "weeklyHide": "週を非表示",
     "weeklyShow": "週を表示",
-    "workingHours": "時間"
+    "workingHours": "時間",
+    "focusOff": "all",
+    "focus1h": "1h",
+    "focus2h": "2h",
+    "focus3h": "3h",
+    "focus4h": "4h"
   },
   "onboarding": {
     "addFirst": "最初のスケジュールを追加",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -39,7 +39,12 @@
     "themeDark": "다크",
     "themeSystem": "자동",
     "weeklyShow": "주간 보이기",
-    "weeklyHide": "주간 숨기기"
+    "weeklyHide": "주간 숨기기",
+    "focusOff": "전체",
+    "focus1h": "1시간",
+    "focus2h": "2시간",
+    "focus3h": "3시간",
+    "focus4h": "4시간"
   },
   "common": {
     "cancel": "취소",
@@ -73,7 +78,8 @@
     "pinActiveTimer": "타이머 고정",
     "setWeekSpan": "주간 범위 설정",
     "setTheme": "테마 설정",
-    "toggleWeeklyPanel": "주간 패널 토글"
+    "toggleWeeklyPanel": "주간 패널 토글",
+    "setFocus": "집중 보기 설정"
   },
   "onboarding": {
     "welcome": "스케줄이 아직 없습니다",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -63,7 +63,8 @@
     "removeCategory": "remover categoria",
     "setTheme": "definir tema",
     "setWeekSpan": "definir período semanal",
-    "toggleWeeklyPanel": "alternar painel semanal"
+    "toggleWeeklyPanel": "alternar painel semanal",
+    "setFocus": "set focus view"
   },
   "nav": {
     "categories": "categorias",
@@ -76,7 +77,12 @@
     "weekSpan3": "3s",
     "weeklyHide": "ocultar semana",
     "weeklyShow": "mostrar semana",
-    "workingHours": "horas"
+    "workingHours": "horas",
+    "focusOff": "all",
+    "focus1h": "1h",
+    "focus2h": "2h",
+    "focus3h": "3h",
+    "focus4h": "4h"
   },
   "onboarding": {
     "addFirst": "adicionar primeiro horário",

--- a/messages/ru.json
+++ b/messages/ru.json
@@ -63,7 +63,8 @@
     "removeCategory": "удалить категорию",
     "setTheme": "установить тему",
     "setWeekSpan": "установить диапазон недели",
-    "toggleWeeklyPanel": "переключить недельную панель"
+    "toggleWeeklyPanel": "переключить недельную панель",
+    "setFocus": "set focus view"
   },
   "nav": {
     "categories": "категории",
@@ -76,7 +77,12 @@
     "weekSpan3": "3н",
     "weeklyHide": "скрыть неделю",
     "weeklyShow": "показать неделю",
-    "workingHours": "часы"
+    "workingHours": "часы",
+    "focusOff": "all",
+    "focus1h": "1h",
+    "focus2h": "2h",
+    "focus3h": "3h",
+    "focus4h": "4h"
   },
   "onboarding": {
     "addFirst": "добавить первое расписание",

--- a/messages/zh-CN.json
+++ b/messages/zh-CN.json
@@ -63,7 +63,8 @@
     "removeCategory": "移除分类",
     "setTheme": "设置主题",
     "setWeekSpan": "设置周跨度",
-    "toggleWeeklyPanel": "切换周视图面板"
+    "toggleWeeklyPanel": "切换周视图面板",
+    "setFocus": "set focus view"
   },
   "nav": {
     "categories": "分类",
@@ -76,7 +77,12 @@
     "weekSpan3": "3周",
     "weeklyHide": "隐藏周",
     "weeklyShow": "显示周",
-    "workingHours": "小时"
+    "workingHours": "小时",
+    "focusOff": "all",
+    "focus1h": "1h",
+    "focus2h": "2h",
+    "focus3h": "3h",
+    "focus4h": "4h"
   },
   "onboarding": {
     "addFirst": "添加第一个日程",


### PR DESCRIPTION
## 배경
대장 prod verify 발견 — PR #42 chain 4/15 본문 "settings UI 별 PR" 명시 누락 catch. focusViewMin DB column + types + DailyTimeline view filter 만 박힘 · UI 입력 (값 set/해지) 부재.

## 변경
- `components/PlanApp.tsx`: focusViewMin button 그룹 5개 (전체 · 1시간 · 2시간 · 3시간 · 4시간)
- `lib/use-run-mutation.ts`: MutationContextKey 'setFocus' 추가
- `messages/en.json` + `ko.json`: nav.focus* + mutation.setFocus (EN+KO 듀얼 마스터)
- 9 lang (es·pt·fr·de·ja·ru·ar·hi·zh-CN): 영문 fallback (i18n-translate workflow 자동 정확 번역 PR 대기)

## 검증
- `tsc --noEmit`: 본 사이클 변경 영역 0건 (사전 존재 `ownership-guards.test.ts:77` 무관)
- `npm run lint`: PASS
- `npm test`: 55/55 PASS
- `PORTAL_ISSUER=... npm run build`: PASS (3 routes + Middleware)

## DailyTimeline 정합
PR #42 의 `DailyTimeline.tsx` slotMin/Max 가 `focusViewMin` 기반 `[now-N/2, now+N/2]`. 본 PR UI 입력으로 사용자가 60·120·180·240 분 set 가능. 전체 (null) = 0~24h.

🤖 Generated with [Claude Code](https://claude.com/claude-code)