### PR TITLE
fix(ui): 집중 보기 모드 재수정 — 위치·UI·옵션·logic 4건 (PLAN1-FOCUS-VIEW-FIX-20260505)

### DIFF
--- a/components/DailyTimeline.tsx
+++ b/components/DailyTimeline.tsx
@@ -1,56 +1,78 @@
 'use client';
 
 import {useMemo} from 'react';
-import {useLocale} from 'next-intl';
+import {useLocale, useTranslations} from 'next-intl';
 import FullCalendar from '@fullcalendar/react';
 import timeGridPlugin from '@fullcalendar/timegrid';
 import interactionPlugin from '@fullcalendar/interaction';
 import {useAppStore} from '@/lib/store';
 import {schedulesToEvents} from '@/lib/schedule-to-event';
-import {pad2} from '@/lib/date-format';
+import {focusBounds} from '@/lib/focus-bounds';
 import {useNow} from '@/lib/now';
+import {useRunMutation} from '@/lib/use-run-mutation';
 import {renderEventContent} from './event-renderer';
-
-function minToTimeStr(min: number): string {
-  const clamped = Math.max(0, Math.min(1440, Math.round(min)));
-  return `${pad2(Math.floor(clamped / 60))}:${pad2(clamped % 60)}:00`;
-}
 
 // next-intl `zh-CN` → FullCalendar `zh-cn`.
 function fcLocale(locale: string): string {
   return locale === 'zh-CN' ? 'zh-cn' : locale;
 }
 
+const FOCUS_OPTIONS: Array<{value: number | null; key: string}> = [
+  {value: null, key: 'focusOff'},
+  {value: 240, key: 'focus4h'},
+  {value: 300, key: 'focus5h'},
+  {value: 360, key: 'focus6h'},
+  {value: 420, key: 'focus7h'},
+  {value: 480, key: 'focus8h'}
+];
+
 export function DailyTimeline({
   onEventClick
 }: {
   onEventClick?: (id: string, splitFrom?: string) => void;
 }) {
+  const t = useTranslations();
   const locale = useLocale();
   const schedules = useAppStore(s => s.schedules);
   const categories = useAppStore(s => s.categories);
-  // PLAN1-WH-FOCUS-20260504 — workingHours 폐기 + 집중 보기 모드.
-  // focusViewMin null = 0~24h 전체. 값 N 일 때 [now-N/2, now+N/2] 구간 (분 단위).
   const focusViewMin = useAppStore(s => s.settings.focusViewMin);
+  const updateSettings = useAppStore(s => s.updateSettings);
+  const runMutation = useRunMutation();
 
   const nowMs = useNow();
 
-  const {slotMinTime, slotMaxTime} = useMemo(() => {
-    if (focusViewMin == null || focusViewMin <= 0 || nowMs <= 0) {
-      return {slotMinTime: '00:00:00', slotMaxTime: '24:00:00'};
-    }
-    const now = new Date(nowMs);
-    const nowMin = now.getHours() * 60 + now.getMinutes();
-    const half = Math.floor(focusViewMin / 2);
-    const startMin = nowMin - half;
-    const endMin = nowMin + (focusViewMin - half);
-    return {slotMinTime: minToTimeStr(startMin), slotMaxTime: minToTimeStr(endMin)};
-  }, [focusViewMin, nowMs]);
+  const {slotMinTime, slotMaxTime} = useMemo(
+    () => focusBounds(focusViewMin, nowMs),
+    [focusViewMin, nowMs]
+  );
 
   const events = useMemo(() => schedulesToEvents(schedules, categories), [schedules, categories]);
 
+  const handleFocusChange = (value: string) => {
+    const next = value === '' ? null : Number(value);
+    runMutation(updateSettings({focusViewMin: next}), 'setFocus');
+  };
+
   return (
     <div className="[&_.fc-event-title]:whitespace-normal [&_.fc-event-title]:break-words">
+      {/* PLAN1-FOCUS-VIEW-FIX-20260505 — 헤더 우측 상단 select.
+          DailyTimeline 전용 — 다른 view 와 분리. select value `''` = null (전체) */}
+      <div className="mb-2 flex items-center justify-end">
+        <label className="flex items-center gap-2 text-xs text-muted font-mono">
+          <span>{t('nav.focusLabel')}</span>
+          <select
+            value={focusViewMin == null ? '' : String(focusViewMin)}
+            onChange={e => handleFocusChange(e.target.value)}
+            className="rounded-none border border-line bg-panel px-2 py-1 text-xs text-txt font-mono"
+          >
+            {FOCUS_OPTIONS.map(opt => (
+              <option key={opt.key} value={opt.value == null ? '' : String(opt.value)}>
+                {t(`nav.${opt.key}` as 'nav.focusOff')}
+              </option>
+            ))}
+          </select>
+        </label>
+      </div>
       <FullCalendar
         plugins={[timeGridPlugin, interactionPlugin]}
         initialView="timeGridDay"

--- a/components/PlanApp.tsx
+++ b/components/PlanApp.tsx
@@ -69,9 +69,7 @@ export function PlanApp() {
   const init = useAppStore(s => s.init);
   const weekViewSpan = useAppStore(s => s.settings.weekViewSpan);
   const weeklyPanelHidden = useAppStore(s => s.settings.weeklyPanelHidden);
-  // PLAN1-FOCUS-VIEW-UI-20260505 — 집중 보기 모드 UI input.
-  // null = 전체 보기 (0~24h) · 60·120·180·240 = 시계/timeline view 가 [now-N/2, now+N/2] 구간
-  const focusViewMin = useAppStore(s => s.settings.focusViewMin);
+  // PLAN1-FOCUS-VIEW-FIX-20260505 — focusViewMin store subscribe 폐기 (DailyTimeline.tsx 가 자체 select)
   const theme = useAppStore(s => s.settings.theme);
   const updateSettings = useAppStore(s => s.updateSettings);
   const schedules = useAppStore(s => s.schedules);
@@ -208,14 +206,7 @@ export function PlanApp() {
         : 'bg-panel text-txt border-line hover:bg-bg'
     }`;
 
-  // PLAN1-FOCUS-VIEW-UI-20260505 — focusViewMin 선택 button class.
-  // off (null) · 60·120·180·240 분 5개 선택지. spanButtonClass 와 동일 결.
-  const focusButtonClass = (val: number | null) =>
-    `px-2 py-1 text-xs rounded-none border transition-colors font-mono ${
-      focusViewMin === val
-        ? 'bg-ink text-bg border-ink'
-        : 'bg-panel text-txt border-line hover:bg-bg'
-    }`;
+  // PLAN1-FOCUS-VIEW-FIX-20260505 — focusButtonClass 폐기 (button 그룹 → DailyTimeline 헤더 select).
 
   const neutralBtn =
     'px-3 py-1 text-sm rounded-none border border-line bg-panel text-txt font-mono hover:bg-bg';
@@ -295,46 +286,7 @@ export function PlanApp() {
                 {t('nav.themeSystem')}
               </button>
             </div>
-            {/* PLAN1-FOCUS-VIEW-UI-20260505 — 집중 보기 모드 button 그룹.
-                null = 전체 보기 (0~24h · DailyTimeline default) · 60·120·180·240 분 = [now-N/2, now+N/2] 구간 */}
-            <div className="flex gap-1">
-              <button
-                type="button"
-                className={focusButtonClass(null)}
-                onClick={() => runMutation(updateSettings({focusViewMin: null}), 'setFocus')}
-                title={t('nav.focusOff')}
-              >
-                {t('nav.focusOff')}
-              </button>
-              <button
-                type="button"
-                className={focusButtonClass(60)}
-                onClick={() => runMutation(updateSettings({focusViewMin: 60}), 'setFocus')}
-              >
-                {t('nav.focus1h')}
-              </button>
-              <button
-                type="button"
-                className={focusButtonClass(120)}
-                onClick={() => runMutation(updateSettings({focusViewMin: 120}), 'setFocus')}
-              >
-                {t('nav.focus2h')}
-              </button>
-              <button
-                type="button"
-                className={focusButtonClass(180)}
-                onClick={() => runMutation(updateSettings({focusViewMin: 180}), 'setFocus')}
-              >
-                {t('nav.focus3h')}
-              </button>
-              <button
-                type="button"
-                className={focusButtonClass(240)}
-                onClick={() => runMutation(updateSettings({focusViewMin: 240}), 'setFocus')}
-              >
-                {t('nav.focus4h')}
-              </button>
-            </div>
+            {/* PLAN1-FOCUS-VIEW-FIX-20260505 — focus 그룹 폐기 (DailyTimeline 헤더 select 으로 이동) */}
             <button
               type="button"
               className={neutralBtn}

--- a/lib/focus-bounds.test.ts
+++ b/lib/focus-bounds.test.ts
@@ -1,0 +1,69 @@
+/**
+ * DailyTimeline focusBounds 비대칭 산식 검증 (PLAN1-FOCUS-VIEW-FIX-20260505).
+ *
+ * 사고 회고: PR #50 (대칭 [now ± N/2]) 가 사용자 mental model 과 불일치 — 대장 명시
+ * "지금 6시 + 4시간 → 5~9시" (= 비대칭 [now-1h, now+(N-1)h]).
+ *
+ * 산식: focusViewMin null 또는 ≤60 → 전체 (00:00-24:00). 그 외 [now-60, now+(N-60)] 분.
+ */
+
+import {describe, it, expect} from 'vitest';
+import {focusBounds} from '@/lib/focus-bounds';
+
+function ymdms(y: number, m: number, d: number, h: number, mm = 0): number {
+  return new Date(y, m - 1, d, h, mm, 0, 0).getTime();
+}
+
+describe('DailyTimeline focusBounds — 비대칭 [now-1h, now+(N-1)h]', () => {
+  const ms6 = ymdms(2026, 5, 5, 6);
+  const ms7 = ymdms(2026, 5, 5, 7);
+  const ms23h30 = ymdms(2026, 5, 5, 23, 30);
+  const ms0h30 = ymdms(2026, 5, 5, 0, 30);
+
+  it('1. focusViewMin null → 전체 (0~24h)', () => {
+    expect(focusBounds(null, ms6)).toEqual({slotMinTime: '00:00:00', slotMaxTime: '24:00:00'});
+  });
+
+  it('2. focusViewMin ≤ 60 → 전체 (degenerate guard)', () => {
+    expect(focusBounds(60, ms6)).toEqual({slotMinTime: '00:00:00', slotMaxTime: '24:00:00'});
+    expect(focusBounds(0, ms6)).toEqual({slotMinTime: '00:00:00', slotMaxTime: '24:00:00'});
+  });
+
+  it('3. nowMs ≤ 0 (SSR/hydration 가드) → 전체', () => {
+    expect(focusBounds(240, 0)).toEqual({slotMinTime: '00:00:00', slotMaxTime: '24:00:00'});
+  });
+
+  it('4. 대장 명시 — 6시 + 4시간(240) = 5~9시', () => {
+    expect(focusBounds(240, ms6)).toEqual({slotMinTime: '05:00:00', slotMaxTime: '09:00:00'});
+  });
+
+  it('5. 6시 + 5시간(300) = 5~10시', () => {
+    expect(focusBounds(300, ms6)).toEqual({slotMinTime: '05:00:00', slotMaxTime: '10:00:00'});
+  });
+
+  it('6. 6시 + 6시간(360) = 5~11시', () => {
+    expect(focusBounds(360, ms6)).toEqual({slotMinTime: '05:00:00', slotMaxTime: '11:00:00'});
+  });
+
+  it('7. 6시 + 7시간(420) = 5~12시', () => {
+    expect(focusBounds(420, ms6)).toEqual({slotMinTime: '05:00:00', slotMaxTime: '12:00:00'});
+  });
+
+  it('8. 6시 + 8시간(480) = 5~13시', () => {
+    expect(focusBounds(480, ms6)).toEqual({slotMinTime: '05:00:00', slotMaxTime: '13:00:00'});
+  });
+
+  it('9. 7시 + 4시간(240) = 6~10시 (시간 흐름 자동 이동)', () => {
+    expect(focusBounds(240, ms7)).toEqual({slotMinTime: '06:00:00', slotMaxTime: '10:00:00'});
+  });
+
+  it('10. 23:30 + 4시간(240) = 22:30~24:00 (clamp · slot 24h max)', () => {
+    // now-60 = 22:30, now+180 = 26:30 → clamp 24:00
+    expect(focusBounds(240, ms23h30)).toEqual({slotMinTime: '22:30:00', slotMaxTime: '24:00:00'});
+  });
+
+  it('11. 00:30 + 4시간(240) = 0:00~3:30 (clamp · slot 0 min)', () => {
+    // now-60 = -30 → clamp 00:00, now+180 = 3:30
+    expect(focusBounds(240, ms0h30)).toEqual({slotMinTime: '00:00:00', slotMaxTime: '03:30:00'});
+  });
+});

--- a/lib/focus-bounds.ts
+++ b/lib/focus-bounds.ts
@@ -1,0 +1,27 @@
+/**
+ * DailyTimeline 집중 보기 모드 산식 (PLAN1-FOCUS-VIEW-FIX-20260505).
+ *
+ * 비대칭 [now-1h, now+(N-1)h] — 대장 명시 정합 (6시 + 4시간 → 5~9시).
+ * 단위 spec 격리 위해 store/api chain 와 분리된 별 module.
+ */
+
+import {pad2} from './date-format';
+
+export function minToTimeStr(min: number): string {
+  const clamped = Math.max(0, Math.min(1440, Math.round(min)));
+  return `${pad2(Math.floor(clamped / 60))}:${pad2(clamped % 60)}:00`;
+}
+
+export function focusBounds(
+  focusViewMin: number | null,
+  nowMs: number
+): {slotMinTime: string; slotMaxTime: string} {
+  if (focusViewMin == null || focusViewMin <= 60 || nowMs <= 0) {
+    return {slotMinTime: '00:00:00', slotMaxTime: '24:00:00'};
+  }
+  const now = new Date(nowMs);
+  const nowMin = now.getHours() * 60 + now.getMinutes();
+  const startMin = nowMin - 60;
+  const endMin = nowMin + (focusViewMin - 60);
+  return {slotMinTime: minToTimeStr(startMin), slotMaxTime: minToTimeStr(endMin)};
+}

--- a/messages/ar.json
+++ b/messages/ar.json
@@ -79,10 +79,12 @@
     "weeklyShow": "إظهار الأسبوع",
     "workingHours": "ساعات",
     "focusOff": "all",
-    "focus1h": "1h",
-    "focus2h": "2h",
-    "focus3h": "3h",
-    "focus4h": "4h"
+    "focus4h": "4h",
+    "focusLabel": "focus",
+    "focus5h": "5h",
+    "focus6h": "6h",
+    "focus7h": "7h",
+    "focus8h": "8h"
   },
   "onboarding": {
     "addFirst": "إضافة أول جدول",

--- a/messages/de.json
+++ b/messages/de.json
@@ -79,10 +79,12 @@
     "weeklyShow": "Woche anzeigen",
     "workingHours": "Stunden",
     "focusOff": "all",
-    "focus1h": "1h",
-    "focus2h": "2h",
-    "focus3h": "3h",
-    "focus4h": "4h"
+    "focus4h": "4h",
+    "focusLabel": "focus",
+    "focus5h": "5h",
+    "focus6h": "6h",
+    "focus7h": "7h",
+    "focus8h": "8h"
   },
   "onboarding": {
     "addFirst": "ersten Zeitplan hinzufügen",

--- a/messages/en.json
+++ b/messages/en.json
@@ -41,10 +41,12 @@
     "weeklyShow": "show week",
     "weeklyHide": "hide week",
     "focusOff": "all",
-    "focus1h": "1h",
-    "focus2h": "2h",
-    "focus3h": "3h",
-    "focus4h": "4h"
+    "focus4h": "4h",
+    "focusLabel": "focus",
+    "focus5h": "5h",
+    "focus6h": "6h",
+    "focus7h": "7h",
+    "focus8h": "8h"
   },
   "common": {
     "cancel": "cancel",

--- a/messages/es.json
+++ b/messages/es.json
@@ -79,10 +79,12 @@
     "weeklyShow": "mostrar semana",
     "workingHours": "horas",
     "focusOff": "all",
-    "focus1h": "1h",
-    "focus2h": "2h",
-    "focus3h": "3h",
-    "focus4h": "4h"
+    "focus4h": "4h",
+    "focusLabel": "focus",
+    "focus5h": "5h",
+    "focus6h": "6h",
+    "focus7h": "7h",
+    "focus8h": "8h"
   },
   "onboarding": {
     "addFirst": "agregar primer horario",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -79,10 +79,12 @@
     "weeklyShow": "afficher semaine",
     "workingHours": "heures",
     "focusOff": "all",
-    "focus1h": "1h",
-    "focus2h": "2h",
-    "focus3h": "3h",
-    "focus4h": "4h"
+    "focus4h": "4h",
+    "focusLabel": "focus",
+    "focus5h": "5h",
+    "focus6h": "6h",
+    "focus7h": "7h",
+    "focus8h": "8h"
   },
   "onboarding": {
     "addFirst": "ajouter le premier planning",

--- a/messages/hi.json
+++ b/messages/hi.json
@@ -79,10 +79,12 @@
     "weeklyShow": "सप्ताह दिखाएं",
     "workingHours": "घंटे",
     "focusOff": "all",
-    "focus1h": "1h",
-    "focus2h": "2h",
-    "focus3h": "3h",
-    "focus4h": "4h"
+    "focus4h": "4h",
+    "focusLabel": "focus",
+    "focus5h": "5h",
+    "focus6h": "6h",
+    "focus7h": "7h",
+    "focus8h": "8h"
   },
   "onboarding": {
     "addFirst": "पहला शेड्यूल जोड़ें",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -79,10 +79,12 @@
     "weeklyShow": "週を表示",
     "workingHours": "時間",
     "focusOff": "all",
-    "focus1h": "1h",
-    "focus2h": "2h",
-    "focus3h": "3h",
-    "focus4h": "4h"
+    "focus4h": "4h",
+    "focusLabel": "focus",
+    "focus5h": "5h",
+    "focus6h": "6h",
+    "focus7h": "7h",
+    "focus8h": "8h"
   },
   "onboarding": {
     "addFirst": "最初のスケジュールを追加",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -41,10 +41,12 @@
     "weeklyShow": "주간 보이기",
     "weeklyHide": "주간 숨기기",
     "focusOff": "전체",
-    "focus1h": "1시간",
-    "focus2h": "2시간",
-    "focus3h": "3시간",
-    "focus4h": "4시간"
+    "focus4h": "4시간",
+    "focusLabel": "집중",
+    "focus5h": "5시간",
+    "focus6h": "6시간",
+    "focus7h": "7시간",
+    "focus8h": "8시간"
   },
   "common": {
     "cancel": "취소",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -79,10 +79,12 @@
     "weeklyShow": "mostrar semana",
     "workingHours": "horas",
     "focusOff": "all",
-    "focus1h": "1h",
-    "focus2h": "2h",
-    "focus3h": "3h",
-    "focus4h": "4h"
+    "focus4h": "4h",
+    "focusLabel": "focus",
+    "focus5h": "5h",
+    "focus6h": "6h",
+    "focus7h": "7h",
+    "focus8h": "8h"
   },
   "onboarding": {
     "addFirst": "adicionar primeiro horário",

--- a/messages/ru.json
+++ b/messages/ru.json
@@ -79,10 +79,12 @@
     "weeklyShow": "показать неделю",
     "workingHours": "часы",
     "focusOff": "all",
-    "focus1h": "1h",
-    "focus2h": "2h",
-    "focus3h": "3h",
-    "focus4h": "4h"
+    "focus4h": "4h",
+    "focusLabel": "focus",
+    "focus5h": "5h",
+    "focus6h": "6h",
+    "focus7h": "7h",
+    "focus8h": "8h"
   },
   "onboarding": {
     "addFirst": "добавить первое расписание",

--- a/messages/zh-CN.json
+++ b/messages/zh-CN.json
@@ -79,10 +79,12 @@
     "weeklyShow": "显示周",
     "workingHours": "小时",
     "focusOff": "all",
-    "focus1h": "1h",
-    "focus2h": "2h",
-    "focus3h": "3h",
-    "focus4h": "4h"
+    "focus4h": "4h",
+    "focusLabel": "focus",
+    "focus5h": "5h",
+    "focus6h": "6h",
+    "focus7h": "7h",
+    "focus8h": "8h"
   },
   "onboarding": {
     "addFirst": "添加第一个日程",


### PR DESCRIPTION
## 배경
대장 prod verify 발견 — PR #50 (PLAN1-FOCUS-VIEW-UI-20260505) 의 4 영역 잘못. 본 PR 정공 fix.

## 변경 4건
1. **위치**: header (theme 그룹 다음) → **DailyTimeline 헤더 우측 상단**
2. **UI 형식**: button 그룹 → **select 드롭다운**
3. **옵션**: 1·2·3·4 시간 → **4·5·6·7·8 시간**
4. **logic**: 대칭 `[now ± N/2]` → **비대칭 `[now-1h, now+(N-1)h]`**

## 산식 (대장 명시 정합 · `lib/focus-bounds.ts`)
```
focusViewMin null/≤60 → 0~24h (default + degenerate guard)
4시간(240) @ 6시 → 5~9시 ✅
4시간(240) @ 7시 → 6~10시 (시간 흐름 자동 이동)
23:30 + 4시간 → 22:30~24:00 (clamp 24h max)
00:30 + 4시간 → 0:00~3:30 (clamp 0 min)
```

## 변경 파일
- `components/DailyTimeline.tsx` — select 추가 + focusBounds 호출
- `lib/focus-bounds.ts` (신설) — 산식 별 module (store/api chain 격리)
- `lib/focus-bounds.test.ts` (신설) — 11 spec
- `components/PlanApp.tsx` — focus button 그룹 폐기
- `messages/{en,ko}.json` — nav.focus{1h·2h·3h} 폐기 + nav.focus{5h·6h·7h·8h} + nav.focusLabel
- `messages/{es,pt,fr,de,ja,ru,ar,hi,zh-CN}.json` — 영문 fallback (i18n-translate workflow 자동 정확 번역 PR 후속)

## 자체 테스트
- `npx tsc --noEmit`: 0건 (사전 존재 `ownership-guards.test.ts:77` 무관)
- `npm run lint`: PASS
- `npm test`: **66/66 PASS** (focus-bounds.test.ts 11 spec 신규)
- `PORTAL_ISSUER=... npm run build`: PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)