### PR TITLE
fix(auth): logout URL portal basePath 정합 (PLAN1-LOGOUT-URL-FIX-20260505)

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -29,8 +29,10 @@ export async function Header() {
   const user = await getCurrentSessionUser();
   const portalUrl = getPortalUrl();
   const portalProjectsUrl = `${portalUrl}/project`;
-  // Better Auth 기본 sign-out 엔드포인트. portal 가 노출 안 하면 portal 메인으로 fallback.
-  const logoutUrl = `${portalUrl}/api/auth/sign-out`;
+  // PLAN1-LOGOUT-URL-FIX-20260505: portal basePath = '/project' + Better Auth basePath = '/api/auth'.
+  // 따라서 sign-out endpoint 실제 path 는 `/project/api/auth/sign-out`.
+  // 옛 `/api/auth/sign-out` 은 cofounder-router 의 `/project/*` routing 밖 → not_found 404.
+  const logoutUrl = `${portalUrl}/project/api/auth/sign-out`;
 
   return (
     <header


### PR DESCRIPTION
## 작업 결과
plan1 Header.tsx logout URL 1줄 fix — portal basePath '/project' + Better Auth basePath '/api/auth' 정합.

## 결함 (옛 사이클 — 2026-04-28 Stage 8.F)
- 옛: `${portalUrl}/api/auth/sign-out` → `cofounder.co.kr/api/auth/sign-out`
- cofounder-router routing: `/project/*` 만 처리 → `/api/auth/*` = `other-404`
- 결과: logout POST 가 endpoint 미도달 → Better Auth session cookie 삭제 0건

## 사용자 본 시나리오 (대장 prod verify 발견 · msg `1501172715564961834`)
- portal `/project` = 로그아웃 ✅
- plan1 `/project/plan1` = 로그인 ⚠️ (cookie 잔존)
- 1h TTL 동안 SSO 상태 mismatch

## 변경
- `components/Header.tsx:33` — `${portalUrl}/api/auth/sign-out` → `${portalUrl}/project/api/auth/sign-out`

## 박힌 시점
- `e63cec23` (2026-04-28 Stage 8.F · cofounder_jwt SSO 도입 시 logout sync 누락)

## 후속 별 PR (작업 ID PORTAL-LOGOUT-JWT-PURGE-20260505)
- portal Better Auth signOut hook 에서 `.cofounder.co.kr` domain `cofounder_jwt` cookie 삭제 logic 추가
- 본 PR (logout URL fix) 만으로는 cofounder_jwt cookie 잔존 — 1h TTL 동안 SSO 상태 mismatch 잔존
- 본 PR + 후속 PR 둘 다 적용해야 logout flow 완전 정공

## 검증
- typecheck: clean (사전 존재 `ownership-guards.test.ts:77` 무관)
- lint: PASS
- post-fix prod verify: portal logout → plan1 도 로그아웃 (단 cofounder_jwt 1h TTL 잔존 — 후속 PR fix 후)

## 회귀 영역
- 본 사이클 m4 PR #51 + m2 PR #29 와 무관 (sign-out endpoint 영역 X)
- 옛 사이클 (2026-04-28 Stage 6 · Stage 8.F) 의 design 결함 — 이번에 발견