### PR TITLE
fix(auth): JwtCookieRefresher interval + visibility + mutex + abort 박음

### DIFF
--- a/components/JwtCookieRefresher.tsx
+++ b/components/JwtCookieRefresher.tsx
@@ -1,32 +1,38 @@
 'use client';
 
 /**
- * plan1 의 cofounder_jwt cookie 자동 갱신 client component (PLAN1-JWT-REFRESHER-20260508).
+ * plan1 의 cofounder_jwt cookie 자동 갱신 client component.
  *
- * 배경 (Stage F0 진단 · 2026-05-08):
- *   - `__Secure-better-auth.session_token` TTL = 7일 (Better Auth)
- *   - `cofounder_jwt` TTL = 1시간 (refresh-jwt)
- *   - portal `JwtCookieRefresher` 가 portal home (`/project`) 만 mount
- *   - sub-project 진입 시 cookie 자동 갱신 trigger 부재 → 1h 후 만료 → middleware self-heal redirect chain
- *   - 사용자 영역 깜빡임 (결함 A "잠깐 보임 → 다시 로그인 필요") + 지속시간 짧음 (결함 B)
+ * 배경 (PLAN1-JWT-REFRESHER-INTERVAL-20260508):
+ *   - `__Secure-better-auth.session_token` TTL = 7일 (Better Auth default · sliding refresh updateAge=1d)
+ *   - `cofounder_jwt` TTL = 1시간 (refresh-jwt route.ts COOKIE_MAX_AGE_SECONDS)
+ *   - 사이클 6 (PR #72) 의 mount 1회 호출은 사용자가 plan1 페이지 머문 채 1시간 지나면 재호출 trigger 부재
+ *   - 결과: cookie 자동 삭제 → server action requireUser() unauthorized → "로그인이 필요합니다" 표시
  *
- * 동작:
- *   - plan1 layout mount 시 1회 fetch portal /api/cofounder/refresh-jwt (절대 URL)
- *   - 401 (no_session) silent — 미인증 사용자는 정상
- *   - 200 응답이면 Set-Cookie 헤더가 cofounder_jwt 자동 등록 (Better Auth session 살아있는 경우)
+ * 본 fix (interval + visibility + mutex + abort 조합 · critic Critical 3건 처방):
+ *   - mount 1회 호출 + 30분 interval (1h TTL 의 50% 마진 — 백그라운드 throttle 영역 catch)
+ *   - `visibilitychange` event listener — 탭 복귀·sleep wake 시 즉시 갱신 (NextAuth refetchOnWindowFocus 패턴)
+ *   - mutex (inFlightRef) + throttle (30s) — visibility + interval race condition 차단
+ *   - AbortController — unmount 시 in-flight fetch cancel + StrictMode dev double-invoke 자연 처리
+ *   - 401 처리 — sessionExpired flag + polling 중단 (Better Auth session 만료 catch)
+ *
+ * 절대 URL 의무:
+ *   - sub-project 의 relative path `/api/...` 는 plan1 own API path 영역
+ *   - portal API 호출하려면 PORTAL_ORIGIN 절대 URL 박음 (router proxy chain · cookie 동반 OK)
  *
  * portal cookie-cutter:
  *   - portal/components/JwtCookieRefresher.tsx 동일 패턴 (relative path 만 절대 URL 으로 변경)
- *   - sub-project 는 portal API 절대 URL 사용 의무 (router proxy chain · same root domain · cookie 동반 OK)
  *
- * 정직성 규칙 정합:
- *   - 본 fix 가 결함 B (TTL mismatch) 직접 해결
- *   - 결함 A (Google OAuth chain 깜빡임) 는 재현 안 됨 영역 — fix 후 사용자 검증 의무
+ * drift risk (4 곳 동기화 의무):
+ *   - REFRESH_INTERVAL_MS (본 파일 + portal/components/JwtCookieRefresher.tsx)
+ *   - COOKIE_MAX_AGE_SECONDS (portal/app/api/cofounder/refresh-jwt/route.ts:29)
+ *   - jwt expirationTime (portal/lib/auth.ts:66)
+ *   → 후속 task qa-pending § F11: NEXT_PUBLIC env 단일 source of truth 박음
  *
  * 근거:
- *   - portal/components/JwtCookieRefresher.tsx (cookie-cutter source)
- *   - wiki/shared/problem-resolution-log.md [2026-05-07] § F5 잔여 결함
- *   - tech-researcher § C.1 NextAuth useSession refetch 패턴 + § C.2 Clerk satellite 자동 sync
+ *   - critic Critical-1·2·3 처방 (race · drift · cleanup)
+ *   - critic Major M-1·M-2 처방 (401 polling 중단 · retry 부재)
+ *   - NextAuth useSession refetch (https://next-auth.js.org/getting-started/client) refetchOnWindowFocus 표준
  */
 
 import {useEffect, useRef} from 'react';
@@ -34,41 +40,81 @@ import {useEffect, useRef} from 'react';
 const PORTAL_ORIGIN =
   process.env.NEXT_PUBLIC_PORTAL_ORIGIN ?? 'https://cofounder.co.kr';
 
-type RefreshResponse =
-  | {ok: true; expiresInSeconds: number; user: {id: string; email: string}}
-  | {ok: false; reason: string};
+const REFRESH_INTERVAL_MS = 30 * 60 * 1000; // 30min · cookie TTL 1h 의 50% 마진
+const MIN_REFRESH_INTERVAL_MS = 30 * 1000; // 30s throttle (race 차단)
 
 export function JwtCookieRefresher() {
-  // React 18 StrictMode dev double-invoke 회피
-  const triggered = useRef(false);
+  const inFlightRef = useRef(false);
+  const lastRefreshAtRef = useRef(0);
+  const sessionExpiredRef = useRef(false);
 
   useEffect(() => {
-    if (triggered.current) return;
-    triggered.current = true;
+    const ac = new AbortController();
+    let intervalId: ReturnType<typeof setInterval> | null = null;
+    let onVisible: (() => void) | null = null;
 
-    // 절대 URL 의무 — sub-project 의 relative path `/api/...` 는 plan1 own API path 영역
-    // portal API 호출하려면 PORTAL_ORIGIN 절대 URL 박음 (router proxy chain · cookie 동반)
-    fetch(`${PORTAL_ORIGIN}/project/api/cofounder/refresh-jwt`, {
-      method: 'GET',
-      credentials: 'include'
-    })
-      .then(async res => {
-        // 401 (no_session) 는 미인증 사용자 — middleware self-heal redirect 가 portal 으로 보냄
-        if (res.status === 401) return null;
+    const cleanup = () => {
+      if (intervalId !== null) {
+        clearInterval(intervalId);
+        intervalId = null;
+      }
+      if (onVisible !== null) {
+        document.removeEventListener('visibilitychange', onVisible);
+        onVisible = null;
+      }
+    };
+
+    const refresh = async () => {
+      if (sessionExpiredRef.current) return; // 401 후 polling 차단
+      const now = Date.now();
+      if (inFlightRef.current) return; // 진행 중 요청 mutex
+      if (now - lastRefreshAtRef.current < MIN_REFRESH_INTERVAL_MS) return; // throttle
+      inFlightRef.current = true;
+      lastRefreshAtRef.current = now;
+      try {
+        const res = await fetch(
+          `${PORTAL_ORIGIN}/project/api/cofounder/refresh-jwt`,
+          {
+            method: 'GET',
+            credentials: 'include',
+            signal: ac.signal
+          }
+        );
+        if (res.status === 401) {
+          // Better Auth session 만료 — polling 중단 (plan1 middleware self-heal redirect 가 page navigate 시 portal 으로 보냄)
+          sessionExpiredRef.current = true;
+          cleanup();
+          return;
+        }
         if (!res.ok) {
           if (process.env.NODE_ENV !== 'production') {
             console.warn('[plan1 jwt-refresh] non-ok response', res.status);
           }
-          return null;
         }
-        const json: RefreshResponse = await res.json();
-        return json;
-      })
-      .catch(err => {
+        // body parse 생략 (set-cookie 헤더만 중요 · 응답 본문 사용처 X)
+      } catch (err) {
+        if ((err as Error).name === 'AbortError') return; // cleanup 정상
         if (process.env.NODE_ENV !== 'production') {
           console.warn('[plan1 jwt-refresh] fetch error', err);
         }
-      });
+      } finally {
+        inFlightRef.current = false;
+      }
+    };
+
+    refresh(); // mount 1회
+
+    intervalId = setInterval(refresh, REFRESH_INTERVAL_MS);
+
+    onVisible = () => {
+      if (document.visibilityState === 'visible') refresh();
+    };
+    document.addEventListener('visibilitychange', onVisible);
+
+    return () => {
+      ac.abort();
+      cleanup();
+    };
   }, []);
 
   return null;


### PR DESCRIPTION
## Summary
- 사이클 6 (PR #72) JwtCookieRefresher mount 1회 호출 한계 catch — SPA 단일 페이지 1h+ 머무는 동안 cookie 만료 → server action unauthorized 결함
- mount 1회 + 30min interval + visibilitychange listener + mutex + AbortController + 401 polling 중단 박음
- 사용자 영상 (대장 2026-05-08): plan1 페이지 머문 채 1h+ 후 "타이머 연장 실패: 로그인이 필요합니다."

## Root cause
- `cofounder_jwt` TTL = 1h (refresh-jwt route.ts:29 `COOKIE_MAX_AGE_SECONDS`)
- `JwtCookieRefresher` (사이클 6) = layout mount 시 1회만 fetch
- 사용자가 plan1 페이지 머무는 동안 navigate 없으면 재호출 trigger 부재 → cookie 자동 삭제 → server action `requireUser()` unauthorized

## 처방 (logic-critic + env-critic 병렬 검토 후 박음)

### Critical (3건)
- C-1 race condition (visibility + interval): mutex (`inFlightRef`) + 30s throttle 박음
- C-2 interval drift (백그라운드 throttle): 50min → 30min 단축 (1h TTL 50% 마진)
- C-3 cleanup race (in-flight fetch cancel 부재): AbortController 박음

### Major (2건)
- M-1 401 polling 무한 (Better Auth session 만료): `sessionExpiredRef` flag + cleanup 박음
- M-2 retry 부재: interval 30min 단축으로 자연 catch + try/catch finally 박음

## Drift risk (4 곳 동기화 의무)
- `REFRESH_INTERVAL_MS` (본 파일 + portal/components/JwtCookieRefresher.tsx)
- `COOKIE_MAX_AGE_SECONDS` (portal/app/api/cofounder/refresh-jwt/route.ts:29)
- `jwt expirationTime` (portal/lib/auth.ts:66)
→ 후속 task qa-pending § F11: NEXT_PUBLIC env 단일 source of truth (별 PR)

## Test plan
- [x] typecheck (components/JwtCookieRefresher.tsx clean)
- [x] lint (`npx eslint components/JwtCookieRefresher.tsx`)
- [x] build (`PORTAL_ISSUER=... npm run build` green)
- [ ] CI mutation E2E SLA (`npm run test:e2e:qa-gate` < 3000ms warm)
- [ ] prod alias 첫 hit 시 mutation E2E 자동 1회
- [ ] 대장 prod 검증 — plan1 페이지 1h+ 머문 후 "타이머 연장" 클릭 → unauthorized 안 발생 (Stage G · 3차 테스트)

## 연관 PR
- cofounder-portal 별 PR (cookie-cutter 동일 패턴 + layout mount 이동 + cookieCache 5min)

작업 ID: PLAN1-JWT-REFRESHER-INTERVAL-20260508

🤖 Generated with [Claude Code](https://claude.com/claude-code)