### PR TITLE
feat: IdleCountdown 즉시 시작 버튼 (PLAN1-IDLE-START-NOW-20260506)

### DIFF
--- a/components/ActiveTimer.tsx
+++ b/components/ActiveTimer.tsx
@@ -262,13 +262,25 @@ interface IdleCountdownProps {
 /**
  * PLAN1-TIMER-DUP-20260504 #3: 빈 시간 카운트다운 — 다음 schedule 까지 남은 시간.
  * 디자인 차별화: 점선 테두리 + 흐릿한 muted 톤 + "다음 스케줄까지" 라벨.
+ *
+ * PLAN1-IDLE-START-NOW-20260506: "즉시 시작" 버튼 — upcoming.startAt = now 로 set.
+ * cascade 자동 적용 (뒤 chainedToPrev=true 연속 구간 같이 당김 · gap 유지).
+ * store.updateSchedule 가 armUndo 자동 호출 → UndoBar 5초 안 되돌리기.
+ * overlap 검사는 submit 경로 외 — silent 진행 (Q3 a · 다른 timer 액션과 일관).
  */
 function IdleCountdown({upcoming, now}: IdleCountdownProps) {
   const t = useTranslations();
   const categoryDisplay = useCategoryDisplay();
   const categories = useAppStore(s => s.categories);
+  const updateSchedule = useAppStore(s => s.updateSchedule);
+  const runMutation = useRunMutation();
   const category = categories.find(c => c.id === upcoming.categoryId);
   const remaining = Math.max(0, upcoming.startAt - now);
+
+  const startNow = () => {
+    runMutation(updateSchedule(upcoming.id, {startAt: Date.now()}), 'startScheduleNow');
+  };
+
   return (
     <div
       className="rounded-none border border-dashed border-line bg-panel p-4 opacity-70"
@@ -290,10 +302,18 @@ function IdleCountdown({upcoming, now}: IdleCountdownProps) {
         </span>
       </div>
       <div className="mb-1 text-xs font-mono text-muted">{t('timer.labelUntilUpcoming')}</div>
-      <div className="font-mono text-4xl font-medium tracking-tight text-muted">
+      <div className="mb-3 font-mono text-4xl font-medium tracking-tight text-muted">
         {formatHMS(remaining)}
       </div>
-      <div className="mt-2 text-[10px] font-mono text-muted opacity-80">
+      <button
+        type="button"
+        onClick={startNow}
+        data-testid="idle-start-now"
+        className="mb-2 w-full rounded-none border border-ink bg-ink px-3 py-2 text-sm font-mono text-bg hover:opacity-90"
+      >
+        {t('timer.buttonStartNow')}
+      </button>
+      <div className="text-[10px] font-mono text-muted opacity-80">
         cat={category ? categoryDisplay(category) : t('timer.categoryFallback')}
       </div>
     </div>

--- a/lib/use-run-mutation.ts
+++ b/lib/use-run-mutation.ts
@@ -43,7 +43,8 @@ export type MutationContextKey =
   | 'completeSchedule'
   | 'changeTimerType'
   | 'setTheme'
-  | 'setFocus';
+  | 'setFocus'
+  | 'startScheduleNow';
 
 export function useRunMutation() {
   const t = useTranslations();

--- a/messages/ar.json
+++ b/messages/ar.json
@@ -47,7 +47,8 @@
     "extendTimer": "تمديد المؤقت",
     "removeCategory": "إزالة الفئة",
     "setFocus": "تعيين عرض التركيز",
-    "setTheme": "تعيين المظهر"
+    "setTheme": "تعيين المظهر",
+    "startScheduleNow": "start schedule now"
   },
   "nav": {
     "categories": "الفئات",
@@ -127,7 +128,8 @@
     "tooltipClickToIdle": "انقر للتبديل إلى خامل",
     "typeCountdown": "العد التنازلي",
     "typeCountup": "عد تصاعدي",
-    "typeTimer1": "timer1"
+    "typeTimer1": "timer1",
+    "buttonStartNow": "start now"
   },
   "topbar": {
     "back": "العودة إلى البوابة",

--- a/messages/de.json
+++ b/messages/de.json
@@ -47,7 +47,8 @@
     "extendTimer": "Timer verlängern",
     "removeCategory": "Kategorie entfernen",
     "setFocus": "Fokusansicht einstellen",
-    "setTheme": "Design einstellen"
+    "setTheme": "Design einstellen",
+    "startScheduleNow": "start schedule now"
   },
   "nav": {
     "categories": "Kategorien",
@@ -127,7 +128,8 @@
     "tooltipClickToIdle": "klicken, um zu Leerlauf zu wechseln",
     "typeCountdown": "Countdown",
     "typeCountup": "Hochzählen",
-    "typeTimer1": "timer1"
+    "typeTimer1": "timer1",
+    "buttonStartNow": "start now"
   },
   "topbar": {
     "back": "zurück zum Portal",

--- a/messages/en.json
+++ b/messages/en.json
@@ -58,7 +58,8 @@
     "completeSchedule": "complete schedule",
     "changeTimerType": "change timer type",
     "setTheme": "set theme",
-    "setFocus": "set focus view"
+    "setFocus": "set focus view",
+    "startScheduleNow": "start schedule now"
   },
   "onboarding": {
     "welcome": "No schedules yet",
@@ -142,7 +143,8 @@
     "categoryFallback": "?",
     "labelUpcoming": "next schedule",
     "labelUntilUpcoming": "until upcoming",
-    "simultaneousLabel": "simultaneous · {count}"
+    "simultaneousLabel": "simultaneous · {count}",
+    "buttonStartNow": "start now"
   },
   "weekdays": {
     "0": "sun",

--- a/messages/es.json
+++ b/messages/es.json
@@ -47,7 +47,8 @@
     "extendTimer": "extender temporizador",
     "removeCategory": "eliminar categoría",
     "setFocus": "establecer vista de enfoque",
-    "setTheme": "establecer tema"
+    "setTheme": "establecer tema",
+    "startScheduleNow": "start schedule now"
   },
   "nav": {
     "categories": "categorías",
@@ -127,7 +128,8 @@
     "tooltipClickToIdle": "haz clic para cambiar a inactivo",
     "typeCountdown": "cuenta regresiva",
     "typeCountup": "contador",
-    "typeTimer1": "temporizador1"
+    "typeTimer1": "temporizador1",
+    "buttonStartNow": "start now"
   },
   "topbar": {
     "back": "volver al portal",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -47,7 +47,8 @@
     "extendTimer": "prolonger le minuteur",
     "removeCategory": "supprimer la catégorie",
     "setFocus": "définir la vue focus",
-    "setTheme": "définir le thème"
+    "setTheme": "définir le thème",
+    "startScheduleNow": "start schedule now"
   },
   "nav": {
     "categories": "catégories",
@@ -127,7 +128,8 @@
     "tooltipClickToIdle": "cliquer pour passer en inactif",
     "typeCountdown": "compte à rebours",
     "typeCountup": "compte à rebours inversé",
-    "typeTimer1": "minuteur1"
+    "typeTimer1": "minuteur1",
+    "buttonStartNow": "start now"
   },
   "topbar": {
     "back": "retour au portail",

--- a/messages/hi.json
+++ b/messages/hi.json
@@ -47,7 +47,8 @@
     "extendTimer": "टाइमर बढ़ाएं",
     "removeCategory": "श्रेणी हटाएं",
     "setFocus": "फोकस व्यू सेट करें",
-    "setTheme": "थीम सेट करें"
+    "setTheme": "थीम सेट करें",
+    "startScheduleNow": "start schedule now"
   },
   "nav": {
     "categories": "श्रेणियां",
@@ -127,7 +128,8 @@
     "tooltipClickToIdle": "निष्क्रिय पर स्विच करने के लिए क्लिक करें",
     "typeCountdown": "उलटी गिनती",
     "typeCountup": "काउंटअप",
-    "typeTimer1": "टाइमर1"
+    "typeTimer1": "टाइमर1",
+    "buttonStartNow": "start now"
   },
   "topbar": {
     "back": "पोर्टल पर वापस जाएं",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -47,7 +47,8 @@
     "extendTimer": "タイマーを延長",
     "removeCategory": "カテゴリを削除",
     "setFocus": "フォーカスビューを設定",
-    "setTheme": "テーマを設定"
+    "setTheme": "テーマを設定",
+    "startScheduleNow": "start schedule now"
   },
   "nav": {
     "categories": "カテゴリ",
@@ -127,7 +128,8 @@
     "tooltipClickToIdle": "クリックして待機中に切り替え",
     "typeCountdown": "カウントダウン",
     "typeCountup": "カウントアップ",
-    "typeTimer1": "タイマー1"
+    "typeTimer1": "タイマー1",
+    "buttonStartNow": "start now"
   },
   "topbar": {
     "back": "ポータルに戻る",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -58,7 +58,8 @@
     "completeSchedule": "스케줄 완료",
     "changeTimerType": "타이머 타입 변경",
     "setTheme": "테마 설정",
-    "setFocus": "집중 보기 설정"
+    "setFocus": "집중 보기 설정",
+    "startScheduleNow": "스케줄 즉시 시작"
   },
   "onboarding": {
     "welcome": "스케줄이 아직 없습니다",
@@ -142,7 +143,8 @@
     "categoryFallback": "?",
     "labelUpcoming": "다음 스케줄",
     "labelUntilUpcoming": "다음 시작까지",
-    "simultaneousLabel": "동시 진행 · {count}"
+    "simultaneousLabel": "동시 진행 · {count}",
+    "buttonStartNow": "즉시 시작"
   },
   "weekdays": {
     "0": "일",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -47,7 +47,8 @@
     "extendTimer": "estender temporizador",
     "removeCategory": "remover categoria",
     "setFocus": "definir visualização de foco",
-    "setTheme": "definir tema"
+    "setTheme": "definir tema",
+    "startScheduleNow": "start schedule now"
   },
   "nav": {
     "categories": "categorias",
@@ -127,7 +128,8 @@
     "tooltipClickToIdle": "clique para mudar para ocioso",
     "typeCountdown": "contagem regressiva",
     "typeCountup": "contagem progressiva",
-    "typeTimer1": "temporizador1"
+    "typeTimer1": "temporizador1",
+    "buttonStartNow": "start now"
   },
   "topbar": {
     "back": "voltar ao portal",

--- a/messages/ru.json
+++ b/messages/ru.json
@@ -47,7 +47,8 @@
     "extendTimer": "продлить таймер",
     "removeCategory": "удалить категорию",
     "setFocus": "установить вид фокуса",
-    "setTheme": "установить тему"
+    "setTheme": "установить тему",
+    "startScheduleNow": "start schedule now"
   },
   "nav": {
     "categories": "категории",
@@ -127,7 +128,8 @@
     "tooltipClickToIdle": "нажмите для переключения в простой",
     "typeCountdown": "обратный отсчёт",
     "typeCountup": "прямой отсчёт",
-    "typeTimer1": "timer1"
+    "typeTimer1": "timer1",
+    "buttonStartNow": "start now"
   },
   "topbar": {
     "back": "вернуться на портал",

--- a/messages/zh-CN.json
+++ b/messages/zh-CN.json
@@ -47,7 +47,8 @@
     "extendTimer": "延长计时器",
     "removeCategory": "删除类别",
     "setFocus": "设置专注视图",
-    "setTheme": "设置主题"
+    "setTheme": "设置主题",
+    "startScheduleNow": "start schedule now"
   },
   "nav": {
     "categories": "类别",
@@ -127,7 +128,8 @@
     "tooltipClickToIdle": "点击切换到空闲",
     "typeCountdown": "倒计时",
     "typeCountup": "正计时",
-    "typeTimer1": "timer1"
+    "typeTimer1": "timer1",
+    "buttonStartNow": "start now"
   },
   "topbar": {
     "back": "返回门户",


### PR DESCRIPTION
## Summary
- 빈 시간 카운트다운 카드 안 "즉시 시작" 버튼 추가
- 클릭 → upcoming.startAt = Date.now() · cascade 자동 적용 (뒤 chainedToPrev=true 연속 구간 같이 당김 · gap 유지)
- store.updateSchedule 가 armUndo 자동 호출 → UndoBar 5초 안 되돌리기

## 대장 결정 (Q1~Q5 a · 2026-05-06 KST)
- **Q1 a**: 5초 undo bar (timer bump · complete 패턴 일관)
- **Q2 a**: 미리보기 X (즉시 실행)
- **Q3 a**: overlap silent OK (submit 경로 외 검사 안 함 · 다른 timer 액션과 일관)
- **Q4 ok**: 라벨 "즉시 시작" / "start now"
- **Q5 ok**: primaryBtn 강조 (border-ink bg-ink)

## 변경
- `components/ActiveTimer.tsx` — IdleCountdown 에 useAppStore + useRunMutation hook + startNow 핸들러 + button
- `lib/use-run-mutation.ts` — MutationContextKey union 에 `startScheduleNow` 추가
- `messages/en.json` + `ko.json` — `mutation.startScheduleNow` + `timer.buttonStartNow` 마스터
- `messages/{es,pt,fr,de,ja,zh-CN,ru,ar,hi}.json` — EN placeholder (i18n-translate workflow 자동 PR 생성 trigger)

## 검증
- lint ✓ 0 warnings
- vitest ✓ 103/103 (i18n catalog drift 9/9 PASS · timer-state · cascade · ownership-guards · server-action 등)
- build ✓ Compiled successfully in 2.7s · 3 static pages

## Test plan
- [ ] preview deploy 진입 → 진행 중 schedule 없는 상태 확인 (idle countdown 카드 표시)
- [ ] "start now" 버튼 클릭 → upcoming schedule 즉시 active 전환 (TimerCard 표시)
- [ ] 5초 안 UndoBar "되돌리기" 클릭 → 원래 startAt 복원 + countdown 카드 다시 표시
- [ ] 뒤 chainedToPrev=true 인 schedule 도 같이 timeline 에서 당겨졌는지 확인
- [ ] DailyTimeline 자동 갱신 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)