### PR TITLE
fix(auth): logout URL portal /api/cofounder/sign-out 사용 (PLAN1-LOGOUT-URL-FIX-V2-20260505)

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -29,10 +29,11 @@ export async function Header() {
   const user = await getCurrentSessionUser();
   const portalUrl = getPortalUrl();
   const portalProjectsUrl = `${portalUrl}/project`;
-  // PLAN1-LOGOUT-URL-FIX-20260505: portal basePath = '/project' + Better Auth basePath = '/api/auth'.
-  // 따라서 sign-out endpoint 실제 path 는 `/project/api/auth/sign-out`.
-  // 옛 `/api/auth/sign-out` 은 cofounder-router 의 `/project/*` routing 밖 → not_found 404.
-  const logoutUrl = `${portalUrl}/project/api/auth/sign-out`;
+  // PLAN1-LOGOUT-URL-FIX-V2-20260505: portal 신설 `/api/cofounder/sign-out` 사용.
+  // Better Auth session cookie 삭제 + sub-project SSO 용 cofounder_jwt cookie purge 통합 처리.
+  // 옛 Better Auth catch-all `/project/api/auth/sign-out` 은 session cookie 만 삭제 → cofounder_jwt
+  // 1h TTL 동안 SSO 상태 mismatch. PORTAL-LOGOUT-JWT-PURGE-20260505 endpoint 가 정공.
+  const logoutUrl = `${portalUrl}/project/api/cofounder/sign-out`;
 
   return (
     <header


### PR DESCRIPTION
## 작업 결과
plan1 Header.tsx logoutUrl 변경 — portal 신설 `/api/cofounder/sign-out` endpoint (cofounder-portal#30) 사용.

## Background (대장 prod verify msg `1501173216259866654`)
- portal `/project` = 로그아웃 ✅
- plan1 `/project/plan1` = 로그인 ⚠️ (cofounder_jwt 잔존 1h TTL)

## 변경
- `components/Header.tsx:33` — `${portalUrl}/project/api/auth/sign-out` → `${portalUrl}/project/api/cofounder/sign-out`

## 의존
**cofounder-portal#30 main merge 후 본 PR 머지 의무** (순서 강제):
1. portal PR #30 main merge → `/api/cofounder/sign-out` endpoint prod 진입
2. 본 PR main merge → plan1 Header 가 신설 endpoint 사용
3. qa-tester E2E (logout flow + SSO sync)

## 후속 (cookie-cutter)
다른 sub-project (workspace1·persona1·starter1) 도 같은 endpoint 사용 가능 — Header logout URL 패턴 표준화

## 7 절차 정합 (`.claude/rules/problem-solving.md` + `.claude/rules/system-change.md`)
- 대장 옵션 B 승인 (msg `1501177460853702708`)