### PR TITLE
fix: prefillStartAt race — 시간 클릭 시간이 1초 후 현재시간으로 덮씌워짐

### DIFF
--- a/components/NewScheduleModal.tsx
+++ b/components/NewScheduleModal.tsx
@@ -187,14 +187,22 @@ export function NewScheduleModal({
   // PLAN1-FOCUS-VIEW-REDESIGN-V2-20260506 #12 (Q-NEW6 d·Q-NEW11 d):
   // 시작 분 자동 갱신. 사용자 명시 변경 = lock (선택값 ≠ 직전 자동값).
   // 사용자 입력값이 시간 흐름 후 자연 일치 (= 직전 자동값) 시 자동 모드 자연 복원.
+  // PLAN1-PREFILL-RACE-FIX-20260509: baseline 영역 = currentSelected → floorToHourMs(live) 정정.
+  // 옛 영역 결함: prefillStartAt 박힌 영역 (시간 클릭) 도 baseline = currentSelected (사용자 클릭 시간)
+  // 박아서, 1초 tick 후 자연 일치로 자동 갱신 → 사용자 클릭 시간이 현재시간으로 덮어쓰임.
+  // 정공: baseline = floorToHourMs(live) (자동 모드 baseline). 사용자 클릭 시간 또는 명시 변경
+  // 영역은 currentSelected ≠ baseline 으로 자연 lock.
   const prevAutoMsRef = useRef<number>(0);
   /* eslint-disable react-hooks/set-state-in-effect */
   useEffect(() => {
     if (!nowReady || isEdit) return;
     const currentSelected = selectedHourMs + minute * 60_000;
-    // 첫 mount 시 prevAutoMs 초기화 (사용자 변경 비교 baseline)
+    // 첫 mount 시 baseline = 자동 모드 baseline (live floor).
+    // 사용자 클릭 시간 (prefillStartAt) 박혔으면 currentSelected ≠ baseline → 자연 lock.
+    // 일반 진입 (prefillStartAt 없음 · nowSnapshot 박힘) → currentSelected = baseline → 자동 모드 자연 시작.
     if (prevAutoMsRef.current === 0) {
-      prevAutoMsRef.current = currentSelected;
+      const {hourMs: liveHourMs0, remainderMin: liveMin0} = floorToHourMs(live);
+      prevAutoMsRef.current = liveHourMs0 + liveMin0 * 60_000;
       return;
     }
     // 사용자 명시 변경 → lock (자동 갱신 안 함)


### PR DESCRIPTION
## Summary
- **결함**: 빈 공간 (시간 슬롯) 클릭 → 새 스케줄 모달 mount → 사용자 클릭 시간 셋팅 → 1초 tick 후 현재시간으로 자연 덮어쓰임
- 대장 영상 catch (003.mov · `msg 1502423709011411036`)
- root cause: 자동 갱신 useEffect (NewScheduleModal.tsx) 의 첫 mount baseline 박힘이 사용자 클릭 시간 = baseline 으로 박아 1초 tick 후 자연 일치 분기 진입 → 현재시간 덮어씀

## Fix
baseline = `floorToHourMs(live)` (자동 모드 baseline) 정정:
- 사용자 클릭 시간 (prefillStartAt): `currentSelected ≠ baseline` → 자연 lock
- 일반 진입: `currentSelected = baseline` → 자동 모드 자연 시작
- 사용자 명시 변경: 같은 lock 패턴 (변경 X)

## Test plan
- [x] typecheck clean (NewScheduleModal 영역)
- [x] eslint clean
- [x] vitest 126/126 PASS (회귀 X)
- [ ] preview deploy 사용자 검증 (대장 직접) — 시간 클릭 → 모달 셋팅 시간이 1초+ 후에도 그대로 유지 확인
- [ ] 회귀 spec 작성 — component test infra 부재 + mutation E2E 무거움 → qa-pending 후속 영역 (별 사이클)

🤖 Generated with [Claude Code](https://claude.com/claude-code)