### PR TITLE
feat(timeline): DailyTimeline 시간 간격 줌 in/out + 레이아웃 swap + 폰트 통일

### DIFF
--- a/app/actions/settings.ts
+++ b/app/actions/settings.ts
@@ -23,6 +23,7 @@ import {plan1Settings} from '@/lib/db/schema';
 import {requireUser} from '@/lib/auth-helpers';
 import {runAction, type ServerActionResult} from '@/lib/server-action';
 import type {AppSettings} from '@/lib/domain/types';
+import {clampZoomPxPerHour} from '@/lib/zoom-helpers';
 
 // PLAN1-FOCUS-VIEW-REDESIGN-20260506:
 //   - focusViewMin default 720 (12h)
@@ -32,6 +33,7 @@ const DEFAULT_SETTINGS = {
   weekViewSpan: 1 as const,         // S12 column drop 까지 INSERT 호환 유지
   weeklyPanelHidden: false,          // S12 column drop 까지 INSERT 호환 유지
   focusViewMin: 720 as number,
+  zoomPxPerHour: 50 as number,       // PLAN1-ZOOM-PX-PER-HOUR-20260509
   pinnedActiveId: null as string | null  // S12 column drop 까지 INSERT 호환 유지
 };
 
@@ -39,7 +41,9 @@ function rowToDomain(row: typeof plan1Settings.$inferSelect): AppSettings {
   return {
     theme: row.theme,
     // 옛 row null fallback (S12 backfill 전까지 안전망 · NOT NULL DEFAULT 720 박힌 후엔 무관)
-    focusViewMin: row.focusViewMin ?? 720
+    focusViewMin: row.focusViewMin ?? 720,
+    // PLAN1-ZOOM-PX-PER-HOUR-20260509: 옛 row 부재 fallback (NOT NULL DEFAULT 50 적용 직후 안전망)
+    zoomPxPerHour: row.zoomPxPerHour ?? 50
   };
 }
 
@@ -76,6 +80,10 @@ export async function updateSettings(
     const dbPatch: Partial<typeof plan1Settings.$inferInsert> = {updatedAt: new Date()};
     if (patch.theme !== undefined) dbPatch.theme = patch.theme;
     if (patch.focusViewMin !== undefined) dbPatch.focusViewMin = patch.focusViewMin;
+    if (patch.zoomPxPerHour !== undefined) {
+      // 서버 사이드 clamp — 클라이언트 변조 차단. lib/zoom-helpers.ts 단일 원천.
+      dbPatch.zoomPxPerHour = clampZoomPxPerHour(patch.zoomPxPerHour);
+    }
 
     const [updated] = await db
       .update(plan1Settings)

--- a/app/globals.css
+++ b/app/globals.css
@@ -150,3 +150,10 @@ body::before {
 .clock-center-inner {
   fill: var(--bg);
 }
+
+/* PLAN1-ZOOM-PX-PER-HOUR-20260509 — DailyTimeline 시간 간격 줌.
+ * .fc-timegrid-slot height 를 CSS variable 로 박음. DailyTimeline wrapping div 가 inline
+ * style 으로 `--plan1-fc-slot-height` 박음. var 미박힘 시 unset → FullCalendar default. */
+.fc .fc-timegrid-slot {
+  height: var(--plan1-fc-slot-height, unset);
+}

--- a/components/DailyTimeline.tsx
+++ b/components/DailyTimeline.tsx
@@ -11,6 +11,14 @@ import {focusBounds} from '@/lib/focus-bounds';
 import {formatDateRangeLabel} from '@/lib/date-format';
 import {useNow} from '@/lib/now';
 import {useRunMutation} from '@/lib/use-run-mutation';
+import {
+  ZOOM_MIN,
+  ZOOM_MAX,
+  ZOOM_STEP,
+  clampZoomPxPerHour,
+  zoomDenseSlotDuration,
+  zoomSlotHeightPx
+} from '@/lib/zoom-helpers';
 import {renderEventContent} from './event-renderer';
 
 // next-intl `zh-CN` → FullCalendar `zh-cn`.
@@ -30,6 +38,8 @@ const FOCUS_OPTIONS: Array<{value: number; key: string}> = [
   {value: 1440, key: 'focus24h'}
 ];
 
+// PLAN1-ZOOM-PX-PER-HOUR-20260509 — DailyTimeline 시간 간격 줌. 상수·헬퍼는 lib/zoom-helpers.ts.
+
 export function DailyTimeline({
   onEventClick,
   onDateClick
@@ -46,6 +56,8 @@ export function DailyTimeline({
   // PLAN1-FOCUS-VIEW-REDESIGN-20260506: null 폐기. 옛 row null 받을 수 있어 fallback 720.
   // S12 portal repo schema migration 후 NOT NULL DEFAULT 720 박힐 때까지 안전망.
   const focusViewMin = useAppStore(s => s.settings.focusViewMin ?? 720);
+  // PLAN1-ZOOM-PX-PER-HOUR-20260509: 옛 row 부재 fallback 50 (NOT NULL DEFAULT 50 적용 직후 안전망).
+  const zoomPxPerHour = useAppStore(s => s.settings.zoomPxPerHour ?? ZOOM_MIN);
   const updateSettings = useAppStore(s => s.updateSettings);
   const runMutation = useRunMutation();
 
@@ -100,30 +112,67 @@ export function DailyTimeline({
     runMutation(updateSettings({focusViewMin: Number(value)}), 'setFocus');
   };
 
+  // PLAN1-ZOOM-PX-PER-HOUR-20260509 — 줌 +/- handler. clamp 후 변경.
+  const handleZoom = (delta: number) => {
+    const next = clampZoomPxPerHour(zoomPxPerHour + delta);
+    if (next === zoomPxPerHour) return; // no-op (min/max 도달)
+    runMutation(updateSettings({zoomPxPerHour: next}), 'setZoom');
+  };
+
+  const slotDuration = zoomDenseSlotDuration(zoomPxPerHour);
+  const slotHeightPx = zoomSlotHeightPx(zoomPxPerHour);
+
+  const atZoomMin = zoomPxPerHour <= ZOOM_MIN;
+  const atZoomMax = zoomPxPerHour >= ZOOM_MAX;
+
   return (
-    <div className="[&_.fc-event-title]:whitespace-normal [&_.fc-event-title]:break-words">
-      {/* PLAN1-FOCUS-VIEW-REDESIGN-V2-20260506 #1·#2·#3:
-            - headerToolbar=false (< > today 폐기)
-            - dayHeaders=false (빈칸|요일 row 폐기)
-            - 자체 헤더: focus dropdown (좌) + 날짜 라벨 (우) · "집중" 라벨 폐기 */}
+    <div
+      className="[&_.fc-event-title]:whitespace-normal [&_.fc-event-title]:break-words"
+      style={{['--plan1-fc-slot-height' as string]: `${slotHeightPx}px`}}
+    >
+      {/* PLAN1-ZOOM-PX-PER-HOUR-20260509 (대장 이미지 정합):
+            - 좌: 날짜 라벨 + 끝 시각 (한 줄 통합 · 폰트 크기 finalEndLabel 과 동일)
+            - 우: focus dropdown + zoom − + 버튼
+            - 폰트 크기 통일 (text-sm font-medium) · 컬러 각각 그대로 (muted/ink) */}
       <div className="mb-2 flex items-center justify-between">
-        <select
-          value={String(focusViewMin)}
-          onChange={e => handleFocusChange(e.target.value)}
-          className="rounded-none border border-line bg-panel px-2 py-1 text-xs text-txt font-mono"
-          aria-label={t('nav.focusLabel')}
-        >
-          {FOCUS_OPTIONS.map(opt => (
-            <option key={opt.key} value={String(opt.value)}>
-              {t(`nav.${opt.key}` as 'nav.focus4h')}
-            </option>
-          ))}
-        </select>
-        {/* 2026-05-06 (대장 명시 · 위치 swap) — 가운데 날짜 · 우측 끝 시각. */}
-        <span className="text-xs text-muted font-mono">{dateLabel}</span>
-        {finalEndLabel && (
-          <span className="text-sm font-medium text-ink font-mono">{finalEndLabel}</span>
-        )}
+        <div className="flex items-baseline gap-2">
+          <span className="text-sm font-medium text-muted font-mono">{dateLabel}</span>
+          {finalEndLabel && (
+            <span className="text-sm font-medium text-ink font-mono">{finalEndLabel}</span>
+          )}
+        </div>
+        <div className="flex items-center gap-1">
+          <select
+            value={String(focusViewMin)}
+            onChange={e => handleFocusChange(e.target.value)}
+            className="rounded-none border border-line bg-panel px-2 py-1 text-xs text-txt font-mono"
+            aria-label={t('nav.focusLabel')}
+          >
+            {FOCUS_OPTIONS.map(opt => (
+              <option key={opt.key} value={String(opt.value)}>
+                {t(`nav.${opt.key}` as 'nav.focus4h')}
+              </option>
+            ))}
+          </select>
+          <button
+            type="button"
+            onClick={() => handleZoom(-ZOOM_STEP)}
+            disabled={atZoomMin}
+            aria-label={t('nav.zoomOut')}
+            className="rounded-none border border-line bg-panel px-2 py-1 text-xs text-txt font-mono leading-none disabled:opacity-30 disabled:cursor-not-allowed"
+          >
+            −
+          </button>
+          <button
+            type="button"
+            onClick={() => handleZoom(ZOOM_STEP)}
+            disabled={atZoomMax}
+            aria-label={t('nav.zoomIn')}
+            className="rounded-none border border-line bg-panel px-2 py-1 text-xs text-txt font-mono leading-none disabled:opacity-30 disabled:cursor-not-allowed"
+          >
+            +
+          </button>
+        </div>
       </div>
       <FullCalendar
         plugins={[timeGridPlugin, interactionPlugin]}
@@ -133,7 +182,7 @@ export function DailyTimeline({
         locale={fcLocale(locale)}
         slotMinTime={slotMinTime}
         slotMaxTime={slotMaxTime}
-        slotDuration="00:30:00"
+        slotDuration={slotDuration}
         nowIndicator
         allDaySlot={false}
         height="auto"

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -114,6 +114,10 @@ export const plan1Settings = plan1Schema.table('settings', {
   // PLAN1-WH-FOCUS-20260504 — defaultWorkingHoursStartMin/EndMin 폐기.
   // 집중 보기 모드 (focusViewMin) — 분 단위. null = 전체 보기 (default).
   focusViewMin: integer('focus_view_min'),
+  // PLAN1-ZOOM-PX-PER-HOUR-20260509 — DailyTimeline 시간 간격 줌 (1시간 height px). default 50.
+  // 사용자 +/- 버튼으로 ±20 조정. min = 50 (default · - 비활성) · max = 200 (10분 슬롯 가독성).
+  // pxPerHour ≥ 120 시 slotDuration 30분 → 10분 자동 변환.
+  zoomPxPerHour: integer('zoom_px_per_hour').default(50).notNull(),
   pinnedActiveId: text('pinned_active_id').references((): AnyPgColumn => plan1Schedules.id, {
     onDelete: 'set null'
   }),

--- a/lib/domain/types.ts
+++ b/lib/domain/types.ts
@@ -24,5 +24,9 @@ export interface AppSettings {
   // 옵션 [4·6·8·10·12·16·20·24h] · null 폐기 · DailyTimeline view = HOUR floor [(h-1)*60, ...].
   // S12 portal repo schema migration 후 NOT NULL DEFAULT 720. 그 전에는 store ?? 720 fallback.
   focusViewMin: number;
+  // PLAN1-ZOOM-PX-PER-HOUR-20260509 — DailyTimeline 시간 간격 줌 (1시간 height px). default 50.
+  // 사용자 +/- 버튼으로 ±20 조정. min 50 (default · - 비활성) · max 200 (10분 슬롯 가독성).
+  // pxPerHour ≥ 120 시 slotDuration 30분 → 10분 자동 변환.
+  zoomPxPerHour: number;
   // PLAN1-FOCUS-VIEW-REDESIGN-20260506 (Q23): pinnedActiveId 폐기 (MAX_OVERLAP=2 정책 후 사용 영역 거의 없음 · S12 column drop).
 }

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -28,9 +28,11 @@ import {unwrapServerActionResult as unwrap, ServerActionError} from './server-ac
 import {armUndo} from './undo-store';
 
 // PLAN1-FOCUS-VIEW-REDESIGN-20260506: weekViewSpan / weeklyPanelHidden 폐기. focusViewMin 720 default.
+// PLAN1-ZOOM-PX-PER-HOUR-20260509: zoomPxPerHour 50 default (FullCalendar v6 default 추정).
 export const DEFAULT_SETTINGS: AppSettings = {
   theme: 'system',
-  focusViewMin: 720
+  focusViewMin: 720,
+  zoomPxPerHour: 50
 };
 
 // Stage 5 i18n: name='default' 영어 base. 표시 시 useCategoryDisplay() 가 name 매칭으로

--- a/lib/use-run-mutation.ts
+++ b/lib/use-run-mutation.ts
@@ -44,6 +44,7 @@ export type MutationContextKey =
   | 'changeTimerType'
   | 'setTheme'
   | 'setFocus'
+  | 'setZoom'
   | 'startScheduleNow';
 
 export function useRunMutation() {

--- a/lib/zoom-helpers.test.ts
+++ b/lib/zoom-helpers.test.ts
@@ -1,0 +1,92 @@
+/**
+ * PLAN1-ZOOM-PX-PER-HOUR-20260509 — zoom-helpers 단위 spec.
+ *
+ * 케이스 환원 (test-case-design-principles.md § 1.2):
+ *   1 변수 (number) → EP/BVA 만 (PICT 미적용 — 변수 2 미만)
+ *   - clampZoomPxPerHour: under-min · at-min · in-range · at-max · over-max · invalid (NaN/Infinity)
+ *   - zoomDenseSlotDuration: 119 (under threshold) · 120 (at) · 121 (above) — BVA
+ *   - zoomSlotHeightPx: 30분 분기 / 10분 분기 양쪽 + threshold 경계
+ */
+
+import {describe, it, expect} from 'vitest';
+import {
+  ZOOM_MIN,
+  ZOOM_MAX,
+  ZOOM_STEP,
+  ZOOM_DENSE_THRESHOLD,
+  clampZoomPxPerHour,
+  zoomDenseSlotDuration,
+  zoomSlotHeightPx
+} from './zoom-helpers';
+
+describe('zoom-helpers — constants', () => {
+  it('min/max/step 박힌 값 = UI · server action clamp 정합', () => {
+    expect(ZOOM_MIN).toBe(50);
+    expect(ZOOM_MAX).toBe(200);
+    expect(ZOOM_STEP).toBe(20);
+    expect(ZOOM_DENSE_THRESHOLD).toBe(120);
+  });
+});
+
+describe('clampZoomPxPerHour — EP/BVA', () => {
+  it('under min → ZOOM_MIN', () => {
+    expect(clampZoomPxPerHour(0)).toBe(ZOOM_MIN);
+    expect(clampZoomPxPerHour(-100)).toBe(ZOOM_MIN);
+    expect(clampZoomPxPerHour(49)).toBe(ZOOM_MIN);
+  });
+  it('at min boundary', () => {
+    expect(clampZoomPxPerHour(50)).toBe(50);
+  });
+  it('in range — pass-through (rounded)', () => {
+    expect(clampZoomPxPerHour(70)).toBe(70);
+    expect(clampZoomPxPerHour(120)).toBe(120);
+    expect(clampZoomPxPerHour(199)).toBe(199);
+    expect(clampZoomPxPerHour(70.4)).toBe(70);
+    expect(clampZoomPxPerHour(70.6)).toBe(71);
+  });
+  it('at max boundary', () => {
+    expect(clampZoomPxPerHour(200)).toBe(200);
+  });
+  it('over max → ZOOM_MAX', () => {
+    expect(clampZoomPxPerHour(201)).toBe(ZOOM_MAX);
+    expect(clampZoomPxPerHour(1000)).toBe(ZOOM_MAX);
+  });
+  it('invalid (NaN · ±Infinity) → ZOOM_MIN (안전 default)', () => {
+    expect(clampZoomPxPerHour(NaN)).toBe(ZOOM_MIN);
+    expect(clampZoomPxPerHour(Infinity)).toBe(ZOOM_MIN);
+    expect(clampZoomPxPerHour(-Infinity)).toBe(ZOOM_MIN);
+  });
+});
+
+describe('zoomDenseSlotDuration — threshold BVA', () => {
+  it('under threshold → 30분 슬롯', () => {
+    expect(zoomDenseSlotDuration(50)).toBe('00:30:00');
+    expect(zoomDenseSlotDuration(100)).toBe('00:30:00');
+    expect(zoomDenseSlotDuration(119)).toBe('00:30:00');
+  });
+  it('at threshold → 10분 슬롯 (>=)', () => {
+    expect(zoomDenseSlotDuration(120)).toBe('00:10:00');
+  });
+  it('above threshold → 10분 슬롯', () => {
+    expect(zoomDenseSlotDuration(121)).toBe('00:10:00');
+    expect(zoomDenseSlotDuration(200)).toBe('00:10:00');
+  });
+});
+
+describe('zoomSlotHeightPx — 분기 정합', () => {
+  it('30분 분기 = pxPerHour / 2', () => {
+    expect(zoomSlotHeightPx(50)).toBe(25);
+    expect(zoomSlotHeightPx(70)).toBe(35);
+    expect(zoomSlotHeightPx(100)).toBe(50);
+    expect(zoomSlotHeightPx(119)).toBe(59.5);
+  });
+  it('10분 분기 = pxPerHour / 6', () => {
+    expect(zoomSlotHeightPx(120)).toBe(20);
+    expect(zoomSlotHeightPx(180)).toBe(30);
+    expect(zoomSlotHeightPx(200)).toBeCloseTo(33.333, 2);
+  });
+  it('threshold 경계 (119 → 30분 / 120 → 10분) 분기 일치', () => {
+    expect(zoomSlotHeightPx(119)).toBe(59.5); // 119/2
+    expect(zoomSlotHeightPx(120)).toBe(20); // 120/6 (slot duration 변환됨)
+  });
+});

--- a/lib/zoom-helpers.ts
+++ b/lib/zoom-helpers.ts
@@ -1,0 +1,28 @@
+/**
+ * PLAN1-ZOOM-PX-PER-HOUR-20260509 — DailyTimeline 시간 간격 줌 helper.
+ *
+ * default 50 (FullCalendar v6 default 추정 · S6 검증 단계 조정 가능).
+ * step 20 · min 50 (default · - 비활성) · max 200 (10분 슬롯 가독성).
+ * pxPerHour ≥ ZOOM_DENSE_THRESHOLD 시 slotDuration 30분 → 10분 자동 변환.
+ *
+ * server action `updateSettings` + DailyTimeline UI 둘 다 같은 clamp 사용.
+ */
+
+export const ZOOM_MIN = 50;
+export const ZOOM_MAX = 200;
+export const ZOOM_STEP = 20;
+export const ZOOM_DENSE_THRESHOLD = 120;
+
+export function clampZoomPxPerHour(value: number): number {
+  if (!Number.isFinite(value)) return ZOOM_MIN;
+  return Math.max(ZOOM_MIN, Math.min(ZOOM_MAX, Math.round(value)));
+}
+
+export function zoomDenseSlotDuration(pxPerHour: number): '00:10:00' | '00:30:00' {
+  return pxPerHour >= ZOOM_DENSE_THRESHOLD ? '00:10:00' : '00:30:00';
+}
+
+export function zoomSlotHeightPx(pxPerHour: number): number {
+  const slot = zoomDenseSlotDuration(pxPerHour);
+  return slot === '00:10:00' ? pxPerHour / 6 : pxPerHour / 2;
+}

--- a/messages/ar.json
+++ b/messages/ar.json
@@ -1,12 +1,12 @@
 {
     "app": {
         "tagline": "مدير الجداول",
-        "title": "خطة1"
+        "title": "plan1"
     },
     "auth": {
         "signIn": "تسجيل الدخول باستخدام Google",
-        "signInDescription": "plan1 هي أداة جدولة شخصية مع مزامنة عبر الأجهزة. سجّل الدخول بحساب Google للبدء.",
-        "signInRequired": "سجل الدخول لاستخدام خطة1"
+        "signInDescription": "plan1 هي أداة جدولة شخصية مع مزامنة عبر الأجهزة. سجل الدخول باستخدام Google للبدء.",
+        "signInRequired": "سجل الدخول لاستخدام plan1"
     },
     "category": {
         "confirmRemoveLabel": "تأكيد الحذف ({count})",
@@ -36,7 +36,7 @@
     "error": {
         "featureUnavailable": "هذه الميزة غير متاحة بعد ({feature}).",
         "loadFailedLabel": "فشل التحميل:",
-        "mutationFailed": "فشل في {action}: {error}",
+        "mutationFailed": "فشل {action}: {error}",
         "unknown": "حدث خطأ غير متوقع. يرجى المحاولة مرة أخرى.",
         "workingHoursInvalid": "إدخال ساعات العمل غير صالح ({reason})."
     },
@@ -52,7 +52,7 @@
         "setFocus": "تعيين عرض التركيز",
         "setTheme": "تعيين المظهر",
         "setZoom": "تعيين التكبير",
-        "startScheduleNow": "بدء الجدول الآن"
+        "startScheduleNow": "ابدأ الجدول الآن"
     },
     "nav": {
         "categories": "الفئات",
@@ -74,8 +74,8 @@
         "zoomOut": "تصغير"
     },
     "onboarding": {
-        "addFirst": "إضافة أول جدول",
-        "firstSchedule": "أضف جدولك الأول لرؤيته على الشبكة الأسبوعية والجدول الزمني اليوم والساعة التناظرية.",
+        "addFirst": "أضف أول جدول",
+        "firstSchedule": "أضف أول جدول لك لرؤيته على الشبكة الأسبوعية، والجدول الزمني لليوم، والساعة التناظرية.",
         "welcome": "لا توجد جداول بعد"
     },
     "schedule": {
@@ -88,7 +88,7 @@
         "buttonPlusHour": "+1س",
         "categoryAddOption": "+ إضافة فئة",
         "chainedCheckbox": "ربط بالجدول السابق",
-        "endLabelV2": "وقت النهاية",
+        "endLabelV2": "وقت الانتهاء",
         "endPlaceholder": "اختر المدة",
         "fieldCategory": "الفئة",
         "fieldDuration": "المدة (دقيقة)",
@@ -103,17 +103,17 @@
         "minuteSuffix": "د",
         "prevChainLabel": "الجدول السابق المتصل",
         "titleDefault": "جدول جديد",
-        "warningOverlapLimit": "يمكن أن يتداخل {limit} جداول كحد أقصى في نفس الوقت. اضبط البداية/المدة أو احذف جدولاً موجوداً."
+        "warningOverlapLimit": "يمكن أن تتداخل {limit} جداول كحد أقصى في نفس الوقت. اضبط البداية/المدة أو احذف جدولاً موجوداً."
     },
     "serverError": {
-        "categoryHasSchedules": "الفئة تحتوي على {scheduleCount} جداول. أكد الحذف المتسلسل للإزالة.",
+        "categoryHasSchedules": "الفئة تحتوي على {scheduleCount} جداول. أكد الحذف المتتالي للإزالة.",
         "categoryNotFound": "الفئة غير موجودة أو غير مملوكة.",
         "scheduleNotFound": "الجدول غير موجود.",
         "unauthorized": "تسجيل الدخول مطلوب."
     },
     "signIn": {
         "cta": "تسجيل الدخول",
-        "description": "سجل الدخول إلى حساب المؤسس المشارك الخاص بك لعرض وإدارة جداولك.",
+        "description": "سجل الدخول إلى حساب cofounder الخاص بك لعرض وإدارة جداولك.",
         "title": "تسجيل الدخول مطلوب"
     },
     "timer": {
@@ -123,10 +123,10 @@
         "buttonStartNow": "ابدأ الآن",
         "categoryFallback": "؟",
         "idleEmpty": "خامل · لا يوجد جدول نشط",
-        "labelElapsed": "منقضي",
+        "labelElapsed": "المنقضي",
         "labelEndAt": "ينتهي-في",
-        "labelRemaining": "متبقي",
-        "labelTarget": "هدف",
+        "labelRemaining": "المتبقي",
+        "labelTarget": "الهدف",
         "labelUntilUpcoming": "حتى القادم",
         "labelUpcoming": "الجدول التالي",
         "overlapLabel": "تداخل {count}",
@@ -135,7 +135,7 @@
         "tooltipClickToIdle": "انقر للتبديل إلى الخمول",
         "typeCountdown": "العد التنازلي",
         "typeCountup": "العد التصاعدي",
-        "typeTimer1": "مؤقت1"
+        "typeTimer1": "timer1"
     },
     "topbar": {
         "back": "العودة إلى البوابة",
@@ -150,8 +150,8 @@
         "button": "تراجع"
     },
     "wallTime": {
-        "am": "ص",
-        "pm": "م"
+        "am": "صباحاً",
+        "pm": "مساءً"
     },
     "weekdays": [
         "الأحد",
@@ -163,19 +163,19 @@
         "السبت"
     ],
     "workingHours": {
-        "checkboxAlsoDefault": "حفظ أيضاً كافتراضي",
+        "checkboxAlsoDefault": "احفظ أيضاً كافتراضي",
         "checkboxWeekdaysOnly": "أيام الأسبوع فقط (الإثنين–الجمعة)",
         "errorEndAfterStart": "يجب أن يكون وقت النهاية بعد وقت البداية.",
         "errorToAfterFrom": "يجب أن يكون تاريخ النهاية في أو بعد تاريخ البداية.",
         "fieldDate": "التاريخ",
-        "fieldEndTime": "وقت النهاية",
+        "fieldEndTime": "وقت الانتهاء",
         "fieldFromDate": "من",
         "fieldStartTime": "وقت البداية",
         "fieldToDate": "إلى",
         "header": "ساعات العمل",
         "tabRange": "النطاق",
-        "tabSingle": "مفرد",
+        "tabSingle": "فردي",
         "warningNoDates": "لا توجد تواريخ للتطبيق في النطاق. (البداية > النهاية أو تعارض أيام الأسبوع فقط)",
-        "warningTruncated": "النطاق يتجاوز {max} أيام، تمت معالجة جزئية فقط. جرب نطاقاً أضيق."
+        "warningTruncated": "النطاق يتجاوز {max} يوم، تمت معالجة جزء فقط. جرب نطاقاً أضيق."
     }
 }

--- a/messages/ar.json
+++ b/messages/ar.json
@@ -48,7 +48,8 @@
     "removeCategory": "إزالة الفئة",
     "setFocus": "تعيين عرض التركيز",
     "setTheme": "تعيين المظهر",
-    "startScheduleNow": "start schedule now"
+    "startScheduleNow": "start schedule now",
+    "setZoom": "تعيين التكبير"
   },
   "nav": {
     "categories": "الفئات",
@@ -65,7 +66,9 @@
     "themeDark": "داكن",
     "themeLight": "فاتح",
     "themeSystem": "تلقائي",
-    "workingHours": "ساعات"
+    "workingHours": "ساعات",
+    "zoomIn": "تكبير",
+    "zoomOut": "تصغير"
   },
   "onboarding": {
     "addFirst": "أضف أول جدول",

--- a/messages/ar.json
+++ b/messages/ar.json
@@ -1,181 +1,181 @@
 {
-  "app": {
-    "tagline": "مدير الجداول",
-    "title": "plan1"
-  },
-  "auth": {
-    "signIn": "تسجيل الدخول باستخدام Google",
-    "signInDescription": "plan1 هي أداة جدولة شخصية مع مزامنة عبر الأجهزة. سجل الدخول باستخدام Google للبدء.",
-    "signInRequired": "سجل الدخول لاستخدام plan1"
-  },
-  "category": {
-    "confirmRemoveLabel": "تأكيد الحذف ({count})",
-    "confirmRemoveText": "سيتم حذف {count} جدول (جداول) مع هذا. انقر مرة أخرى للتأكيد.",
-    "defaultName": "افتراضي",
-    "empty": "لا توجد فئات.",
-    "fieldColor": "اللون",
-    "fieldName": "الاسم",
-    "header": "الفئات",
-    "removeButton": "إزالة",
-    "scheduleCountSuffix": "{count} جداول"
-  },
-  "common": {
-    "add": "إضافة",
-    "cancel": "إلغاء",
-    "close": "إغلاق",
-    "confirmDelete": "تأكيد الحذف",
-    "delete": "حذف",
-    "dismiss": "تجاهل",
-    "now": "الآن",
-    "retry": "إعادة المحاولة",
-    "save": "حفظ"
-  },
-  "confirmation": {
-    "scheduleAdded": "تمت إضافة الجدول"
-  },
-  "error": {
-    "featureUnavailable": "هذه الميزة غير متاحة بعد ({feature}).",
-    "loadFailedLabel": "فشل التحميل:",
-    "mutationFailed": "فشل {action}: {error}",
-    "unknown": "حدث خطأ غير متوقع. يرجى المحاولة مرة أخرى.",
-    "workingHoursInvalid": "إدخال ساعات العمل غير صالح ({reason})."
-  },
-  "loading": "جاري التحميل...",
-  "mutation": {
-    "changeTimerType": "تغيير نوع المؤقت",
-    "completeSchedule": "إكمال الجدول",
-    "extendTimer": "تمديد المؤقت",
-    "removeCategory": "إزالة الفئة",
-    "setFocus": "تعيين عرض التركيز",
-    "setTheme": "تعيين المظهر",
-    "startScheduleNow": "start schedule now",
-    "setZoom": "تعيين التكبير"
-  },
-  "nav": {
-    "categories": "الفئات",
-    "focus10h": "10س",
-    "focus12h": "12س",
-    "focus16h": "16س",
-    "focus20h": "20س",
-    "focus24h": "24س",
-    "focus4h": "4س",
-    "focus6h": "6س",
-    "focus8h": "8س",
-    "focusLabel": "تركيز",
-    "newSchedule": "جديد",
-    "themeDark": "داكن",
-    "themeLight": "فاتح",
-    "themeSystem": "تلقائي",
-    "workingHours": "ساعات",
-    "zoomIn": "تكبير",
-    "zoomOut": "تصغير"
-  },
-  "onboarding": {
-    "addFirst": "أضف أول جدول",
-    "firstSchedule": "أضف جدولك الأول لرؤيته على الشبكة الأسبوعية، والجدول الزمني لليوم، والساعة التناظرية.",
-    "welcome": "لا توجد جداول بعد"
-  },
-  "schedule": {
-    "afterLastNoneHint": "لا يوجد جدول قادم",
-    "buttonAfterLast": "next after last schedule",
-    "buttonMinus10": "10د-",
-    "buttonMinus30": "30د-",
-    "buttonPlus10": "10د+",
-    "buttonPlus30": "30د+",
-    "buttonPlusHour": "1س+",
-    "categoryAddOption": "+ إضافة فئة",
-    "chainedCheckbox": "ربط بالجدول السابق",
-    "endLabelV2": "وقت الانتهاء",
-    "endPlaceholder": "اختر المدة",
-    "fieldCategory": "الفئة",
-    "fieldDuration": "المدة (دقيقة)",
-    "fieldName": "الاسم",
-    "fieldStartHour": "ساعة البداية",
-    "fieldStartMinute": "دقيقة البداية",
-    "headerEdit": "تعديل الجدول",
-    "headerNew": "جدول جديد",
-    "hourSuffix": "س",
-    "hourTodaySuffix": "(اليوم)",
-    "hourTomorrowSuffix": "(غداً)",
-    "minuteSuffix": "د",
-    "prevChainLabel": "الجدول السابق متصل",
-    "titleDefault": "جدول جديد",
-    "warningOverlapLimit": "يمكن أن يتداخل {limit} جدول كحد أقصى في نفس الوقت. اضبط البداية/المدة أو احذف جدولاً موجوداً."
-  },
-  "serverError": {
-    "categoryHasSchedules": "الفئة تحتوي على {scheduleCount} جداول. أكد الحذف المتسلسل للإزالة.",
-    "categoryNotFound": "الفئة غير موجودة أو غير مملوكة.",
-    "scheduleNotFound": "الجدول غير موجود.",
-    "unauthorized": "تسجيل الدخول مطلوب."
-  },
-  "signIn": {
-    "cta": "تسجيل الدخول",
-    "description": "سجل الدخول إلى حساب cofounder الخاص بك لعرض وإدارة جداولك.",
-    "title": "تسجيل الدخول مطلوب"
-  },
-  "timer": {
-    "buttonComplete": "مكتمل",
-    "buttonFocus": "تركيز",
-    "buttonIdle": "خامل",
-    "categoryFallback": "؟",
-    "idleEmpty": "خامل · لا يوجد جدول نشط",
-    "labelElapsed": "منقضي",
-    "labelEndAt": "ينتهي-في",
-    "labelRemaining": "متبقي",
-    "labelTarget": "الهدف",
-    "labelUntilUpcoming": "حتى القادم",
-    "labelUpcoming": "الجدول التالي",
-    "overlapLabel": "تداخل {count}",
-    "simultaneousLabel": "متزامن · {count}",
-    "tooltipClickToFocus": "انقر للتبديل إلى التركيز",
-    "tooltipClickToIdle": "انقر للتبديل إلى خامل",
-    "typeCountdown": "العد التنازلي",
-    "typeCountup": "عد تصاعدي",
-    "typeTimer1": "timer1",
-    "buttonStartNow": "start now"
-  },
-  "topbar": {
-    "back": "العودة إلى البوابة",
-    "creditsLabel": "الأرصدة",
-    "creditsPlaceholder": "—",
-    "guest": "ضيف",
-    "languageLabel": "اللغة",
-    "logout": "تسجيل الخروج"
-  },
-  "undo": {
-    "actionLabel": "التراجع متاح",
-    "button": "تراجع"
-  },
-  "wallTime": {
-    "am": "ص",
-    "pm": "م"
-  },
-  "weekdays": [
-    "الأحد",
-    "الإثنين",
-    "الثلاثاء",
-    "الأربعاء",
-    "الخميس",
-    "الجمعة",
-    "السبت"
-  ],
-  "workingHours": {
-    "checkboxAlsoDefault": "حفظ أيضاً كافتراضي",
-    "checkboxWeekdaysOnly": "أيام الأسبوع فقط (الإثنين–الجمعة)",
-    "errorEndAfterStart": "يجب أن يكون وقت النهاية بعد وقت البداية.",
-    "errorToAfterFrom": "يجب أن يكون تاريخ الانتهاء في أو بعد تاريخ البداية.",
-    "fieldDate": "التاريخ",
-    "fieldEndTime": "وقت الانتهاء",
-    "fieldFromDate": "من",
-    "fieldStartTime": "وقت البداية",
-    "fieldToDate": "إلى",
-    "header": "ساعات العمل",
-    "tabRange": "نطاق",
-    "tabSingle": "مفرد",
-    "warningNoDates": "لا توجد تواريخ للتطبيق في النطاق. (البداية > النهاية أو تعارض أيام الأسبوع فقط)",
-    "warningTruncated": "النطاق يتجاوز {max} أيام، تمت معالجة جزء فقط. جرب نطاقاً أضيق."
-  },
-  "header": {
-    "finalEndAtSuffix": "end"
-  }
+    "app": {
+        "tagline": "مدير الجداول",
+        "title": "خطة1"
+    },
+    "auth": {
+        "signIn": "تسجيل الدخول باستخدام Google",
+        "signInDescription": "plan1 هي أداة جدولة شخصية مع مزامنة عبر الأجهزة. سجّل الدخول بحساب Google للبدء.",
+        "signInRequired": "سجل الدخول لاستخدام خطة1"
+    },
+    "category": {
+        "confirmRemoveLabel": "تأكيد الحذف ({count})",
+        "confirmRemoveText": "سيتم حذف {count} جدول (جداول) مع هذا. انقر مرة أخرى للتأكيد.",
+        "defaultName": "افتراضي",
+        "empty": "لا توجد فئات.",
+        "fieldColor": "اللون",
+        "fieldName": "الاسم",
+        "header": "الفئات",
+        "removeButton": "حذف",
+        "scheduleCountSuffix": "{count} جداول"
+    },
+    "common": {
+        "add": "إضافة",
+        "cancel": "إلغاء",
+        "close": "إغلاق",
+        "confirmDelete": "تأكيد الحذف",
+        "delete": "حذف",
+        "dismiss": "تجاهل",
+        "now": "الآن",
+        "retry": "إعادة المحاولة",
+        "save": "حفظ"
+    },
+    "confirmation": {
+        "scheduleAdded": "تمت إضافة الجدول"
+    },
+    "error": {
+        "featureUnavailable": "هذه الميزة غير متاحة بعد ({feature}).",
+        "loadFailedLabel": "فشل التحميل:",
+        "mutationFailed": "فشل في {action}: {error}",
+        "unknown": "حدث خطأ غير متوقع. يرجى المحاولة مرة أخرى.",
+        "workingHoursInvalid": "إدخال ساعات العمل غير صالح ({reason})."
+    },
+    "header": {
+        "finalEndAtSuffix": "النهاية"
+    },
+    "loading": "جاري التحميل...",
+    "mutation": {
+        "changeTimerType": "تغيير نوع المؤقت",
+        "completeSchedule": "إكمال الجدول",
+        "extendTimer": "تمديد المؤقت",
+        "removeCategory": "إزالة الفئة",
+        "setFocus": "تعيين عرض التركيز",
+        "setTheme": "تعيين المظهر",
+        "setZoom": "تعيين التكبير",
+        "startScheduleNow": "بدء الجدول الآن"
+    },
+    "nav": {
+        "categories": "الفئات",
+        "focus10h": "10س",
+        "focus12h": "12س",
+        "focus16h": "16س",
+        "focus20h": "20س",
+        "focus24h": "24س",
+        "focus4h": "4س",
+        "focus6h": "6س",
+        "focus8h": "8س",
+        "focusLabel": "التركيز",
+        "newSchedule": "جديد",
+        "themeDark": "داكن",
+        "themeLight": "فاتح",
+        "themeSystem": "تلقائي",
+        "workingHours": "ساعات",
+        "zoomIn": "تكبير",
+        "zoomOut": "تصغير"
+    },
+    "onboarding": {
+        "addFirst": "إضافة أول جدول",
+        "firstSchedule": "أضف جدولك الأول لرؤيته على الشبكة الأسبوعية والجدول الزمني اليوم والساعة التناظرية.",
+        "welcome": "لا توجد جداول بعد"
+    },
+    "schedule": {
+        "afterLastNoneHint": "لا يوجد جدول قادم",
+        "buttonAfterLast": "التالي بعد آخر جدول",
+        "buttonMinus10": "-10د",
+        "buttonMinus30": "-30د",
+        "buttonPlus10": "+10د",
+        "buttonPlus30": "+30د",
+        "buttonPlusHour": "+1س",
+        "categoryAddOption": "+ إضافة فئة",
+        "chainedCheckbox": "ربط بالجدول السابق",
+        "endLabelV2": "وقت النهاية",
+        "endPlaceholder": "اختر المدة",
+        "fieldCategory": "الفئة",
+        "fieldDuration": "المدة (دقيقة)",
+        "fieldName": "الاسم",
+        "fieldStartHour": "ساعة البداية",
+        "fieldStartMinute": "دقيقة البداية",
+        "headerEdit": "تعديل الجدول",
+        "headerNew": "جدول جديد",
+        "hourSuffix": "س",
+        "hourTodaySuffix": "(اليوم)",
+        "hourTomorrowSuffix": "(غداً)",
+        "minuteSuffix": "د",
+        "prevChainLabel": "الجدول السابق المتصل",
+        "titleDefault": "جدول جديد",
+        "warningOverlapLimit": "يمكن أن يتداخل {limit} جداول كحد أقصى في نفس الوقت. اضبط البداية/المدة أو احذف جدولاً موجوداً."
+    },
+    "serverError": {
+        "categoryHasSchedules": "الفئة تحتوي على {scheduleCount} جداول. أكد الحذف المتسلسل للإزالة.",
+        "categoryNotFound": "الفئة غير موجودة أو غير مملوكة.",
+        "scheduleNotFound": "الجدول غير موجود.",
+        "unauthorized": "تسجيل الدخول مطلوب."
+    },
+    "signIn": {
+        "cta": "تسجيل الدخول",
+        "description": "سجل الدخول إلى حساب المؤسس المشارك الخاص بك لعرض وإدارة جداولك.",
+        "title": "تسجيل الدخول مطلوب"
+    },
+    "timer": {
+        "buttonComplete": "مكتمل",
+        "buttonFocus": "التركيز",
+        "buttonIdle": "خامل",
+        "buttonStartNow": "ابدأ الآن",
+        "categoryFallback": "؟",
+        "idleEmpty": "خامل · لا يوجد جدول نشط",
+        "labelElapsed": "منقضي",
+        "labelEndAt": "ينتهي-في",
+        "labelRemaining": "متبقي",
+        "labelTarget": "هدف",
+        "labelUntilUpcoming": "حتى القادم",
+        "labelUpcoming": "الجدول التالي",
+        "overlapLabel": "تداخل {count}",
+        "simultaneousLabel": "متزامن · {count}",
+        "tooltipClickToFocus": "انقر للتبديل إلى التركيز",
+        "tooltipClickToIdle": "انقر للتبديل إلى الخمول",
+        "typeCountdown": "العد التنازلي",
+        "typeCountup": "العد التصاعدي",
+        "typeTimer1": "مؤقت1"
+    },
+    "topbar": {
+        "back": "العودة إلى البوابة",
+        "creditsLabel": "الأرصدة",
+        "creditsPlaceholder": "—",
+        "guest": "ضيف",
+        "languageLabel": "اللغة",
+        "logout": "تسجيل الخروج"
+    },
+    "undo": {
+        "actionLabel": "التراجع متاح",
+        "button": "تراجع"
+    },
+    "wallTime": {
+        "am": "ص",
+        "pm": "م"
+    },
+    "weekdays": [
+        "الأحد",
+        "الإثنين",
+        "الثلاثاء",
+        "الأربعاء",
+        "الخميس",
+        "الجمعة",
+        "السبت"
+    ],
+    "workingHours": {
+        "checkboxAlsoDefault": "حفظ أيضاً كافتراضي",
+        "checkboxWeekdaysOnly": "أيام الأسبوع فقط (الإثنين–الجمعة)",
+        "errorEndAfterStart": "يجب أن يكون وقت النهاية بعد وقت البداية.",
+        "errorToAfterFrom": "يجب أن يكون تاريخ النهاية في أو بعد تاريخ البداية.",
+        "fieldDate": "التاريخ",
+        "fieldEndTime": "وقت النهاية",
+        "fieldFromDate": "من",
+        "fieldStartTime": "وقت البداية",
+        "fieldToDate": "إلى",
+        "header": "ساعات العمل",
+        "tabRange": "النطاق",
+        "tabSingle": "مفرد",
+        "warningNoDates": "لا توجد تواريخ للتطبيق في النطاق. (البداية > النهاية أو تعارض أيام الأسبوع فقط)",
+        "warningTruncated": "النطاق يتجاوز {max} أيام، تمت معالجة جزئية فقط. جرب نطاقاً أضيق."
+    }
 }

--- a/messages/ar.json
+++ b/messages/ar.json
@@ -4,19 +4,19 @@
         "title": "plan1"
     },
     "auth": {
-        "signIn": "تسجيل الدخول باستخدام Google",
-        "signInDescription": "plan1 هي أداة جدولة شخصية مع مزامنة عبر الأجهزة. سجل الدخول باستخدام Google للبدء.",
-        "signInRequired": "سجل الدخول لاستخدام plan1"
+        "signIn": "تسجيل الدخول بواسطة Google",
+        "signInDescription": "plan1 هي أداة جدولة شخصية مع مزامنة عبر الأجهزة. سجّل الدخول باستخدام Google للبدء.",
+        "signInRequired": "سجّل الدخول لاستخدام plan1"
     },
     "category": {
         "confirmRemoveLabel": "تأكيد الحذف ({count})",
-        "confirmRemoveText": "سيتم حذف {count} جدول (جداول) مع هذا. انقر مرة أخرى للتأكيد.",
+        "confirmRemoveText": "{count} جدول/جداول سيتم حذفها مع هذا. انقر مرة أخرى للتأكيد.",
         "defaultName": "افتراضي",
         "empty": "لا توجد فئات.",
         "fieldColor": "اللون",
         "fieldName": "الاسم",
         "header": "الفئات",
-        "removeButton": "حذف",
+        "removeButton": "ح",
         "scheduleCountSuffix": "{count} جداول"
     },
     "common": {
@@ -25,7 +25,7 @@
         "close": "إغلاق",
         "confirmDelete": "تأكيد الحذف",
         "delete": "حذف",
-        "dismiss": "تجاهل",
+        "dismiss": "إغلاق",
         "now": "الآن",
         "retry": "إعادة المحاولة",
         "save": "حفظ"
@@ -49,9 +49,9 @@
         "completeSchedule": "إكمال الجدول",
         "extendTimer": "تمديد المؤقت",
         "removeCategory": "إزالة الفئة",
-        "setFocus": "تعيين عرض التركيز",
+        "setFocus": "ضبط عرض التركيز",
         "setTheme": "تعيين المظهر",
-        "setZoom": "تعيين التكبير",
+        "setZoom": "ضبط التكبير",
         "startScheduleNow": "ابدأ الجدول الآن"
     },
     "nav": {
@@ -63,8 +63,8 @@
         "focus24h": "24س",
         "focus4h": "4س",
         "focus6h": "6س",
-        "focus8h": "8س",
-        "focusLabel": "التركيز",
+        "focus8h": "8 ساعات",
+        "focusLabel": "تركيز",
         "newSchedule": "جديد",
         "themeDark": "داكن",
         "themeLight": "فاتح",
@@ -74,8 +74,8 @@
         "zoomOut": "تصغير"
     },
     "onboarding": {
-        "addFirst": "أضف أول جدول",
-        "firstSchedule": "أضف أول جدول لك لرؤيته على الشبكة الأسبوعية، والجدول الزمني لليوم، والساعة التناظرية.",
+        "addFirst": "إضافة أول جدول",
+        "firstSchedule": "أضف جدولك الأول لرؤيته على الشبكة الأسبوعية، والجدول الزمني اليومي، والساعة التناظرية.",
         "welcome": "لا توجد جداول بعد"
     },
     "schedule": {
@@ -101,9 +101,9 @@
         "hourTodaySuffix": "(اليوم)",
         "hourTomorrowSuffix": "(غداً)",
         "minuteSuffix": "د",
-        "prevChainLabel": "الجدول السابق المتصل",
+        "prevChainLabel": "الجدول السابق متصل",
         "titleDefault": "جدول جديد",
-        "warningOverlapLimit": "يمكن أن تتداخل {limit} جداول كحد أقصى في نفس الوقت. اضبط البداية/المدة أو احذف جدولاً موجوداً."
+        "warningOverlapLimit": "يمكن أن يتداخل {limit} جدول كحد أقصى في نفس الوقت. اضبط البداية/المدة أو احذف جدولاً موجوداً."
     },
     "serverError": {
         "categoryHasSchedules": "الفئة تحتوي على {scheduleCount} جداول. أكد الحذف المتتالي للإزالة.",
@@ -113,19 +113,19 @@
     },
     "signIn": {
         "cta": "تسجيل الدخول",
-        "description": "سجل الدخول إلى حساب cofounder الخاص بك لعرض وإدارة جداولك.",
+        "description": "سجّل الدخول إلى حساب المؤسس المشارك لعرض وإدارة جداولك.",
         "title": "تسجيل الدخول مطلوب"
     },
     "timer": {
         "buttonComplete": "مكتمل",
-        "buttonFocus": "التركيز",
+        "buttonFocus": "تركيز",
         "buttonIdle": "خامل",
         "buttonStartNow": "ابدأ الآن",
         "categoryFallback": "؟",
         "idleEmpty": "خامل · لا يوجد جدول نشط",
         "labelElapsed": "المنقضي",
-        "labelEndAt": "ينتهي-في",
-        "labelRemaining": "المتبقي",
+        "labelEndAt": "ينتهي في",
+        "labelRemaining": "متبقي",
         "labelTarget": "الهدف",
         "labelUntilUpcoming": "حتى القادم",
         "labelUpcoming": "الجدول التالي",
@@ -133,13 +133,13 @@
         "simultaneousLabel": "متزامن · {count}",
         "tooltipClickToFocus": "انقر للتبديل إلى التركيز",
         "tooltipClickToIdle": "انقر للتبديل إلى الخمول",
-        "typeCountdown": "العد التنازلي",
-        "typeCountup": "العد التصاعدي",
+        "typeCountdown": "عد تنازلي",
+        "typeCountup": "عد تصاعدي",
         "typeTimer1": "timer1"
     },
     "topbar": {
         "back": "العودة إلى البوابة",
-        "creditsLabel": "الأرصدة",
+        "creditsLabel": "الاعتمادات",
         "creditsPlaceholder": "—",
         "guest": "ضيف",
         "languageLabel": "اللغة",
@@ -150,12 +150,12 @@
         "button": "تراجع"
     },
     "wallTime": {
-        "am": "صباحاً",
-        "pm": "مساءً"
+        "am": "ص",
+        "pm": "م"
     },
     "weekdays": [
         "الأحد",
-        "الإثنين",
+        "الاثنين",
         "الثلاثاء",
         "الأربعاء",
         "الخميس",
@@ -163,9 +163,9 @@
         "السبت"
     ],
     "workingHours": {
-        "checkboxAlsoDefault": "احفظ أيضاً كافتراضي",
+        "checkboxAlsoDefault": "احفظ أيضاً كإعداد افتراضي",
         "checkboxWeekdaysOnly": "أيام الأسبوع فقط (الإثنين–الجمعة)",
-        "errorEndAfterStart": "يجب أن يكون وقت النهاية بعد وقت البداية.",
+        "errorEndAfterStart": "يجب أن يكون وقت الانتهاء بعد وقت البداية.",
         "errorToAfterFrom": "يجب أن يكون تاريخ النهاية في أو بعد تاريخ البداية.",
         "fieldDate": "التاريخ",
         "fieldEndTime": "وقت الانتهاء",
@@ -174,7 +174,7 @@
         "fieldToDate": "إلى",
         "header": "ساعات العمل",
         "tabRange": "النطاق",
-        "tabSingle": "فردي",
+        "tabSingle": "مفرد",
         "warningNoDates": "لا توجد تواريخ للتطبيق في النطاق. (البداية > النهاية أو تعارض أيام الأسبوع فقط)",
         "warningTruncated": "النطاق يتجاوز {max} يوم، تمت معالجة جزء فقط. جرب نطاقاً أضيق."
     }

--- a/messages/de.json
+++ b/messages/de.json
@@ -1,181 +1,181 @@
 {
-  "app": {
-    "tagline": "Zeitplanverwaltung",
-    "title": "plan1"
-  },
-  "auth": {
-    "signIn": "Mit Google anmelden",
-    "signInDescription": "plan1 ist ein persönliches Planungstool mit geräteübergreifender Synchronisation. Melden Sie sich mit Google an, um loszulegen.",
-    "signInRequired": "Anmelden, um plan1 zu verwenden"
-  },
-  "category": {
-    "confirmRemoveLabel": "Löschen bestätigen ({count})",
-    "confirmRemoveText": "{count} Zeitplan/Zeitpläne wird/werden damit gelöscht. Klicken Sie erneut zur Bestätigung.",
-    "defaultName": "Standard",
-    "empty": "Keine Kategorien.",
-    "fieldColor": "Farbe",
-    "fieldName": "Name",
-    "header": "Kategorien",
-    "removeButton": "entf",
-    "scheduleCountSuffix": "{count} Zeitpläne"
-  },
-  "common": {
-    "add": "hinzufügen",
-    "cancel": "abbrechen",
-    "close": "schließen",
-    "confirmDelete": "Löschen bestätigen",
-    "delete": "löschen",
-    "dismiss": "verwerfen",
-    "now": "jetzt",
-    "retry": "erneut versuchen",
-    "save": "speichern"
-  },
-  "confirmation": {
-    "scheduleAdded": "Zeitplan hinzugefügt"
-  },
-  "error": {
-    "featureUnavailable": "Diese Funktion ist noch nicht verfügbar ({feature}).",
-    "loadFailedLabel": "Laden fehlgeschlagen:",
-    "mutationFailed": "Fehler bei {action}: {error}",
-    "unknown": "Ein unerwarteter Fehler ist aufgetreten. Bitte versuchen Sie es erneut.",
-    "workingHoursInvalid": "Ungültige Eingabe für Arbeitszeiten ({reason})."
-  },
-  "loading": "lädt...",
-  "mutation": {
-    "changeTimerType": "Timer-Typ ändern",
-    "completeSchedule": "Zeitplan abschließen",
-    "extendTimer": "Timer verlängern",
-    "removeCategory": "Kategorie entfernen",
-    "setFocus": "Fokusansicht einstellen",
-    "setTheme": "Design einstellen",
-    "startScheduleNow": "start schedule now",
-    "setZoom": "Zoom einstellen"
-  },
-  "nav": {
-    "categories": "Kategorien",
-    "focus10h": "10h",
-    "focus12h": "12h",
-    "focus16h": "16h",
-    "focus20h": "20h",
-    "focus24h": "24h",
-    "focus4h": "4h",
-    "focus6h": "6h",
-    "focus8h": "8h",
-    "focusLabel": "Fokus",
-    "newSchedule": "neu",
-    "themeDark": "dunkel",
-    "themeLight": "hell",
-    "themeSystem": "auto",
-    "workingHours": "Stunden",
-    "zoomIn": "vergrößern",
-    "zoomOut": "verkleinern"
-  },
-  "onboarding": {
-    "addFirst": "ersten Zeitplan hinzufügen",
-    "firstSchedule": "Fügen Sie Ihren ersten Zeitplan hinzu, um ihn im Wochenraster, der heutigen Zeitachse und der analogen Uhr zu sehen.",
-    "welcome": "Noch keine Zeitpläne"
-  },
-  "schedule": {
-    "afterLastNoneHint": "kein anstehender Zeitplan",
-    "buttonAfterLast": "next after last schedule",
-    "buttonMinus10": "-10m",
-    "buttonMinus30": "-30m",
-    "buttonPlus10": "+10m",
-    "buttonPlus30": "+30m",
-    "buttonPlusHour": "+1h",
-    "categoryAddOption": "+ Kategorie hinzufügen",
-    "chainedCheckbox": "mit vorherigem Zeitplan verketten",
-    "endLabelV2": "Endzeit",
-    "endPlaceholder": "Dauer auswählen",
-    "fieldCategory": "Kategorie",
-    "fieldDuration": "Dauer (Min)",
-    "fieldName": "Name",
-    "fieldStartHour": "Startstunde",
-    "fieldStartMinute": "Startminute",
-    "headerEdit": "Zeitplan bearbeiten",
-    "headerNew": "neuer Zeitplan",
-    "hourSuffix": "h",
-    "hourTodaySuffix": "(heute)",
-    "hourTomorrowSuffix": "(morgen)",
-    "minuteSuffix": "m",
-    "prevChainLabel": "verbundener vorheriger Zeitplan",
-    "titleDefault": "Neuer Zeitplan",
-    "warningOverlapLimit": "Maximal {limit} Zeitpläne können gleichzeitig überschneiden. Passen Sie Start/Dauer an oder entfernen Sie einen bestehenden."
-  },
-  "serverError": {
-    "categoryHasSchedules": "Kategorie hat {scheduleCount} Zeitpläne. Bestätigen Sie das Löschen, um sie zu entfernen.",
-    "categoryNotFound": "Kategorie nicht gefunden oder nicht im Besitz.",
-    "scheduleNotFound": "Zeitplan nicht gefunden.",
-    "unauthorized": "Anmeldung erforderlich."
-  },
-  "signIn": {
-    "cta": "Anmelden",
-    "description": "Melden Sie sich bei Ihrem Cofounder-Konto an, um Ihre Zeitpläne anzuzeigen und zu verwalten.",
-    "title": "Anmeldung erforderlich"
-  },
-  "timer": {
-    "buttonComplete": "abschließen",
-    "buttonFocus": "Fokus",
-    "buttonIdle": "inaktiv",
-    "categoryFallback": "?",
-    "idleEmpty": "Leerlauf · kein aktiver Zeitplan",
-    "labelElapsed": "vergangen",
-    "labelEndAt": "endet um",
-    "labelRemaining": "verbleibend",
-    "labelTarget": "Ziel",
-    "labelUntilUpcoming": "bis bevorstehend",
-    "labelUpcoming": "nächster Zeitplan",
-    "overlapLabel": "Überschneidung {count}",
-    "simultaneousLabel": "gleichzeitig · {count}",
-    "tooltipClickToFocus": "klicken, um zu Fokus zu wechseln",
-    "tooltipClickToIdle": "klicken, um zu Leerlauf zu wechseln",
-    "typeCountdown": "Countdown",
-    "typeCountup": "Hochzählen",
-    "typeTimer1": "timer1",
-    "buttonStartNow": "start now"
-  },
-  "topbar": {
-    "back": "zurück zum Portal",
-    "creditsLabel": "Credits",
-    "creditsPlaceholder": "—",
-    "guest": "Gast",
-    "languageLabel": "Sprache",
-    "logout": "Abmelden"
-  },
-  "undo": {
-    "actionLabel": "Rückgängig verfügbar",
-    "button": "rückgängig"
-  },
-  "wallTime": {
-    "am": "AM",
-    "pm": "PM"
-  },
-  "weekdays": [
-    "So",
-    "Mo",
-    "Di",
-    "Mi",
-    "Do",
-    "Fr",
-    "Sa"
-  ],
-  "workingHours": {
-    "checkboxAlsoDefault": "auch als Standard speichern",
-    "checkboxWeekdaysOnly": "nur Wochentage (Mo–Fr)",
-    "errorEndAfterStart": "Endzeit muss nach Startzeit liegen.",
-    "errorToAfterFrom": "Enddatum muss am oder nach dem Startdatum liegen.",
-    "fieldDate": "Datum",
-    "fieldEndTime": "Endzeit",
-    "fieldFromDate": "von",
-    "fieldStartTime": "Startzeit",
-    "fieldToDate": "bis",
-    "header": "Arbeitszeiten",
-    "tabRange": "Bereich",
-    "tabSingle": "einzeln",
-    "warningNoDates": "Keine Daten zum Anwenden im Bereich. (Start > Ende oder Konflikt mit nur Wochentagen)",
-    "warningTruncated": "Bereich überschreitet {max} Tage, nur teilweise verarbeitet. Versuchen Sie einen kleineren Bereich."
-  },
-  "header": {
-    "finalEndAtSuffix": "end"
-  }
+    "app": {
+        "tagline": "Zeitfenster-Manager",
+        "title": "plan1"
+    },
+    "auth": {
+        "signIn": "Mit Google anmelden",
+        "signInDescription": "plan1 ist ein persönliches Zeitplan-Tool mit geräteübergreifender Synchronisation. Melden Sie sich mit Google an, um loszulegen.",
+        "signInRequired": "Anmelden um plan1 zu verwenden"
+    },
+    "category": {
+        "confirmRemoveLabel": "Entfernen bestätigen ({count})",
+        "confirmRemoveText": "{count} Zeitfenster werden hiermit gelöscht. Klicken Sie erneut zur Bestätigung.",
+        "defaultName": "Standard",
+        "empty": "Keine Kategorien.",
+        "fieldColor": "Farbe",
+        "fieldName": "Name",
+        "header": "Kategorien",
+        "removeButton": "entf",
+        "scheduleCountSuffix": "{count} Zeitfenster"
+    },
+    "common": {
+        "add": "hinzufügen",
+        "cancel": "abbrechen",
+        "close": "schließen",
+        "confirmDelete": "Löschen bestätigen",
+        "delete": "löschen",
+        "dismiss": "schließen",
+        "now": "jetzt",
+        "retry": "wiederholen",
+        "save": "speichern"
+    },
+    "confirmation": {
+        "scheduleAdded": "Zeitfenster hinzugefügt"
+    },
+    "error": {
+        "featureUnavailable": "Diese Funktion ist noch nicht verfügbar ({feature}).",
+        "loadFailedLabel": "Laden fehlgeschlagen:",
+        "mutationFailed": "{action} fehlgeschlagen: {error}",
+        "unknown": "Ein unerwarteter Fehler ist aufgetreten. Bitte versuchen Sie es erneut.",
+        "workingHoursInvalid": "Ungültige Arbeitszeiteneingabe ({reason})."
+    },
+    "header": {
+        "finalEndAtSuffix": "Ende"
+    },
+    "loading": "Lädt...",
+    "mutation": {
+        "changeTimerType": "Timer-Typ ändern",
+        "completeSchedule": "Zeitfenster abschließen",
+        "extendTimer": "Timer verlängern",
+        "removeCategory": "Kategorie entfernen",
+        "setFocus": "Fokusansicht einstellen",
+        "setTheme": "Design festlegen",
+        "setZoom": "Zoom einstellen",
+        "startScheduleNow": "Zeitfenster jetzt starten"
+    },
+    "nav": {
+        "categories": "Kategorien",
+        "focus10h": "10h",
+        "focus12h": "12h",
+        "focus16h": "16h",
+        "focus20h": "20h",
+        "focus24h": "24h",
+        "focus4h": "4h",
+        "focus6h": "6h",
+        "focus8h": "8h",
+        "focusLabel": "Fokus",
+        "newSchedule": "neu",
+        "themeDark": "dunkel",
+        "themeLight": "hell",
+        "themeSystem": "auto",
+        "workingHours": "Stunden",
+        "zoomIn": "vergrößern",
+        "zoomOut": "verkleinern"
+    },
+    "onboarding": {
+        "addFirst": "erstes Zeitfenster hinzufügen",
+        "firstSchedule": "Fügen Sie Ihr erstes Zeitfenster hinzu, um es im Wochenraster, der heutigen Zeitleiste und der analogen Uhr zu sehen.",
+        "welcome": "Noch keine Zeitfenster"
+    },
+    "schedule": {
+        "afterLastNoneHint": "kein anstehendes Zeitfenster",
+        "buttonAfterLast": "Nächstes nach letztem Zeitfenster",
+        "buttonMinus10": "-10m",
+        "buttonMinus30": "-30m",
+        "buttonPlus10": "+10m",
+        "buttonPlus30": "+30m",
+        "buttonPlusHour": "+1h",
+        "categoryAddOption": "+ Kategorie hinzufügen",
+        "chainedCheckbox": "mit vorherigem Zeitfenster verketten",
+        "endLabelV2": "Endzeit",
+        "endPlaceholder": "Dauer auswählen",
+        "fieldCategory": "Kategorie",
+        "fieldDuration": "Dauer (Min)",
+        "fieldName": "Name",
+        "fieldStartHour": "Startstunde",
+        "fieldStartMinute": "Startminute",
+        "headerEdit": "Zeitfenster bearbeiten",
+        "headerNew": "Neues Zeitfenster",
+        "hourSuffix": "h",
+        "hourTodaySuffix": "(heute)",
+        "hourTomorrowSuffix": "(morgen)",
+        "minuteSuffix": "m",
+        "prevChainLabel": "verbundenes vorheriges Zeitfenster",
+        "titleDefault": "Neues Zeitfenster",
+        "warningOverlapLimit": "Es können maximal {limit} Zeitfenster gleichzeitig überlappen. Passen Sie Start/Dauer an oder entfernen Sie ein bestehendes."
+    },
+    "serverError": {
+        "categoryHasSchedules": "Kategorie hat {scheduleCount} Zeitfenster. Bestätigen Sie Kaskadenlöschung zum Entfernen.",
+        "categoryNotFound": "Kategorie nicht gefunden oder nicht im Besitz.",
+        "scheduleNotFound": "Zeitfenster nicht gefunden.",
+        "unauthorized": "Anmeldung erforderlich."
+    },
+    "signIn": {
+        "cta": "Anmelden",
+        "description": "Melden Sie sich bei Ihrem Cofounder-Konto an, um Ihre Zeitfenster anzuzeigen und zu verwalten.",
+        "title": "Anmeldung erforderlich"
+    },
+    "timer": {
+        "buttonComplete": "abgeschlossen",
+        "buttonFocus": "Fokus",
+        "buttonIdle": "Pause",
+        "buttonStartNow": "jetzt starten",
+        "categoryFallback": "?",
+        "idleEmpty": "Pause · kein aktives Zeitfenster",
+        "labelElapsed": "vergangen",
+        "labelEndAt": "Ende-um",
+        "labelRemaining": "verbleibend",
+        "labelTarget": "Ziel",
+        "labelUntilUpcoming": "bis anstehend",
+        "labelUpcoming": "Nächstes Zeitfenster",
+        "overlapLabel": "Überschneidung {count}",
+        "simultaneousLabel": "gleichzeitig · {count}",
+        "tooltipClickToFocus": "klicken um zu Fokus zu wechseln",
+        "tooltipClickToIdle": "klicken um zu Pause zu wechseln",
+        "typeCountdown": "Countdown",
+        "typeCountup": "Hochzählen",
+        "typeTimer1": "timer1"
+    },
+    "topbar": {
+        "back": "zurück zum Portal",
+        "creditsLabel": "Danksagungen",
+        "creditsPlaceholder": "—",
+        "guest": "Gast",
+        "languageLabel": "Sprache",
+        "logout": "Abmelden"
+    },
+    "undo": {
+        "actionLabel": "Rückgängig verfügbar",
+        "button": "rückgängig"
+    },
+    "wallTime": {
+        "am": "am",
+        "pm": "pm"
+    },
+    "weekdays": [
+        "So",
+        "Mo",
+        "Di",
+        "Mi",
+        "Do",
+        "Fr",
+        "Sa"
+    ],
+    "workingHours": {
+        "checkboxAlsoDefault": "auch als Standard speichern",
+        "checkboxWeekdaysOnly": "nur Wochentage (Mo–Fr)",
+        "errorEndAfterStart": "Endzeit muss nach Startzeit liegen.",
+        "errorToAfterFrom": "Enddatum muss am oder nach dem Startdatum liegen.",
+        "fieldDate": "Datum",
+        "fieldEndTime": "Endzeit",
+        "fieldFromDate": "von",
+        "fieldStartTime": "Startzeit",
+        "fieldToDate": "bis",
+        "header": "Arbeitszeit",
+        "tabRange": "Bereich",
+        "tabSingle": "einzeln",
+        "warningNoDates": "Keine Daten im Bereich zum Anwenden. (Start > Ende oder Konflikt nur-Wochentage)",
+        "warningTruncated": "Bereich überschreitet {max} Tage, nur teilweise verarbeitet. Versuchen Sie einen kleineren Bereich."
+    }
 }

--- a/messages/de.json
+++ b/messages/de.json
@@ -1,16 +1,16 @@
 {
     "app": {
-        "tagline": "Zeitplanmanager",
-        "title": "Plan1"
+        "tagline": "Zeitplanverwaltung",
+        "title": "plan1"
     },
     "auth": {
         "signIn": "Mit Google anmelden",
-        "signInDescription": "plan1 ist ein persönliches Planungstool mit geräteübergreifender Synchronisierung. Melden Sie sich mit Google an, um loszulegen.",
-        "signInRequired": "Melden Sie sich an, um plan1 zu verwenden"
+        "signInDescription": "plan1 ist ein persönliches Planungstool mit geräteübergreifender Synchronisierung. Melden Sie sich mit Google an, um zu beginnen.",
+        "signInRequired": "Anmelden, um plan1 zu verwenden"
     },
     "category": {
-        "confirmRemoveLabel": "Entfernen bestätigen ({count})",
-        "confirmRemoveText": "{count} Zeitplan/Zeitpläne werden hiermit gelöscht. Klicken Sie erneut zur Bestätigung.",
+        "confirmRemoveLabel": "Entf. bestät. ({count})",
+        "confirmRemoveText": "{count} Zeitplan/Zeitpläne wird/werden damit gelöscht. Klicken Sie erneut zur Bestätigung.",
         "defaultName": "Standard",
         "empty": "Keine Kategorien.",
         "fieldColor": "Farbe",
@@ -25,7 +25,7 @@
         "close": "schließen",
         "confirmDelete": "Löschen bestätigen",
         "delete": "löschen",
-        "dismiss": "verwerfen",
+        "dismiss": "schließen",
         "now": "jetzt",
         "retry": "wiederholen",
         "save": "speichern"
@@ -49,7 +49,7 @@
         "completeSchedule": "Zeitplan abschließen",
         "extendTimer": "Timer verlängern",
         "removeCategory": "Kategorie entfernen",
-        "setFocus": "Fokusansicht festlegen",
+        "setFocus": "Fokusansicht einstellen",
         "setTheme": "Design festlegen",
         "setZoom": "Zoom einstellen",
         "startScheduleNow": "Zeitplan jetzt starten"
@@ -68,10 +68,10 @@
         "newSchedule": "neu",
         "themeDark": "dunkel",
         "themeLight": "hell",
-        "themeSystem": "automatisch",
+        "themeSystem": "auto",
         "workingHours": "Stunden",
-        "zoomIn": "hineinzoomen",
-        "zoomOut": "herauszoomen"
+        "zoomIn": "vergrößern",
+        "zoomOut": "verkleinern"
     },
     "onboarding": {
         "addFirst": "ersten Zeitplan hinzufügen",
@@ -79,7 +79,7 @@
         "welcome": "Noch keine Zeitpläne"
     },
     "schedule": {
-        "afterLastNoneHint": "kein anstehender Zeitplan",
+        "afterLastNoneHint": "kein bevorstehender Zeitplan",
         "buttonAfterLast": "nächster nach letztem Zeitplan",
         "buttonMinus10": "-10m",
         "buttonMinus30": "-30m",
@@ -87,7 +87,7 @@
         "buttonPlus30": "+30m",
         "buttonPlusHour": "+1h",
         "categoryAddOption": "+ Kategorie hinzufügen",
-        "chainedCheckbox": "mit vorigem Zeitplan verketten",
+        "chainedCheckbox": "an vorherigen Zeitplan ketten",
         "endLabelV2": "Endzeit",
         "endPlaceholder": "Dauer auswählen",
         "fieldCategory": "Kategorie",
@@ -101,40 +101,40 @@
         "hourTodaySuffix": "(heute)",
         "hourTomorrowSuffix": "(morgen)",
         "minuteSuffix": "m",
-        "prevChainLabel": "verbundener voriger Zeitplan",
+        "prevChainLabel": "verbundener vorheriger Zeitplan",
         "titleDefault": "Neuer Zeitplan",
         "warningOverlapLimit": "Maximal {limit} Zeitpläne können gleichzeitig überlappen. Passen Sie Start/Dauer an oder entfernen Sie einen vorhandenen."
     },
     "serverError": {
-        "categoryHasSchedules": "Kategorie hat {scheduleCount} Zeitpläne. Bestätigen Sie das kaskadierende Löschen zum Entfernen.",
+        "categoryHasSchedules": "Kategorie hat {scheduleCount} Zeitplan/Zeitpläne. Bestätigen Sie die Kaskadenlöschung zum Entfernen.",
         "categoryNotFound": "Kategorie nicht gefunden oder nicht im Besitz.",
         "scheduleNotFound": "Zeitplan nicht gefunden.",
         "unauthorized": "Anmeldung erforderlich."
     },
     "signIn": {
         "cta": "Anmelden",
-        "description": "Melden Sie sich bei Ihrem Mitgründer-Konto an, um Ihre Zeitpläne anzuzeigen und zu verwalten.",
+        "description": "Melden Sie sich bei Ihrem Cofounder-Konto an, um Ihre Zeitpläne anzuzeigen und zu verwalten.",
         "title": "Anmeldung erforderlich"
     },
     "timer": {
         "buttonComplete": "abgeschlossen",
         "buttonFocus": "Fokus",
-        "buttonIdle": "inaktiv",
+        "buttonIdle": "untätig",
         "buttonStartNow": "jetzt starten",
         "categoryFallback": "?",
-        "idleEmpty": "inaktiv · kein aktiver Zeitplan",
+        "idleEmpty": "untätig · kein aktiver Zeitplan",
         "labelElapsed": "vergangen",
-        "labelEndAt": "endet um",
+        "labelEndAt": "endet-um",
         "labelRemaining": "verbleibend",
         "labelTarget": "Ziel",
         "labelUntilUpcoming": "bis bevorstehend",
         "labelUpcoming": "nächster Zeitplan",
-        "overlapLabel": "Überlappung {count}",
+        "overlapLabel": "Überschneidung {count}",
         "simultaneousLabel": "gleichzeitig · {count}",
-        "tooltipClickToFocus": "klicken um zu fokussiert zu wechseln",
-        "tooltipClickToIdle": "klicken um zu inaktiv zu wechseln",
+        "tooltipClickToFocus": "klicken, um zu Fokus zu wechseln",
+        "tooltipClickToIdle": "klicken, um zu untätig zu wechseln",
         "typeCountdown": "Countdown",
-        "typeCountup": "hochzählen",
+        "typeCountup": "Hochzählen",
         "typeTimer1": "Timer1"
     },
     "topbar": {
@@ -150,7 +150,7 @@
         "button": "rückgängig"
     },
     "wallTime": {
-        "am": "vm",
+        "am": "am",
         "pm": "pm"
     },
     "weekdays": [
@@ -164,8 +164,8 @@
     ],
     "workingHours": {
         "checkboxAlsoDefault": "auch als Standard speichern",
-        "checkboxWeekdaysOnly": "nur Wochentage (Mo–Fr)",
-        "errorEndAfterStart": "Endzeit muss nach der Startzeit liegen.",
+        "checkboxWeekdaysOnly": "nur Wochentags (Mo–Fr)",
+        "errorEndAfterStart": "Endzeit muss nach Startzeit liegen.",
         "errorToAfterFrom": "Enddatum muss am oder nach dem Startdatum liegen.",
         "fieldDate": "Datum",
         "fieldEndTime": "Endzeit",
@@ -175,7 +175,7 @@
         "header": "Arbeitszeiten",
         "tabRange": "Bereich",
         "tabSingle": "einzeln",
-        "warningNoDates": "Keine Daten im Bereich anwendbar. (Start > Ende oder Wochentags-Konflikt)",
+        "warningNoDates": "Keine Daten zum Anwenden im Bereich. (Start > Ende oder Wochentags-Konflikt)",
         "warningTruncated": "Bereich überschreitet {max} Tage, nur teilweise verarbeitet. Versuchen Sie einen kleineren Bereich."
     }
 }

--- a/messages/de.json
+++ b/messages/de.json
@@ -1,23 +1,23 @@
 {
     "app": {
-        "tagline": "Zeitfenster-Manager",
-        "title": "plan1"
+        "tagline": "Zeitplanmanager",
+        "title": "Plan1"
     },
     "auth": {
         "signIn": "Mit Google anmelden",
-        "signInDescription": "plan1 ist ein persönliches Zeitplan-Tool mit geräteübergreifender Synchronisation. Melden Sie sich mit Google an, um loszulegen.",
-        "signInRequired": "Anmelden um plan1 zu verwenden"
+        "signInDescription": "plan1 ist ein persönliches Planungstool mit geräteübergreifender Synchronisierung. Melden Sie sich mit Google an, um loszulegen.",
+        "signInRequired": "Melden Sie sich an, um plan1 zu verwenden"
     },
     "category": {
         "confirmRemoveLabel": "Entfernen bestätigen ({count})",
-        "confirmRemoveText": "{count} Zeitfenster werden hiermit gelöscht. Klicken Sie erneut zur Bestätigung.",
+        "confirmRemoveText": "{count} Zeitplan/Zeitpläne werden hiermit gelöscht. Klicken Sie erneut zur Bestätigung.",
         "defaultName": "Standard",
         "empty": "Keine Kategorien.",
         "fieldColor": "Farbe",
         "fieldName": "Name",
         "header": "Kategorien",
         "removeButton": "entf",
-        "scheduleCountSuffix": "{count} Zeitfenster"
+        "scheduleCountSuffix": "{count} Zeitpläne"
     },
     "common": {
         "add": "hinzufügen",
@@ -25,34 +25,34 @@
         "close": "schließen",
         "confirmDelete": "Löschen bestätigen",
         "delete": "löschen",
-        "dismiss": "schließen",
+        "dismiss": "verwerfen",
         "now": "jetzt",
         "retry": "wiederholen",
         "save": "speichern"
     },
     "confirmation": {
-        "scheduleAdded": "Zeitfenster hinzugefügt"
+        "scheduleAdded": "Zeitplan hinzugefügt"
     },
     "error": {
         "featureUnavailable": "Diese Funktion ist noch nicht verfügbar ({feature}).",
         "loadFailedLabel": "Laden fehlgeschlagen:",
-        "mutationFailed": "{action} fehlgeschlagen: {error}",
+        "mutationFailed": "Fehler bei {action}: {error}",
         "unknown": "Ein unerwarteter Fehler ist aufgetreten. Bitte versuchen Sie es erneut.",
         "workingHoursInvalid": "Ungültige Arbeitszeiteneingabe ({reason})."
     },
     "header": {
         "finalEndAtSuffix": "Ende"
     },
-    "loading": "Lädt...",
+    "loading": "lädt...",
     "mutation": {
         "changeTimerType": "Timer-Typ ändern",
-        "completeSchedule": "Zeitfenster abschließen",
+        "completeSchedule": "Zeitplan abschließen",
         "extendTimer": "Timer verlängern",
         "removeCategory": "Kategorie entfernen",
-        "setFocus": "Fokusansicht einstellen",
+        "setFocus": "Fokusansicht festlegen",
         "setTheme": "Design festlegen",
         "setZoom": "Zoom einstellen",
-        "startScheduleNow": "Zeitfenster jetzt starten"
+        "startScheduleNow": "Zeitplan jetzt starten"
     },
     "nav": {
         "categories": "Kategorien",
@@ -68,26 +68,26 @@
         "newSchedule": "neu",
         "themeDark": "dunkel",
         "themeLight": "hell",
-        "themeSystem": "auto",
+        "themeSystem": "automatisch",
         "workingHours": "Stunden",
-        "zoomIn": "vergrößern",
-        "zoomOut": "verkleinern"
+        "zoomIn": "hineinzoomen",
+        "zoomOut": "herauszoomen"
     },
     "onboarding": {
-        "addFirst": "erstes Zeitfenster hinzufügen",
-        "firstSchedule": "Fügen Sie Ihr erstes Zeitfenster hinzu, um es im Wochenraster, der heutigen Zeitleiste und der analogen Uhr zu sehen.",
-        "welcome": "Noch keine Zeitfenster"
+        "addFirst": "ersten Zeitplan hinzufügen",
+        "firstSchedule": "Fügen Sie Ihren ersten Zeitplan hinzu, um ihn im Wochenraster, der heutigen Zeitleiste und der analogen Uhr zu sehen.",
+        "welcome": "Noch keine Zeitpläne"
     },
     "schedule": {
-        "afterLastNoneHint": "kein anstehendes Zeitfenster",
-        "buttonAfterLast": "Nächstes nach letztem Zeitfenster",
+        "afterLastNoneHint": "kein anstehender Zeitplan",
+        "buttonAfterLast": "nächster nach letztem Zeitplan",
         "buttonMinus10": "-10m",
         "buttonMinus30": "-30m",
         "buttonPlus10": "+10m",
         "buttonPlus30": "+30m",
         "buttonPlusHour": "+1h",
         "categoryAddOption": "+ Kategorie hinzufügen",
-        "chainedCheckbox": "mit vorherigem Zeitfenster verketten",
+        "chainedCheckbox": "mit vorigem Zeitplan verketten",
         "endLabelV2": "Endzeit",
         "endPlaceholder": "Dauer auswählen",
         "fieldCategory": "Kategorie",
@@ -95,62 +95,62 @@
         "fieldName": "Name",
         "fieldStartHour": "Startstunde",
         "fieldStartMinute": "Startminute",
-        "headerEdit": "Zeitfenster bearbeiten",
-        "headerNew": "Neues Zeitfenster",
+        "headerEdit": "Zeitplan bearbeiten",
+        "headerNew": "neuer Zeitplan",
         "hourSuffix": "h",
         "hourTodaySuffix": "(heute)",
         "hourTomorrowSuffix": "(morgen)",
         "minuteSuffix": "m",
-        "prevChainLabel": "verbundenes vorheriges Zeitfenster",
-        "titleDefault": "Neues Zeitfenster",
-        "warningOverlapLimit": "Es können maximal {limit} Zeitfenster gleichzeitig überlappen. Passen Sie Start/Dauer an oder entfernen Sie ein bestehendes."
+        "prevChainLabel": "verbundener voriger Zeitplan",
+        "titleDefault": "Neuer Zeitplan",
+        "warningOverlapLimit": "Maximal {limit} Zeitpläne können gleichzeitig überlappen. Passen Sie Start/Dauer an oder entfernen Sie einen vorhandenen."
     },
     "serverError": {
-        "categoryHasSchedules": "Kategorie hat {scheduleCount} Zeitfenster. Bestätigen Sie Kaskadenlöschung zum Entfernen.",
+        "categoryHasSchedules": "Kategorie hat {scheduleCount} Zeitpläne. Bestätigen Sie das kaskadierende Löschen zum Entfernen.",
         "categoryNotFound": "Kategorie nicht gefunden oder nicht im Besitz.",
-        "scheduleNotFound": "Zeitfenster nicht gefunden.",
+        "scheduleNotFound": "Zeitplan nicht gefunden.",
         "unauthorized": "Anmeldung erforderlich."
     },
     "signIn": {
         "cta": "Anmelden",
-        "description": "Melden Sie sich bei Ihrem Cofounder-Konto an, um Ihre Zeitfenster anzuzeigen und zu verwalten.",
+        "description": "Melden Sie sich bei Ihrem Mitgründer-Konto an, um Ihre Zeitpläne anzuzeigen und zu verwalten.",
         "title": "Anmeldung erforderlich"
     },
     "timer": {
         "buttonComplete": "abgeschlossen",
         "buttonFocus": "Fokus",
-        "buttonIdle": "Pause",
+        "buttonIdle": "inaktiv",
         "buttonStartNow": "jetzt starten",
         "categoryFallback": "?",
-        "idleEmpty": "Pause · kein aktives Zeitfenster",
+        "idleEmpty": "inaktiv · kein aktiver Zeitplan",
         "labelElapsed": "vergangen",
-        "labelEndAt": "Ende-um",
+        "labelEndAt": "endet um",
         "labelRemaining": "verbleibend",
         "labelTarget": "Ziel",
-        "labelUntilUpcoming": "bis anstehend",
-        "labelUpcoming": "Nächstes Zeitfenster",
-        "overlapLabel": "Überschneidung {count}",
+        "labelUntilUpcoming": "bis bevorstehend",
+        "labelUpcoming": "nächster Zeitplan",
+        "overlapLabel": "Überlappung {count}",
         "simultaneousLabel": "gleichzeitig · {count}",
-        "tooltipClickToFocus": "klicken um zu Fokus zu wechseln",
-        "tooltipClickToIdle": "klicken um zu Pause zu wechseln",
+        "tooltipClickToFocus": "klicken um zu fokussiert zu wechseln",
+        "tooltipClickToIdle": "klicken um zu inaktiv zu wechseln",
         "typeCountdown": "Countdown",
-        "typeCountup": "Hochzählen",
-        "typeTimer1": "timer1"
+        "typeCountup": "hochzählen",
+        "typeTimer1": "Timer1"
     },
     "topbar": {
         "back": "zurück zum Portal",
-        "creditsLabel": "Danksagungen",
+        "creditsLabel": "Credits",
         "creditsPlaceholder": "—",
         "guest": "Gast",
         "languageLabel": "Sprache",
-        "logout": "Abmelden"
+        "logout": "abmelden"
     },
     "undo": {
         "actionLabel": "Rückgängig verfügbar",
         "button": "rückgängig"
     },
     "wallTime": {
-        "am": "am",
+        "am": "vm",
         "pm": "pm"
     },
     "weekdays": [
@@ -165,17 +165,17 @@
     "workingHours": {
         "checkboxAlsoDefault": "auch als Standard speichern",
         "checkboxWeekdaysOnly": "nur Wochentage (Mo–Fr)",
-        "errorEndAfterStart": "Endzeit muss nach Startzeit liegen.",
+        "errorEndAfterStart": "Endzeit muss nach der Startzeit liegen.",
         "errorToAfterFrom": "Enddatum muss am oder nach dem Startdatum liegen.",
         "fieldDate": "Datum",
         "fieldEndTime": "Endzeit",
         "fieldFromDate": "von",
         "fieldStartTime": "Startzeit",
         "fieldToDate": "bis",
-        "header": "Arbeitszeit",
+        "header": "Arbeitszeiten",
         "tabRange": "Bereich",
         "tabSingle": "einzeln",
-        "warningNoDates": "Keine Daten im Bereich zum Anwenden. (Start > Ende oder Konflikt nur-Wochentage)",
+        "warningNoDates": "Keine Daten im Bereich anwendbar. (Start > Ende oder Wochentags-Konflikt)",
         "warningTruncated": "Bereich überschreitet {max} Tage, nur teilweise verarbeitet. Versuchen Sie einen kleineren Bereich."
     }
 }

--- a/messages/de.json
+++ b/messages/de.json
@@ -48,7 +48,8 @@
     "removeCategory": "Kategorie entfernen",
     "setFocus": "Fokusansicht einstellen",
     "setTheme": "Design einstellen",
-    "startScheduleNow": "start schedule now"
+    "startScheduleNow": "start schedule now",
+    "setZoom": "Zoom einstellen"
   },
   "nav": {
     "categories": "Kategorien",
@@ -65,7 +66,9 @@
     "themeDark": "dunkel",
     "themeLight": "hell",
     "themeSystem": "auto",
-    "workingHours": "Stunden"
+    "workingHours": "Stunden",
+    "zoomIn": "vergrößern",
+    "zoomOut": "verkleinern"
   },
   "onboarding": {
     "addFirst": "ersten Zeitplan hinzufügen",

--- a/messages/en.json
+++ b/messages/en.json
@@ -26,7 +26,9 @@
     "focus12h": "12h",
     "focus16h": "16h",
     "focus20h": "20h",
-    "focus24h": "24h"
+    "focus24h": "24h",
+    "zoomIn": "zoom in",
+    "zoomOut": "zoom out"
   },
   "common": {
     "cancel": "cancel",
@@ -59,6 +61,7 @@
     "changeTimerType": "change timer type",
     "setTheme": "set theme",
     "setFocus": "set focus view",
+    "setZoom": "set zoom",
     "startScheduleNow": "start schedule now"
   },
   "onboarding": {

--- a/messages/es.json
+++ b/messages/es.json
@@ -48,7 +48,8 @@
     "removeCategory": "eliminar categoría",
     "setFocus": "establecer vista de enfoque",
     "setTheme": "establecer tema",
-    "startScheduleNow": "start schedule now"
+    "startScheduleNow": "start schedule now",
+    "setZoom": "establecer zoom"
   },
   "nav": {
     "categories": "categorías",
@@ -65,7 +66,9 @@
     "themeDark": "oscuro",
     "themeLight": "claro",
     "themeSystem": "auto",
-    "workingHours": "horas"
+    "workingHours": "horas",
+    "zoomIn": "acercar",
+    "zoomOut": "alejar"
   },
   "onboarding": {
     "addFirst": "añadir primer horario",

--- a/messages/es.json
+++ b/messages/es.json
@@ -10,9 +10,9 @@
     },
     "category": {
         "confirmRemoveLabel": "confirmar eliminar ({count})",
-        "confirmRemoveText": "{count} horario(s) serán eliminados con esto. Haz clic de nuevo para confirmar.",
+        "confirmRemoveText": "{count} horario(s) se eliminará(n) con esto. Haz clic de nuevo para confirmar.",
         "defaultName": "predeterminado",
-        "empty": "Sin categorías.",
+        "empty": "No hay categorías.",
         "fieldColor": "color",
         "fieldName": "nombre",
         "header": "categorías",
@@ -35,10 +35,10 @@
     },
     "error": {
         "featureUnavailable": "Esta función aún no está disponible ({feature}).",
-        "loadFailedLabel": "error al cargar:",
+        "loadFailedLabel": "carga fallida:",
         "mutationFailed": "Error al {action}: {error}",
         "unknown": "Ocurrió un error inesperado. Por favor, inténtalo de nuevo.",
-        "workingHoursInvalid": "Entrada de horas laborales inválida ({reason})."
+        "workingHoursInvalid": "Entrada de horas de trabajo inválida ({reason})."
     },
     "header": {
         "finalEndAtSuffix": "fin"
@@ -46,7 +46,7 @@
     "loading": "cargando...",
     "mutation": {
         "changeTimerType": "cambiar tipo de temporizador",
-        "completeSchedule": "horario completo",
+        "completeSchedule": "completar horario",
         "extendTimer": "extender temporizador",
         "removeCategory": "eliminar categoría",
         "setFocus": "establecer vista de enfoque",
@@ -79,7 +79,7 @@
         "welcome": "Aún no hay horarios"
     },
     "schedule": {
-        "afterLastNoneHint": "no hay próximo horario",
+        "afterLastNoneHint": "no hay horario próximo",
         "buttonAfterLast": "siguiente después del último horario",
         "buttonMinus10": "-10m",
         "buttonMinus30": "-30m",
@@ -106,14 +106,14 @@
         "warningOverlapLimit": "Como máximo {limit} horarios pueden superponerse al mismo tiempo. Ajusta el inicio/duración o elimina uno existente."
     },
     "serverError": {
-        "categoryHasSchedules": "La categoría tiene {scheduleCount} horarios. Confirma la eliminación en cascada para eliminar.",
+        "categoryHasSchedules": "La categoría tiene {scheduleCount} horarios. Confirma eliminación en cascada para eliminar.",
         "categoryNotFound": "Categoría no encontrada o no es de tu propiedad.",
         "scheduleNotFound": "Horario no encontrado.",
         "unauthorized": "Inicio de sesión requerido."
     },
     "signIn": {
         "cta": "Iniciar sesión",
-        "description": "Inicia sesión en tu cuenta de cofundador para ver y gestionar tus horarios.",
+        "description": "Inicia sesión en tu cuenta de cofundador para ver y administrar tus horarios.",
         "title": "Inicio de sesión requerido"
     },
     "timer": {
@@ -124,18 +124,18 @@
         "categoryFallback": "?",
         "idleEmpty": "inactivo · sin horario activo",
         "labelElapsed": "transcurrido",
-        "labelEndAt": "terminar-a",
+        "labelEndAt": "termina-en",
         "labelRemaining": "restante",
         "labelTarget": "objetivo",
         "labelUntilUpcoming": "hasta el próximo",
         "labelUpcoming": "siguiente horario",
-        "overlapLabel": "superponer {count}",
+        "overlapLabel": "superposición {count}",
         "simultaneousLabel": "simultáneos · {count}",
         "tooltipClickToFocus": "haz clic para cambiar a enfoque",
         "tooltipClickToIdle": "haz clic para cambiar a inactivo",
-        "typeCountdown": "conteo regresivo",
-        "typeCountup": "conteo ascendente",
-        "typeTimer1": "temporizador1"
+        "typeCountdown": "cuenta regresiva",
+        "typeCountup": "cuenta progresiva",
+        "typeTimer1": "timer1"
     },
     "topbar": {
         "back": "volver al portal",
@@ -171,11 +171,11 @@
         "fieldEndTime": "hora de fin",
         "fieldFromDate": "desde",
         "fieldStartTime": "hora de inicio",
-        "fieldToDate": "hasta",
-        "header": "horas laborales",
+        "fieldToDate": "a",
+        "header": "horas de trabajo",
         "tabRange": "rango",
         "tabSingle": "único",
-        "warningNoDates": "No hay fechas para aplicar en el rango. (inicio > fin o conflicto de solo días laborales)",
+        "warningNoDates": "No hay fechas para aplicar en el rango. (inicio > fin o conflicto de solo días laborables)",
         "warningTruncated": "El rango excede {max} días, solo se procesó parcialmente. Intenta un rango más estrecho."
     }
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -6,13 +6,13 @@
     "auth": {
         "signIn": "Iniciar sesión con Google",
         "signInDescription": "plan1 es una herramienta de horarios personal con sincronización entre dispositivos. Inicia sesión con Google para comenzar.",
-        "signInRequired": "Inicia sesión para usar plan1"
+        "signInRequired": "Iniciar sesión para usar plan1"
     },
     "category": {
-        "confirmRemoveLabel": "confirmar eliminar ({count})",
-        "confirmRemoveText": "{count} horario(s) se eliminará(n) con esto. Haz clic de nuevo para confirmar.",
+        "confirmRemoveLabel": "confirmar eliminación ({count})",
+        "confirmRemoveText": "{count} horario(s) serán eliminados con esto. Haz clic de nuevo para confirmar.",
         "defaultName": "predeterminado",
-        "empty": "No hay categorías.",
+        "empty": "Sin categorías.",
         "fieldColor": "color",
         "fieldName": "nombre",
         "header": "categorías",
@@ -34,9 +34,9 @@
         "scheduleAdded": "Horario añadido"
     },
     "error": {
-        "featureUnavailable": "Esta función aún no está disponible ({feature}).",
+        "featureUnavailable": "Esta funcionalidad aún no está disponible ({feature}).",
         "loadFailedLabel": "carga fallida:",
-        "mutationFailed": "Error al {action}: {error}",
+        "mutationFailed": "Fallo al {action}: {error}",
         "unknown": "Ocurrió un error inesperado. Por favor, inténtalo de nuevo.",
         "workingHoursInvalid": "Entrada de horas de trabajo inválida ({reason})."
     },
@@ -46,7 +46,7 @@
     "loading": "cargando...",
     "mutation": {
         "changeTimerType": "cambiar tipo de temporizador",
-        "completeSchedule": "completar horario",
+        "completeSchedule": "horario completo",
         "extendTimer": "extender temporizador",
         "removeCategory": "eliminar categoría",
         "setFocus": "establecer vista de enfoque",
@@ -79,7 +79,7 @@
         "welcome": "Aún no hay horarios"
     },
     "schedule": {
-        "afterLastNoneHint": "no hay horario próximo",
+        "afterLastNoneHint": "sin horario próximo",
         "buttonAfterLast": "siguiente después del último horario",
         "buttonMinus10": "-10m",
         "buttonMinus30": "-30m",
@@ -87,7 +87,7 @@
         "buttonPlus30": "+30m",
         "buttonPlusHour": "+1h",
         "categoryAddOption": "+ añadir categoría",
-        "chainedCheckbox": "encadenar al horario anterior",
+        "chainedCheckbox": "encadenar con horario anterior",
         "endLabelV2": "hora de fin",
         "endPlaceholder": "seleccionar duración",
         "fieldCategory": "categoría",
@@ -103,39 +103,39 @@
         "minuteSuffix": "m",
         "prevChainLabel": "horario anterior conectado",
         "titleDefault": "Nuevo horario",
-        "warningOverlapLimit": "Como máximo {limit} horarios pueden superponerse al mismo tiempo. Ajusta el inicio/duración o elimina uno existente."
+        "warningOverlapLimit": "Como máximo {limit} horarios pueden superponerse al mismo tiempo. Ajusta inicio/duración o elimina uno existente."
     },
     "serverError": {
-        "categoryHasSchedules": "La categoría tiene {scheduleCount} horarios. Confirma eliminación en cascada para eliminar.",
+        "categoryHasSchedules": "La categoría tiene {scheduleCount} horarios. Confirmar eliminación en cascada para remover.",
         "categoryNotFound": "Categoría no encontrada o no es de tu propiedad.",
         "scheduleNotFound": "Horario no encontrado.",
         "unauthorized": "Inicio de sesión requerido."
     },
     "signIn": {
         "cta": "Iniciar sesión",
-        "description": "Inicia sesión en tu cuenta de cofundador para ver y administrar tus horarios.",
+        "description": "Inicia sesión en tu cuenta de cofundador para ver y gestionar tus horarios.",
         "title": "Inicio de sesión requerido"
     },
     "timer": {
         "buttonComplete": "completar",
         "buttonFocus": "enfoque",
         "buttonIdle": "inactivo",
-        "buttonStartNow": "iniciar ahora",
+        "buttonStartNow": "comenzar ahora",
         "categoryFallback": "?",
         "idleEmpty": "inactivo · sin horario activo",
         "labelElapsed": "transcurrido",
-        "labelEndAt": "termina-en",
+        "labelEndAt": "terminar-a",
         "labelRemaining": "restante",
         "labelTarget": "objetivo",
-        "labelUntilUpcoming": "hasta el próximo",
+        "labelUntilUpcoming": "hasta próximo",
         "labelUpcoming": "siguiente horario",
         "overlapLabel": "superposición {count}",
-        "simultaneousLabel": "simultáneos · {count}",
+        "simultaneousLabel": "simultáneo · {count}",
         "tooltipClickToFocus": "haz clic para cambiar a enfoque",
         "tooltipClickToIdle": "haz clic para cambiar a inactivo",
         "typeCountdown": "cuenta regresiva",
         "typeCountup": "cuenta progresiva",
-        "typeTimer1": "timer1"
+        "typeTimer1": "temporizador1"
     },
     "topbar": {
         "back": "volver al portal",
@@ -165,13 +165,13 @@
     "workingHours": {
         "checkboxAlsoDefault": "guardar también como predeterminado",
         "checkboxWeekdaysOnly": "solo días laborables (lun–vie)",
-        "errorEndAfterStart": "La hora de fin debe ser posterior a la hora de inicio.",
-        "errorToAfterFrom": "La fecha de fin debe ser igual o posterior a la fecha de inicio.",
+        "errorEndAfterStart": "La hora de finalización debe ser posterior a la hora de inicio.",
+        "errorToAfterFrom": "La fecha de finalización debe ser igual o posterior a la fecha de inicio.",
         "fieldDate": "fecha",
         "fieldEndTime": "hora de fin",
         "fieldFromDate": "desde",
         "fieldStartTime": "hora de inicio",
-        "fieldToDate": "a",
+        "fieldToDate": "hasta",
         "header": "horas de trabajo",
         "tabRange": "rango",
         "tabSingle": "único",

--- a/messages/es.json
+++ b/messages/es.json
@@ -1,181 +1,181 @@
 {
-  "app": {
-    "tagline": "gestor de horarios",
-    "title": "plan1"
-  },
-  "auth": {
-    "signIn": "Iniciar sesión con Google",
-    "signInDescription": "plan1 es una herramienta de horarios personal con sincronización entre dispositivos. Inicia sesión con Google para comenzar.",
-    "signInRequired": "Inicia sesión para usar plan1"
-  },
-  "category": {
-    "confirmRemoveLabel": "confirmar eliminar ({count})",
-    "confirmRemoveText": "{count} horario(s) se eliminarán con esto. Haz clic de nuevo para confirmar.",
-    "defaultName": "predeterminado",
-    "empty": "Sin categorías.",
-    "fieldColor": "color",
-    "fieldName": "nombre",
-    "header": "categorías",
-    "removeButton": "eliminar",
-    "scheduleCountSuffix": "{count} horarios"
-  },
-  "common": {
-    "add": "añadir",
-    "cancel": "cancelar",
-    "close": "cerrar",
-    "confirmDelete": "confirmar eliminación",
-    "delete": "eliminar",
-    "dismiss": "descartar",
-    "now": "ahora",
-    "retry": "reintentar",
-    "save": "guardar"
-  },
-  "confirmation": {
-    "scheduleAdded": "Horario añadido"
-  },
-  "error": {
-    "featureUnavailable": "Esta función aún no está disponible ({feature}).",
-    "loadFailedLabel": "carga fallida:",
-    "mutationFailed": "Error al {action}: {error}",
-    "unknown": "Ocurrió un error inesperado. Por favor, inténtalo de nuevo.",
-    "workingHoursInvalid": "Entrada de horas de trabajo inválida ({reason})."
-  },
-  "loading": "cargando...",
-  "mutation": {
-    "changeTimerType": "cambiar tipo de temporizador",
-    "completeSchedule": "completar horario",
-    "extendTimer": "extender temporizador",
-    "removeCategory": "eliminar categoría",
-    "setFocus": "establecer vista de enfoque",
-    "setTheme": "establecer tema",
-    "startScheduleNow": "start schedule now",
-    "setZoom": "establecer zoom"
-  },
-  "nav": {
-    "categories": "categorías",
-    "focus10h": "10h",
-    "focus12h": "12h",
-    "focus16h": "16h",
-    "focus20h": "20h",
-    "focus24h": "24h",
-    "focus4h": "4h",
-    "focus6h": "6h",
-    "focus8h": "8h",
-    "focusLabel": "enfoque",
-    "newSchedule": "nuevo",
-    "themeDark": "oscuro",
-    "themeLight": "claro",
-    "themeSystem": "auto",
-    "workingHours": "horas",
-    "zoomIn": "acercar",
-    "zoomOut": "alejar"
-  },
-  "onboarding": {
-    "addFirst": "añadir primer horario",
-    "firstSchedule": "Añade tu primer horario para verlo en la cuadrícula semanal, la línea de tiempo de hoy y el reloj analógico.",
-    "welcome": "Aún no hay horarios"
-  },
-  "schedule": {
-    "afterLastNoneHint": "sin horario próximo",
-    "buttonAfterLast": "next after last schedule",
-    "buttonMinus10": "-10m",
-    "buttonMinus30": "-30m",
-    "buttonPlus10": "+10m",
-    "buttonPlus30": "+30m",
-    "buttonPlusHour": "+1h",
-    "categoryAddOption": "+ añadir categoría",
-    "chainedCheckbox": "encadenar al horario anterior",
-    "endLabelV2": "hora de finalización",
-    "endPlaceholder": "seleccionar duración",
-    "fieldCategory": "categoría",
-    "fieldDuration": "duración (min)",
-    "fieldName": "nombre",
-    "fieldStartHour": "hora de inicio",
-    "fieldStartMinute": "minuto de inicio",
-    "headerEdit": "editar horario",
-    "headerNew": "nuevo horario",
-    "hourSuffix": "h",
-    "hourTodaySuffix": "(hoy)",
-    "hourTomorrowSuffix": "(mañana)",
-    "minuteSuffix": "m",
-    "prevChainLabel": "horario anterior conectado",
-    "titleDefault": "Nuevo horario",
-    "warningOverlapLimit": "Como máximo {limit} horarios pueden superponerse al mismo tiempo. Ajusta inicio/duración o elimina uno existente."
-  },
-  "serverError": {
-    "categoryHasSchedules": "La categoría tiene {scheduleCount} horarios. Confirma eliminación en cascada para eliminar.",
-    "categoryNotFound": "Categoría no encontrada o no es de tu propiedad.",
-    "scheduleNotFound": "Horario no encontrado.",
-    "unauthorized": "Inicio de sesión requerido."
-  },
-  "signIn": {
-    "cta": "Iniciar sesión",
-    "description": "Inicia sesión en tu cuenta de cofundador para ver y gestionar tus horarios.",
-    "title": "Inicio de sesión requerido"
-  },
-  "timer": {
-    "buttonComplete": "completar",
-    "buttonFocus": "enfoque",
-    "buttonIdle": "inactivo",
-    "categoryFallback": "?",
-    "idleEmpty": "inactivo · sin horario activo",
-    "labelElapsed": "transcurrido",
-    "labelEndAt": "termina-a",
-    "labelRemaining": "restante",
-    "labelTarget": "objetivo",
-    "labelUntilUpcoming": "hasta próximo",
-    "labelUpcoming": "siguiente horario",
-    "overlapLabel": "superposición {count}",
-    "simultaneousLabel": "simultáneo · {count}",
-    "tooltipClickToFocus": "haz clic para cambiar a enfoque",
-    "tooltipClickToIdle": "haz clic para cambiar a inactivo",
-    "typeCountdown": "cuenta regresiva",
-    "typeCountup": "contador",
-    "typeTimer1": "temporizador1",
-    "buttonStartNow": "start now"
-  },
-  "topbar": {
-    "back": "volver al portal",
-    "creditsLabel": "créditos",
-    "creditsPlaceholder": "—",
-    "guest": "invitado",
-    "languageLabel": "idioma",
-    "logout": "cerrar sesión"
-  },
-  "undo": {
-    "actionLabel": "deshacer disponible",
-    "button": "deshacer"
-  },
-  "wallTime": {
-    "am": "am",
-    "pm": "pm"
-  },
-  "weekdays": [
-    "dom",
-    "lun",
-    "mar",
-    "mié",
-    "jue",
-    "vie",
-    "sáb"
-  ],
-  "workingHours": {
-    "checkboxAlsoDefault": "guardar también como predeterminado",
-    "checkboxWeekdaysOnly": "solo días laborables (lun–vie)",
-    "errorEndAfterStart": "La hora de finalización debe ser posterior a la hora de inicio.",
-    "errorToAfterFrom": "La fecha de finalización debe ser igual o posterior a la fecha de inicio.",
-    "fieldDate": "fecha",
-    "fieldEndTime": "hora de finalización",
-    "fieldFromDate": "desde",
-    "fieldStartTime": "hora de inicio",
-    "fieldToDate": "a",
-    "header": "horas laborables",
-    "tabRange": "rango",
-    "tabSingle": "individual",
-    "warningNoDates": "No hay fechas para aplicar en el rango. (inicio > fin o conflicto de solo días laborables)",
-    "warningTruncated": "El rango excede {max} días, solo se procesó parcialmente. Intenta un rango más estrecho."
-  },
-  "header": {
-    "finalEndAtSuffix": "end"
-  }
+    "app": {
+        "tagline": "gestor de horarios",
+        "title": "plan1"
+    },
+    "auth": {
+        "signIn": "Iniciar sesión con Google",
+        "signInDescription": "plan1 es una herramienta de horarios personal con sincronización entre dispositivos. Inicia sesión con Google para comenzar.",
+        "signInRequired": "Inicia sesión para usar plan1"
+    },
+    "category": {
+        "confirmRemoveLabel": "confirmar eliminar ({count})",
+        "confirmRemoveText": "{count} horario(s) serán eliminados con esto. Haz clic de nuevo para confirmar.",
+        "defaultName": "predeterminado",
+        "empty": "Sin categorías.",
+        "fieldColor": "color",
+        "fieldName": "nombre",
+        "header": "categorías",
+        "removeButton": "eliminar",
+        "scheduleCountSuffix": "{count} horarios"
+    },
+    "common": {
+        "add": "añadir",
+        "cancel": "cancelar",
+        "close": "cerrar",
+        "confirmDelete": "confirmar eliminación",
+        "delete": "eliminar",
+        "dismiss": "descartar",
+        "now": "ahora",
+        "retry": "reintentar",
+        "save": "guardar"
+    },
+    "confirmation": {
+        "scheduleAdded": "Horario añadido"
+    },
+    "error": {
+        "featureUnavailable": "Esta función aún no está disponible ({feature}).",
+        "loadFailedLabel": "error al cargar:",
+        "mutationFailed": "Error al {action}: {error}",
+        "unknown": "Ocurrió un error inesperado. Por favor, inténtalo de nuevo.",
+        "workingHoursInvalid": "Entrada de horas laborales inválida ({reason})."
+    },
+    "header": {
+        "finalEndAtSuffix": "fin"
+    },
+    "loading": "cargando...",
+    "mutation": {
+        "changeTimerType": "cambiar tipo de temporizador",
+        "completeSchedule": "horario completo",
+        "extendTimer": "extender temporizador",
+        "removeCategory": "eliminar categoría",
+        "setFocus": "establecer vista de enfoque",
+        "setTheme": "establecer tema",
+        "setZoom": "establecer zoom",
+        "startScheduleNow": "iniciar horario ahora"
+    },
+    "nav": {
+        "categories": "categorías",
+        "focus10h": "10h",
+        "focus12h": "12h",
+        "focus16h": "16h",
+        "focus20h": "20h",
+        "focus24h": "24h",
+        "focus4h": "4h",
+        "focus6h": "6h",
+        "focus8h": "8h",
+        "focusLabel": "enfoque",
+        "newSchedule": "nuevo",
+        "themeDark": "oscuro",
+        "themeLight": "claro",
+        "themeSystem": "auto",
+        "workingHours": "horas",
+        "zoomIn": "acercar",
+        "zoomOut": "alejar"
+    },
+    "onboarding": {
+        "addFirst": "añadir primer horario",
+        "firstSchedule": "Añade tu primer horario para verlo en la cuadrícula semanal, la línea de tiempo de hoy y el reloj analógico.",
+        "welcome": "Aún no hay horarios"
+    },
+    "schedule": {
+        "afterLastNoneHint": "no hay próximo horario",
+        "buttonAfterLast": "siguiente después del último horario",
+        "buttonMinus10": "-10m",
+        "buttonMinus30": "-30m",
+        "buttonPlus10": "+10m",
+        "buttonPlus30": "+30m",
+        "buttonPlusHour": "+1h",
+        "categoryAddOption": "+ añadir categoría",
+        "chainedCheckbox": "encadenar al horario anterior",
+        "endLabelV2": "hora de fin",
+        "endPlaceholder": "seleccionar duración",
+        "fieldCategory": "categoría",
+        "fieldDuration": "duración (min)",
+        "fieldName": "nombre",
+        "fieldStartHour": "hora de inicio",
+        "fieldStartMinute": "minuto de inicio",
+        "headerEdit": "editar horario",
+        "headerNew": "nuevo horario",
+        "hourSuffix": "h",
+        "hourTodaySuffix": "(hoy)",
+        "hourTomorrowSuffix": "(mañana)",
+        "minuteSuffix": "m",
+        "prevChainLabel": "horario anterior conectado",
+        "titleDefault": "Nuevo horario",
+        "warningOverlapLimit": "Como máximo {limit} horarios pueden superponerse al mismo tiempo. Ajusta el inicio/duración o elimina uno existente."
+    },
+    "serverError": {
+        "categoryHasSchedules": "La categoría tiene {scheduleCount} horarios. Confirma la eliminación en cascada para eliminar.",
+        "categoryNotFound": "Categoría no encontrada o no es de tu propiedad.",
+        "scheduleNotFound": "Horario no encontrado.",
+        "unauthorized": "Inicio de sesión requerido."
+    },
+    "signIn": {
+        "cta": "Iniciar sesión",
+        "description": "Inicia sesión en tu cuenta de cofundador para ver y gestionar tus horarios.",
+        "title": "Inicio de sesión requerido"
+    },
+    "timer": {
+        "buttonComplete": "completar",
+        "buttonFocus": "enfoque",
+        "buttonIdle": "inactivo",
+        "buttonStartNow": "iniciar ahora",
+        "categoryFallback": "?",
+        "idleEmpty": "inactivo · sin horario activo",
+        "labelElapsed": "transcurrido",
+        "labelEndAt": "terminar-a",
+        "labelRemaining": "restante",
+        "labelTarget": "objetivo",
+        "labelUntilUpcoming": "hasta el próximo",
+        "labelUpcoming": "siguiente horario",
+        "overlapLabel": "superponer {count}",
+        "simultaneousLabel": "simultáneos · {count}",
+        "tooltipClickToFocus": "haz clic para cambiar a enfoque",
+        "tooltipClickToIdle": "haz clic para cambiar a inactivo",
+        "typeCountdown": "conteo regresivo",
+        "typeCountup": "conteo ascendente",
+        "typeTimer1": "temporizador1"
+    },
+    "topbar": {
+        "back": "volver al portal",
+        "creditsLabel": "créditos",
+        "creditsPlaceholder": "—",
+        "guest": "invitado",
+        "languageLabel": "idioma",
+        "logout": "cerrar sesión"
+    },
+    "undo": {
+        "actionLabel": "deshacer disponible",
+        "button": "deshacer"
+    },
+    "wallTime": {
+        "am": "am",
+        "pm": "pm"
+    },
+    "weekdays": [
+        "dom",
+        "lun",
+        "mar",
+        "mié",
+        "jue",
+        "vie",
+        "sáb"
+    ],
+    "workingHours": {
+        "checkboxAlsoDefault": "guardar también como predeterminado",
+        "checkboxWeekdaysOnly": "solo días laborables (lun–vie)",
+        "errorEndAfterStart": "La hora de fin debe ser posterior a la hora de inicio.",
+        "errorToAfterFrom": "La fecha de fin debe ser igual o posterior a la fecha de inicio.",
+        "fieldDate": "fecha",
+        "fieldEndTime": "hora de fin",
+        "fieldFromDate": "desde",
+        "fieldStartTime": "hora de inicio",
+        "fieldToDate": "hasta",
+        "header": "horas laborales",
+        "tabRange": "rango",
+        "tabSingle": "único",
+        "warningNoDates": "No hay fechas para aplicar en el rango. (inicio > fin o conflicto de solo días laborales)",
+        "warningTruncated": "El rango excede {max} días, solo se procesó parcialmente. Intenta un rango más estrecho."
+    }
 }

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -5,12 +5,12 @@
     },
     "auth": {
         "signIn": "Se connecter avec Google",
-        "signInDescription": "plan1 est un outil de planification personnel avec synchronisation multi-appareils. Connectez-vous avec Google pour commencer.",
+        "signInDescription": "plan1 est un outil d'horaire personnel avec synchronisation multi-appareils. Connectez-vous avec Google pour commencer.",
         "signInRequired": "Connectez-vous pour utiliser plan1"
     },
     "category": {
         "confirmRemoveLabel": "confirmer suppr ({count})",
-        "confirmRemoveText": "{count} horaire(s) seront supprimés avec ceci. Cliquez à nouveau pour confirmer.",
+        "confirmRemoveText": "{count} horaire(s) sera/seront supprimé(s) avec ceci. Cliquez à nouveau pour confirmer.",
         "defaultName": "par défaut",
         "empty": "Aucune catégorie.",
         "fieldColor": "couleur",
@@ -36,9 +36,9 @@
     "error": {
         "featureUnavailable": "Cette fonctionnalité n'est pas encore disponible ({feature}).",
         "loadFailedLabel": "échec du chargement :",
-        "mutationFailed": "Échec de {action} : {error}",
+        "mutationFailed": "Échec de {action}: {error}",
         "unknown": "Une erreur inattendue s'est produite. Veuillez réessayer.",
-        "workingHoursInvalid": "Saisie d'heures de travail invalide ({reason})."
+        "workingHoursInvalid": "Saisie des heures de travail invalide ({reason})."
     },
     "header": {
         "finalEndAtSuffix": "fin"
@@ -49,7 +49,7 @@
         "completeSchedule": "terminer l'horaire",
         "extendTimer": "prolonger le minuteur",
         "removeCategory": "supprimer la catégorie",
-        "setFocus": "définir la vue focus",
+        "setFocus": "définir la vue concentration",
         "setTheme": "définir le thème",
         "setZoom": "définir le zoom",
         "startScheduleNow": "démarrer l'horaire maintenant"
@@ -64,7 +64,7 @@
         "focus4h": "4h",
         "focus6h": "6h",
         "focus8h": "8h",
-        "focusLabel": "focus",
+        "focusLabel": "concentration",
         "newSchedule": "nouveau",
         "themeDark": "sombre",
         "themeLight": "clair",
@@ -75,8 +75,8 @@
     },
     "onboarding": {
         "addFirst": "ajouter le premier horaire",
-        "firstSchedule": "Ajoutez votre premier horaire pour le voir sur la grille hebdomadaire, la chronologie du jour et l'horloge analogique.",
-        "welcome": "Aucun horaire pour le moment"
+        "firstSchedule": "Ajoutez votre premier horaire pour le voir sur la grille hebdomadaire, la chronologie d'aujourd'hui et l'horloge analogique.",
+        "welcome": "Aucun horaire pour l'instant"
     },
     "schedule": {
         "afterLastNoneHint": "aucun horaire à venir",
@@ -87,7 +87,7 @@
         "buttonPlus30": "+30m",
         "buttonPlusHour": "+1h",
         "categoryAddOption": "+ ajouter une catégorie",
-        "chainedCheckbox": "enchaîner à l'horaire précédent",
+        "chainedCheckbox": "chaîner à l'horaire précédent",
         "endLabelV2": "heure de fin",
         "endPlaceholder": "sélectionner la durée",
         "fieldCategory": "catégorie",
@@ -103,7 +103,7 @@
         "minuteSuffix": "m",
         "prevChainLabel": "horaire précédent connecté",
         "titleDefault": "Nouvel horaire",
-        "warningOverlapLimit": "Au maximum {limit} horaires peuvent se chevaucher en même temps. Ajustez le début/durée ou supprimez-en un existant."
+        "warningOverlapLimit": "Au maximum {limit} horaires peuvent se chevaucher en même temps. Ajustez le début/la durée ou supprimez-en un existant."
     },
     "serverError": {
         "categoryHasSchedules": "La catégorie a {scheduleCount} horaires. Confirmez la suppression en cascade pour retirer.",
@@ -118,7 +118,7 @@
     },
     "timer": {
         "buttonComplete": "terminé",
-        "buttonFocus": "focus",
+        "buttonFocus": "concentration",
         "buttonIdle": "inactif",
         "buttonStartNow": "commencer maintenant",
         "categoryFallback": "?",
@@ -131,10 +131,10 @@
         "labelUpcoming": "horaire suivant",
         "overlapLabel": "chevauchement {count}",
         "simultaneousLabel": "simultané · {count}",
-        "tooltipClickToFocus": "cliquer pour passer en focus",
+        "tooltipClickToFocus": "cliquer pour passer en concentration",
         "tooltipClickToIdle": "cliquer pour passer en inactif",
         "typeCountdown": "compte à rebours",
-        "typeCountup": "compteur",
+        "typeCountup": "compte à rebours croissant",
         "typeTimer1": "minuteur1"
     },
     "topbar": {
@@ -164,7 +164,7 @@
     ],
     "workingHours": {
         "checkboxAlsoDefault": "enregistrer aussi par défaut",
-        "checkboxWeekdaysOnly": "jours de semaine uniquement (lun–ven)",
+        "checkboxWeekdaysOnly": "jours ouvrables uniquement (lun–ven)",
         "errorEndAfterStart": "L'heure de fin doit être après l'heure de début.",
         "errorToAfterFrom": "La date de fin doit être égale ou postérieure à la date de début.",
         "fieldDate": "date",
@@ -175,7 +175,7 @@
         "header": "heures de travail",
         "tabRange": "plage",
         "tabSingle": "unique",
-        "warningNoDates": "Aucune date à appliquer dans la plage. (début > fin ou conflit jours de semaine uniquement)",
+        "warningNoDates": "Aucune date à appliquer dans la plage. (début > fin ou conflit jours ouvrables uniquement)",
         "warningTruncated": "La plage dépasse {max} jours, seulement partiellement traité. Essayez une plage plus étroite."
     }
 }

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -48,7 +48,8 @@
     "removeCategory": "supprimer la catégorie",
     "setFocus": "définir la vue focus",
     "setTheme": "définir le thème",
-    "startScheduleNow": "start schedule now"
+    "startScheduleNow": "start schedule now",
+    "setZoom": "définir le zoom"
   },
   "nav": {
     "categories": "catégories",
@@ -65,7 +66,9 @@
     "themeDark": "sombre",
     "themeLight": "clair",
     "themeSystem": "auto",
-    "workingHours": "heures"
+    "workingHours": "heures",
+    "zoomIn": "zoomer",
+    "zoomOut": "dézoomer"
   },
   "onboarding": {
     "addFirst": "ajouter le premier horaire",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -1,181 +1,181 @@
 {
-  "app": {
-    "tagline": "gestionnaire d'horaires",
-    "title": "plan1"
-  },
-  "auth": {
-    "signIn": "Se connecter avec Google",
-    "signInDescription": "plan1 est un outil d'horaire personnel avec synchronisation multi-appareils. Connectez-vous avec Google pour commencer.",
-    "signInRequired": "Connectez-vous pour utiliser plan1"
-  },
-  "category": {
-    "confirmRemoveLabel": "confirmer sup ({count})",
-    "confirmRemoveText": "{count} horaire(s) seront supprimés avec ceci. Cliquez à nouveau pour confirmer.",
-    "defaultName": "par défaut",
-    "empty": "Aucune catégorie.",
-    "fieldColor": "couleur",
-    "fieldName": "nom",
-    "header": "catégories",
-    "removeButton": "sup",
-    "scheduleCountSuffix": "{count} horaires"
-  },
-  "common": {
-    "add": "ajouter",
-    "cancel": "annuler",
-    "close": "fermer",
-    "confirmDelete": "confirmer la suppression",
-    "delete": "supprimer",
-    "dismiss": "ignorer",
-    "now": "maintenant",
-    "retry": "réessayer",
-    "save": "enregistrer"
-  },
-  "confirmation": {
-    "scheduleAdded": "Horaire ajouté"
-  },
-  "error": {
-    "featureUnavailable": "Cette fonctionnalité n'est pas encore disponible ({feature}).",
-    "loadFailedLabel": "échec du chargement :",
-    "mutationFailed": "Échec de {action} : {error}",
-    "unknown": "Une erreur inattendue s'est produite. Veuillez réessayer.",
-    "workingHoursInvalid": "Entrée d'heures de travail invalide ({reason})."
-  },
-  "loading": "chargement...",
-  "mutation": {
-    "changeTimerType": "changer le type de minuteur",
-    "completeSchedule": "terminer l'horaire",
-    "extendTimer": "prolonger le minuteur",
-    "removeCategory": "supprimer la catégorie",
-    "setFocus": "définir la vue focus",
-    "setTheme": "définir le thème",
-    "startScheduleNow": "start schedule now",
-    "setZoom": "définir le zoom"
-  },
-  "nav": {
-    "categories": "catégories",
-    "focus10h": "10h",
-    "focus12h": "12h",
-    "focus16h": "16h",
-    "focus20h": "20h",
-    "focus24h": "24h",
-    "focus4h": "4h",
-    "focus6h": "6h",
-    "focus8h": "8h",
-    "focusLabel": "focus",
-    "newSchedule": "nouveau",
-    "themeDark": "sombre",
-    "themeLight": "clair",
-    "themeSystem": "auto",
-    "workingHours": "heures",
-    "zoomIn": "zoomer",
-    "zoomOut": "dézoomer"
-  },
-  "onboarding": {
-    "addFirst": "ajouter le premier horaire",
-    "firstSchedule": "Ajoutez votre premier horaire pour le voir sur la grille hebdomadaire, la chronologie du jour et l'horloge analogique.",
-    "welcome": "Aucun horaire pour le moment"
-  },
-  "schedule": {
-    "afterLastNoneHint": "aucun horaire à venir",
-    "buttonAfterLast": "next after last schedule",
-    "buttonMinus10": "-10m",
-    "buttonMinus30": "-30m",
-    "buttonPlus10": "+10m",
-    "buttonPlus30": "+30m",
-    "buttonPlusHour": "+1h",
-    "categoryAddOption": "+ ajouter une catégorie",
-    "chainedCheckbox": "enchaîner à l'horaire précédent",
-    "endLabelV2": "heure de fin",
-    "endPlaceholder": "sélectionner la durée",
-    "fieldCategory": "catégorie",
-    "fieldDuration": "durée (min)",
-    "fieldName": "nom",
-    "fieldStartHour": "heure de début",
-    "fieldStartMinute": "minute de début",
-    "headerEdit": "modifier l'horaire",
-    "headerNew": "nouvel horaire",
-    "hourSuffix": "h",
-    "hourTodaySuffix": "(aujourd'hui)",
-    "hourTomorrowSuffix": "(demain)",
-    "minuteSuffix": "m",
-    "prevChainLabel": "horaire précédent connecté",
-    "titleDefault": "Nouvel horaire",
-    "warningOverlapLimit": "Au maximum {limit} horaires peuvent se chevaucher en même temps. Ajustez le début/la durée ou supprimez-en un existant."
-  },
-  "serverError": {
-    "categoryHasSchedules": "La catégorie a {scheduleCount} horaires. Confirmez la suppression en cascade pour supprimer.",
-    "categoryNotFound": "Catégorie introuvable ou non possédée.",
-    "scheduleNotFound": "Horaire introuvable.",
-    "unauthorized": "Connexion requise."
-  },
-  "signIn": {
-    "cta": "Se connecter",
-    "description": "Connectez-vous à votre compte cofounder pour voir et gérer vos horaires.",
-    "title": "Connexion requise"
-  },
-  "timer": {
-    "buttonComplete": "terminé",
-    "buttonFocus": "focus",
-    "buttonIdle": "inactif",
-    "categoryFallback": "?",
-    "idleEmpty": "inactif · aucun horaire actif",
-    "labelElapsed": "écoulé",
-    "labelEndAt": "fin-à",
-    "labelRemaining": "restant",
-    "labelTarget": "cible",
-    "labelUntilUpcoming": "jusqu'au prochain",
-    "labelUpcoming": "horaire suivant",
-    "overlapLabel": "chevauchement {count}",
-    "simultaneousLabel": "simultané · {count}",
-    "tooltipClickToFocus": "cliquer pour passer en focus",
-    "tooltipClickToIdle": "cliquer pour passer en inactif",
-    "typeCountdown": "compte à rebours",
-    "typeCountup": "compte à rebours inversé",
-    "typeTimer1": "minuteur1",
-    "buttonStartNow": "start now"
-  },
-  "topbar": {
-    "back": "retour au portail",
-    "creditsLabel": "crédits",
-    "creditsPlaceholder": "—",
-    "guest": "invité",
-    "languageLabel": "langue",
-    "logout": "déconnexion"
-  },
-  "undo": {
-    "actionLabel": "annulation disponible",
-    "button": "annuler"
-  },
-  "wallTime": {
-    "am": "am",
-    "pm": "pm"
-  },
-  "weekdays": [
-    "dim",
-    "lun",
-    "mar",
-    "mer",
-    "jeu",
-    "ven",
-    "sam"
-  ],
-  "workingHours": {
-    "checkboxAlsoDefault": "enregistrer aussi par défaut",
-    "checkboxWeekdaysOnly": "jours de semaine seulement (lun–ven)",
-    "errorEndAfterStart": "L'heure de fin doit être après l'heure de début.",
-    "errorToAfterFrom": "La date de fin doit être égale ou postérieure à la date de début.",
-    "fieldDate": "date",
-    "fieldEndTime": "heure de fin",
-    "fieldFromDate": "de",
-    "fieldStartTime": "heure de début",
-    "fieldToDate": "à",
-    "header": "heures de travail",
-    "tabRange": "plage",
-    "tabSingle": "unique",
-    "warningNoDates": "Aucune date à appliquer dans la plage. (début > fin ou conflit jours de semaine uniquement)",
-    "warningTruncated": "La plage dépasse {max} jours, seulement partiellement traité. Essayez une plage plus étroite."
-  },
-  "header": {
-    "finalEndAtSuffix": "end"
-  }
+    "app": {
+        "tagline": "gestionnaire d'horaires",
+        "title": "plan1"
+    },
+    "auth": {
+        "signIn": "Se connecter avec Google",
+        "signInDescription": "plan1 est un outil d'horaires personnel avec synchronisation multi-appareils. Connectez-vous avec Google pour commencer.",
+        "signInRequired": "Connectez-vous pour utiliser plan1"
+    },
+    "category": {
+        "confirmRemoveLabel": "confirmer suppr ({count})",
+        "confirmRemoveText": "{count} horaire(s) sera/seront supprimé(s) avec ceci. Cliquez à nouveau pour confirmer.",
+        "defaultName": "par défaut",
+        "empty": "Aucune catégorie.",
+        "fieldColor": "couleur",
+        "fieldName": "nom",
+        "header": "catégories",
+        "removeButton": "rm",
+        "scheduleCountSuffix": "{count} horaires"
+    },
+    "common": {
+        "add": "ajouter",
+        "cancel": "annuler",
+        "close": "fermer",
+        "confirmDelete": "confirmer la suppression",
+        "delete": "supprimer",
+        "dismiss": "ignorer",
+        "now": "maintenant",
+        "retry": "réessayer",
+        "save": "enregistrer"
+    },
+    "confirmation": {
+        "scheduleAdded": "Horaire ajouté"
+    },
+    "error": {
+        "featureUnavailable": "Cette fonctionnalité n'est pas encore disponible ({feature}).",
+        "loadFailedLabel": "échec du chargement :",
+        "mutationFailed": "Échec de {action} : {error}",
+        "unknown": "Une erreur inattendue s'est produite. Veuillez réessayer.",
+        "workingHoursInvalid": "Entrée d'heures de travail invalide ({reason})."
+    },
+    "header": {
+        "finalEndAtSuffix": "fin"
+    },
+    "loading": "chargement...",
+    "mutation": {
+        "changeTimerType": "changer le type de minuteur",
+        "completeSchedule": "terminer l'horaire",
+        "extendTimer": "prolonger le minuteur",
+        "removeCategory": "retirer la catégorie",
+        "setFocus": "définir la vue de focus",
+        "setTheme": "définir le thème",
+        "setZoom": "définir le zoom",
+        "startScheduleNow": "démarrer l'horaire maintenant"
+    },
+    "nav": {
+        "categories": "catégories",
+        "focus10h": "10h",
+        "focus12h": "12h",
+        "focus16h": "16h",
+        "focus20h": "20h",
+        "focus24h": "24h",
+        "focus4h": "4h",
+        "focus6h": "6h",
+        "focus8h": "8h",
+        "focusLabel": "concentration",
+        "newSchedule": "nouveau",
+        "themeDark": "sombre",
+        "themeLight": "léger",
+        "themeSystem": "auto",
+        "workingHours": "heures",
+        "zoomIn": "zoomer",
+        "zoomOut": "dézoomer"
+    },
+    "onboarding": {
+        "addFirst": "ajouter le premier horaire",
+        "firstSchedule": "Ajoutez votre premier horaire pour le voir sur la grille hebdomadaire, la chronologie du jour et l'horloge analogique.",
+        "welcome": "Aucun horaire pour le moment"
+    },
+    "schedule": {
+        "afterLastNoneHint": "aucun horaire à venir",
+        "buttonAfterLast": "suivant après le dernier horaire",
+        "buttonMinus10": "-10m",
+        "buttonMinus30": "-30m",
+        "buttonPlus10": "+10m",
+        "buttonPlus30": "+30m",
+        "buttonPlusHour": "+1h",
+        "categoryAddOption": "+ ajouter une catégorie",
+        "chainedCheckbox": "enchaîner à l'horaire précédent",
+        "endLabelV2": "heure de fin",
+        "endPlaceholder": "sélectionner la durée",
+        "fieldCategory": "catégorie",
+        "fieldDuration": "durée (min)",
+        "fieldName": "nom",
+        "fieldStartHour": "heure de début",
+        "fieldStartMinute": "minute de début",
+        "headerEdit": "modifier l'horaire",
+        "headerNew": "nouvel horaire",
+        "hourSuffix": "h",
+        "hourTodaySuffix": "(aujourd'hui)",
+        "hourTomorrowSuffix": "(demain)",
+        "minuteSuffix": "m",
+        "prevChainLabel": "horaire précédent connecté",
+        "titleDefault": "Nouvel horaire",
+        "warningOverlapLimit": "Au maximum {limit} horaires peuvent se chevaucher en même temps. Ajustez le début/la durée ou supprimez-en un existant."
+    },
+    "serverError": {
+        "categoryHasSchedules": "La catégorie a {scheduleCount} horaires. Confirmez la suppression en cascade pour retirer.",
+        "categoryNotFound": "Catégorie introuvable ou non possédée.",
+        "scheduleNotFound": "Horaire introuvable.",
+        "unauthorized": "Connexion requise."
+    },
+    "signIn": {
+        "cta": "Se connecter",
+        "description": "Connectez-vous à votre compte cofondateur pour voir et gérer vos horaires.",
+        "title": "Connexion requise"
+    },
+    "timer": {
+        "buttonComplete": "terminé",
+        "buttonFocus": "concentration",
+        "buttonIdle": "inactif",
+        "buttonStartNow": "démarrer maintenant",
+        "categoryFallback": "?",
+        "idleEmpty": "inactif · aucun horaire actif",
+        "labelElapsed": "écoulé",
+        "labelEndAt": "fin-à",
+        "labelRemaining": "restant",
+        "labelTarget": "cible",
+        "labelUntilUpcoming": "jusqu'au prochain",
+        "labelUpcoming": "horaire suivant",
+        "overlapLabel": "chevauchement {count}",
+        "simultaneousLabel": "simultané · {count}",
+        "tooltipClickToFocus": "cliquer pour basculer en concentration",
+        "tooltipClickToIdle": "cliquer pour basculer en inactif",
+        "typeCountdown": "compte à rebours",
+        "typeCountup": "compte à rebours",
+        "typeTimer1": "minuteur1"
+    },
+    "topbar": {
+        "back": "retour au portail",
+        "creditsLabel": "crédits",
+        "creditsPlaceholder": "—",
+        "guest": "invité",
+        "languageLabel": "langue",
+        "logout": "déconnexion"
+    },
+    "undo": {
+        "actionLabel": "annulation disponible",
+        "button": "annuler"
+    },
+    "wallTime": {
+        "am": "am",
+        "pm": "pm"
+    },
+    "weekdays": [
+        "dim",
+        "lun",
+        "mar",
+        "mer",
+        "jeu",
+        "ven",
+        "sam"
+    ],
+    "workingHours": {
+        "checkboxAlsoDefault": "enregistrer aussi par défaut",
+        "checkboxWeekdaysOnly": "jours de semaine uniquement (lun–ven)",
+        "errorEndAfterStart": "L'heure de fin doit être après l'heure de début.",
+        "errorToAfterFrom": "La date de fin doit être le jour de la date de début ou après.",
+        "fieldDate": "date",
+        "fieldEndTime": "heure de fin",
+        "fieldFromDate": "de",
+        "fieldStartTime": "heure de début",
+        "fieldToDate": "à",
+        "header": "heures de travail",
+        "tabRange": "plage",
+        "tabSingle": "unique",
+        "warningNoDates": "Aucune date à appliquer dans la plage. (début > fin ou conflit jours de semaine uniquement)",
+        "warningTruncated": "La plage dépasse {max} jours, seulement partiellement traité. Essayez une plage plus étroite."
+    }
 }

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -5,18 +5,18 @@
     },
     "auth": {
         "signIn": "Se connecter avec Google",
-        "signInDescription": "plan1 est un outil d'horaires personnel avec synchronisation multi-appareils. Connectez-vous avec Google pour commencer.",
+        "signInDescription": "plan1 est un outil de planification personnel avec synchronisation multi-appareils. Connectez-vous avec Google pour commencer.",
         "signInRequired": "Connectez-vous pour utiliser plan1"
     },
     "category": {
         "confirmRemoveLabel": "confirmer suppr ({count})",
-        "confirmRemoveText": "{count} horaire(s) sera/seront supprimé(s) avec ceci. Cliquez à nouveau pour confirmer.",
+        "confirmRemoveText": "{count} horaire(s) seront supprimés avec ceci. Cliquez à nouveau pour confirmer.",
         "defaultName": "par défaut",
         "empty": "Aucune catégorie.",
         "fieldColor": "couleur",
         "fieldName": "nom",
         "header": "catégories",
-        "removeButton": "rm",
+        "removeButton": "suppr",
         "scheduleCountSuffix": "{count} horaires"
     },
     "common": {
@@ -38,7 +38,7 @@
         "loadFailedLabel": "échec du chargement :",
         "mutationFailed": "Échec de {action} : {error}",
         "unknown": "Une erreur inattendue s'est produite. Veuillez réessayer.",
-        "workingHoursInvalid": "Entrée d'heures de travail invalide ({reason})."
+        "workingHoursInvalid": "Saisie d'heures de travail invalide ({reason})."
     },
     "header": {
         "finalEndAtSuffix": "fin"
@@ -48,8 +48,8 @@
         "changeTimerType": "changer le type de minuteur",
         "completeSchedule": "terminer l'horaire",
         "extendTimer": "prolonger le minuteur",
-        "removeCategory": "retirer la catégorie",
-        "setFocus": "définir la vue de focus",
+        "removeCategory": "supprimer la catégorie",
+        "setFocus": "définir la vue focus",
         "setTheme": "définir le thème",
         "setZoom": "définir le zoom",
         "startScheduleNow": "démarrer l'horaire maintenant"
@@ -64,10 +64,10 @@
         "focus4h": "4h",
         "focus6h": "6h",
         "focus8h": "8h",
-        "focusLabel": "concentration",
+        "focusLabel": "focus",
         "newSchedule": "nouveau",
         "themeDark": "sombre",
-        "themeLight": "léger",
+        "themeLight": "clair",
         "themeSystem": "auto",
         "workingHours": "heures",
         "zoomIn": "zoomer",
@@ -103,7 +103,7 @@
         "minuteSuffix": "m",
         "prevChainLabel": "horaire précédent connecté",
         "titleDefault": "Nouvel horaire",
-        "warningOverlapLimit": "Au maximum {limit} horaires peuvent se chevaucher en même temps. Ajustez le début/la durée ou supprimez-en un existant."
+        "warningOverlapLimit": "Au maximum {limit} horaires peuvent se chevaucher en même temps. Ajustez le début/durée ou supprimez-en un existant."
     },
     "serverError": {
         "categoryHasSchedules": "La catégorie a {scheduleCount} horaires. Confirmez la suppression en cascade pour retirer.",
@@ -118,9 +118,9 @@
     },
     "timer": {
         "buttonComplete": "terminé",
-        "buttonFocus": "concentration",
+        "buttonFocus": "focus",
         "buttonIdle": "inactif",
-        "buttonStartNow": "démarrer maintenant",
+        "buttonStartNow": "commencer maintenant",
         "categoryFallback": "?",
         "idleEmpty": "inactif · aucun horaire actif",
         "labelElapsed": "écoulé",
@@ -131,10 +131,10 @@
         "labelUpcoming": "horaire suivant",
         "overlapLabel": "chevauchement {count}",
         "simultaneousLabel": "simultané · {count}",
-        "tooltipClickToFocus": "cliquer pour basculer en concentration",
-        "tooltipClickToIdle": "cliquer pour basculer en inactif",
+        "tooltipClickToFocus": "cliquer pour passer en focus",
+        "tooltipClickToIdle": "cliquer pour passer en inactif",
         "typeCountdown": "compte à rebours",
-        "typeCountup": "compte à rebours",
+        "typeCountup": "compteur",
         "typeTimer1": "minuteur1"
     },
     "topbar": {
@@ -166,7 +166,7 @@
         "checkboxAlsoDefault": "enregistrer aussi par défaut",
         "checkboxWeekdaysOnly": "jours de semaine uniquement (lun–ven)",
         "errorEndAfterStart": "L'heure de fin doit être après l'heure de début.",
-        "errorToAfterFrom": "La date de fin doit être le jour de la date de début ou après.",
+        "errorToAfterFrom": "La date de fin doit être égale ou postérieure à la date de début.",
         "fieldDate": "date",
         "fieldEndTime": "heure de fin",
         "fieldFromDate": "de",

--- a/messages/hi.json
+++ b/messages/hi.json
@@ -1,21 +1,21 @@
 {
     "app": {
-        "tagline": "शेड्यूल प्रबंधक",
-        "title": "योजना1"
+        "tagline": "शेड्यूल मैनेजर",
+        "title": "plan1"
     },
     "auth": {
-        "signIn": "Google के साथ साइन इन करें",
-        "signInDescription": "plan1 एक व्यक्तिगत शेड्यूल टूल है जिसमें क्रॉस-डिवाइस सिंक है। शुरू करने के लिए Google के साथ साइन इन करें।",
-        "signInRequired": "योजना1 का उपयोग करने के लिए साइन इन करें"
+        "signIn": "Google से साइन इन करें",
+        "signInDescription": "plan1 एक व्यक्तिगत शेड्यूल टूल है जिसमें क्रॉस-डिवाइस सिंक है। शुरू करने के लिए Google से साइन इन करें।",
+        "signInRequired": "plan1 उपयोग करने के लिए साइन इन करें"
     },
     "category": {
         "confirmRemoveLabel": "हटाने की पुष्टि करें ({count})",
-        "confirmRemoveText": "{count} शेड्यूल इसके साथ हटा दिए जाएंगे। पुष्टि करने के लिए फिर से क्लिक करें।",
+        "confirmRemoveText": "{count} शेड्यूल इसके साथ हटाए जाएंगे। पुष्टि के लिए फिर से क्लिक करें।",
         "defaultName": "डिफ़ॉल्ट",
-        "empty": "कोई श्रेणी नहीं।",
+        "empty": "कोई श्रेणियां नहीं।",
         "fieldColor": "रंग",
         "fieldName": "नाम",
-        "header": "श्रेणियाँ",
+        "header": "श्रेणियां",
         "removeButton": "हटाएं",
         "scheduleCountSuffix": "{count} शेड्यूल"
     },
@@ -23,7 +23,7 @@
         "add": "जोड़ें",
         "cancel": "रद्द करें",
         "close": "बंद करें",
-        "confirmDelete": "हटाना पुष्टि करें",
+        "confirmDelete": "हटाने की पुष्टि करें",
         "delete": "हटाएं",
         "dismiss": "खारिज करें",
         "now": "अभी",
@@ -41,7 +41,7 @@
         "workingHoursInvalid": "अमान्य कार्य घंटे इनपुट ({reason})।"
     },
     "header": {
-        "finalEndAtSuffix": "समाप्ति"
+        "finalEndAtSuffix": "समाप्त"
     },
     "loading": "लोड हो रहा है...",
     "mutation": {
@@ -55,7 +55,7 @@
         "startScheduleNow": "शेड्यूल अभी शुरू करें"
     },
     "nav": {
-        "categories": "श्रेणियाँ",
+        "categories": "श्रेणियां",
         "focus10h": "10घं",
         "focus12h": "12घं",
         "focus16h": "16घं",
@@ -68,10 +68,10 @@
         "newSchedule": "नया",
         "themeDark": "गहरा",
         "themeLight": "हल्का",
-        "themeSystem": "स्वतः",
+        "themeSystem": "स्वचालित",
         "workingHours": "घंटे",
-        "zoomIn": "ज़ूम इन",
-        "zoomOut": "ज़ूम आउट"
+        "zoomIn": "ज़ूम इन करें",
+        "zoomOut": "ज़ूम आउट करें"
     },
     "onboarding": {
         "addFirst": "पहला शेड्यूल जोड़ें",
@@ -101,13 +101,13 @@
         "hourTodaySuffix": "(आज)",
         "hourTomorrowSuffix": "(कल)",
         "minuteSuffix": "मि",
-        "prevChainLabel": "जुड़ा हुआ पिछला शेड्यूल",
+        "prevChainLabel": "पिछला शेड्यूल जुड़ा हुआ",
         "titleDefault": "नया शेड्यूल",
-        "warningOverlapLimit": "एक ही समय में अधिकतम {limit} शेड्यूल ओवरलैप हो सकते हैं। प्रारंभ/अवधि समायोजित करें या मौजूदा को हटाएं।"
+        "warningOverlapLimit": "अधिकतम {limit} शेड्यूल एक साथ ओवरलैप हो सकते हैं। प्रारंभ/अवधि समायोजित करें या मौजूदा को हटाएं।"
     },
     "serverError": {
         "categoryHasSchedules": "श्रेणी में {scheduleCount} शेड्यूल हैं। हटाने के लिए कैस्केड डिलीट की पुष्टि करें।",
-        "categoryNotFound": "श्रेणी नहीं मिली या स्वामित्व में नहीं।",
+        "categoryNotFound": "श्रेणी नहीं मिली या स्वामित्व में नहीं है।",
         "scheduleNotFound": "शेड्यूल नहीं मिला।",
         "unauthorized": "साइन इन आवश्यक।"
     },
@@ -123,18 +123,18 @@
         "buttonStartNow": "अभी शुरू करें",
         "categoryFallback": "?",
         "idleEmpty": "निष्क्रिय · कोई सक्रिय शेड्यूल नहीं",
-        "labelElapsed": "बीता हुआ",
-        "labelEndAt": "समाप्ति-पर",
+        "labelElapsed": "बीत चुका",
+        "labelEndAt": "समाप्त-पर",
         "labelRemaining": "शेष",
         "labelTarget": "लक्ष्य",
         "labelUntilUpcoming": "आगामी तक",
         "labelUpcoming": "अगला शेड्यूल",
         "overlapLabel": "ओवरलैप {count}",
-        "simultaneousLabel": "समकालिक · {count}",
+        "simultaneousLabel": "एक साथ · {count}",
         "tooltipClickToFocus": "फोकस पर स्विच करने के लिए क्लिक करें",
         "tooltipClickToIdle": "निष्क्रिय पर स्विच करने के लिए क्लिक करें",
-        "typeCountdown": "काउंटडाउन",
-        "typeCountup": "काउंटअप",
+        "typeCountdown": "उलटी गिनती",
+        "typeCountup": "गिनती बढ़ाएं",
         "typeTimer1": "टाइमर1"
     },
     "topbar": {
@@ -166,16 +166,16 @@
         "checkboxAlsoDefault": "डिफ़ॉल्ट के रूप में भी सहेजें",
         "checkboxWeekdaysOnly": "केवल सप्ताह के दिन (सोम–शुक्र)",
         "errorEndAfterStart": "समाप्ति समय प्रारंभ समय के बाद होना चाहिए।",
-        "errorToAfterFrom": "समाप्ति तिथि प्रारंभ तिथि के बराबर या बाद में होनी चाहिए।",
-        "fieldDate": "तिथि",
+        "errorToAfterFrom": "समाप्ति तिथि प्रारंभ तिथि के बराबर या उसके बाद होनी चाहिए।",
+        "fieldDate": "तारीख",
         "fieldEndTime": "समाप्ति समय",
         "fieldFromDate": "से",
         "fieldStartTime": "प्रारंभ समय",
         "fieldToDate": "से",
         "header": "कार्य घंटे",
-        "tabRange": "सीमा",
+        "tabRange": "रेंज",
         "tabSingle": "एकल",
-        "warningNoDates": "सीमा में लागू करने के लिए कोई तिथियां नहीं। (प्रारंभ > समाप्ति या सप्ताह के दिनों का टकराव)",
-        "warningTruncated": "सीमा {max} दिनों से अधिक है, केवल आंशिक प्रोसेस किया गया। संकीर्ण सीमा आज़माएं।"
+        "warningNoDates": "सीमा में लागू करने के लिए कोई तिथियां नहीं। (प्रारंभ > समाप्ति या सप्ताह के दिनों-केवल विरोध)",
+        "warningTruncated": "रेंज {max} दिनों से अधिक है, केवल आंशिक रूप से प्रोसेस किया गया। एक संकीर्ण रेंज आज़माएं।"
     }
 }

--- a/messages/hi.json
+++ b/messages/hi.json
@@ -1,21 +1,21 @@
 {
     "app": {
         "tagline": "शेड्यूल प्रबंधक",
-        "title": "प्लान1"
+        "title": "योजना1"
     },
     "auth": {
         "signIn": "Google के साथ साइन इन करें",
         "signInDescription": "plan1 एक व्यक्तिगत शेड्यूल टूल है जिसमें क्रॉस-डिवाइस सिंक है। शुरू करने के लिए Google के साथ साइन इन करें।",
-        "signInRequired": "plan1 उपयोग करने के लिए साइन इन करें"
+        "signInRequired": "योजना1 का उपयोग करने के लिए साइन इन करें"
     },
     "category": {
         "confirmRemoveLabel": "हटाने की पुष्टि करें ({count})",
-        "confirmRemoveText": "इसके साथ {count} शेड्यूल डिलीट हो जाएंगे। पुष्टि करने के लिए फिर से क्लिक करें।",
+        "confirmRemoveText": "{count} शेड्यूल इसके साथ हटा दिए जाएंगे। पुष्टि करने के लिए फिर से क्लिक करें।",
         "defaultName": "डिफ़ॉल्ट",
         "empty": "कोई श्रेणी नहीं।",
         "fieldColor": "रंग",
         "fieldName": "नाम",
-        "header": "श्रेणियां",
+        "header": "श्रेणियाँ",
         "removeButton": "हटाएं",
         "scheduleCountSuffix": "{count} शेड्यूल"
     },
@@ -23,8 +23,8 @@
         "add": "जोड़ें",
         "cancel": "रद्द करें",
         "close": "बंद करें",
-        "confirmDelete": "डिलीट की पुष्टि करें",
-        "delete": "डिलीट करें",
+        "confirmDelete": "हटाना पुष्टि करें",
+        "delete": "हटाएं",
         "dismiss": "खारिज करें",
         "now": "अभी",
         "retry": "पुनः प्रयास करें",
@@ -36,12 +36,12 @@
     "error": {
         "featureUnavailable": "यह सुविधा अभी उपलब्ध नहीं है ({feature})।",
         "loadFailedLabel": "लोड विफल:",
-        "mutationFailed": "{action} विफल रहा: {error}",
+        "mutationFailed": "{action} विफल: {error}",
         "unknown": "एक अप्रत्याशित त्रुटि हुई। कृपया पुनः प्रयास करें।",
         "workingHoursInvalid": "अमान्य कार्य घंटे इनपुट ({reason})।"
     },
     "header": {
-        "finalEndAtSuffix": "समाप्त"
+        "finalEndAtSuffix": "समाप्ति"
     },
     "loading": "लोड हो रहा है...",
     "mutation": {
@@ -49,13 +49,13 @@
         "completeSchedule": "शेड्यूल पूर्ण करें",
         "extendTimer": "टाइमर बढ़ाएं",
         "removeCategory": "श्रेणी हटाएं",
-        "setFocus": "फोकस व्यू सेट करें",
+        "setFocus": "फ़ोकस व्यू सेट करें",
         "setTheme": "थीम सेट करें",
         "setZoom": "ज़ूम सेट करें",
         "startScheduleNow": "शेड्यूल अभी शुरू करें"
     },
     "nav": {
-        "categories": "श्रेणियां",
+        "categories": "श्रेणियाँ",
         "focus10h": "10घं",
         "focus12h": "12घं",
         "focus16h": "16घं",
@@ -66,16 +66,16 @@
         "focus8h": "8घं",
         "focusLabel": "फ़ोकस",
         "newSchedule": "नया",
-        "themeDark": "डार्क",
-        "themeLight": "लाइट",
-        "themeSystem": "ऑटो",
+        "themeDark": "गहरा",
+        "themeLight": "हल्का",
+        "themeSystem": "स्वतः",
         "workingHours": "घंटे",
         "zoomIn": "ज़ूम इन",
         "zoomOut": "ज़ूम आउट"
     },
     "onboarding": {
         "addFirst": "पहला शेड्यूल जोड़ें",
-        "firstSchedule": "साप्ताहिक ग्रिड, आज की टाइमलाइन और एनालॉग घड़ी पर देखने के लिए अपना पहला शेड्यूल जोड़ें।",
+        "firstSchedule": "साप्ताहिक ग्रिड, आज की समयरेखा और एनालॉग घड़ी पर देखने के लिए अपना पहला शेड्यूल जोड़ें।",
         "welcome": "अभी तक कोई शेड्यूल नहीं"
     },
     "schedule": {
@@ -93,17 +93,17 @@
         "fieldCategory": "श्रेणी",
         "fieldDuration": "अवधि (मिनट)",
         "fieldName": "नाम",
-        "fieldStartHour": "शुरुआती घंटा",
-        "fieldStartMinute": "शुरुआत मिनट",
+        "fieldStartHour": "प्रारंभ घंटा",
+        "fieldStartMinute": "प्रारंभ मिनट",
         "headerEdit": "शेड्यूल संपादित करें",
         "headerNew": "नया शेड्यूल",
         "hourSuffix": "घं",
         "hourTodaySuffix": "(आज)",
         "hourTomorrowSuffix": "(कल)",
         "minuteSuffix": "मि",
-        "prevChainLabel": "पिछला शेड्यूल जुड़ा हुआ",
+        "prevChainLabel": "जुड़ा हुआ पिछला शेड्यूल",
         "titleDefault": "नया शेड्यूल",
-        "warningOverlapLimit": "अधिकतम {limit} शेड्यूल एक ही समय पर ओवरलैप हो सकते हैं। शुरुआत/अवधि समायोजित करें या मौजूदा को हटाएं।"
+        "warningOverlapLimit": "एक ही समय में अधिकतम {limit} शेड्यूल ओवरलैप हो सकते हैं। प्रारंभ/अवधि समायोजित करें या मौजूदा को हटाएं।"
     },
     "serverError": {
         "categoryHasSchedules": "श्रेणी में {scheduleCount} शेड्यूल हैं। हटाने के लिए कैस्केड डिलीट की पुष्टि करें।",
@@ -130,8 +130,8 @@
         "labelUntilUpcoming": "आगामी तक",
         "labelUpcoming": "अगला शेड्यूल",
         "overlapLabel": "ओवरलैप {count}",
-        "simultaneousLabel": "एक साथ · {count}",
-        "tooltipClickToFocus": "फ़ोकस पर स्विच करने के लिए क्लिक करें",
+        "simultaneousLabel": "समकालिक · {count}",
+        "tooltipClickToFocus": "फोकस पर स्विच करने के लिए क्लिक करें",
         "tooltipClickToIdle": "निष्क्रिय पर स्विच करने के लिए क्लिक करें",
         "typeCountdown": "काउंटडाउन",
         "typeCountup": "काउंटअप",
@@ -151,7 +151,7 @@
     },
     "wallTime": {
         "am": "पूर्वाह्न",
-        "pm": "pm"
+        "pm": "अपराह्न"
     },
     "weekdays": [
         "रवि",
@@ -165,17 +165,17 @@
     "workingHours": {
         "checkboxAlsoDefault": "डिफ़ॉल्ट के रूप में भी सहेजें",
         "checkboxWeekdaysOnly": "केवल सप्ताह के दिन (सोम–शुक्र)",
-        "errorEndAfterStart": "समाप्ति समय शुरुआती समय के बाद होना चाहिए।",
-        "errorToAfterFrom": "समाप्ति तिथि शुरुआती तिथि को या उसके बाद होनी चाहिए।",
-        "fieldDate": "तारीख",
+        "errorEndAfterStart": "समाप्ति समय प्रारंभ समय के बाद होना चाहिए।",
+        "errorToAfterFrom": "समाप्ति तिथि प्रारंभ तिथि के बराबर या बाद में होनी चाहिए।",
+        "fieldDate": "तिथि",
         "fieldEndTime": "समाप्ति समय",
         "fieldFromDate": "से",
-        "fieldStartTime": "शुरुआत का समय",
-        "fieldToDate": "तक",
+        "fieldStartTime": "प्रारंभ समय",
+        "fieldToDate": "से",
         "header": "कार्य घंटे",
-        "tabRange": "रेंज",
+        "tabRange": "सीमा",
         "tabSingle": "एकल",
-        "warningNoDates": "रेंज में लागू करने के लिए कोई तिथियां नहीं। (शुरुआत > अंत या सप्ताह के दिनों-केवल विरोध)",
-        "warningTruncated": "रेंज {max} दिनों से अधिक है, केवल आंशिक प्रोसेस किया गया। एक संकीर्ण रेंज का प्रयास करें।"
+        "warningNoDates": "सीमा में लागू करने के लिए कोई तिथियां नहीं। (प्रारंभ > समाप्ति या सप्ताह के दिनों का टकराव)",
+        "warningTruncated": "सीमा {max} दिनों से अधिक है, केवल आंशिक प्रोसेस किया गया। संकीर्ण सीमा आज़माएं।"
     }
 }

--- a/messages/hi.json
+++ b/messages/hi.json
@@ -48,7 +48,8 @@
     "removeCategory": "श्रेणी हटाएं",
     "setFocus": "फोकस व्यू सेट करें",
     "setTheme": "थीम सेट करें",
-    "startScheduleNow": "start schedule now"
+    "startScheduleNow": "start schedule now",
+    "setZoom": "ज़ूम सेट करें"
   },
   "nav": {
     "categories": "श्रेणियां",
@@ -65,7 +66,9 @@
     "themeDark": "डार्क",
     "themeLight": "हल्का",
     "themeSystem": "ऑटो",
-    "workingHours": "घंटे"
+    "workingHours": "घंटे",
+    "zoomIn": "ज़ूम इन",
+    "zoomOut": "ज़ूम आउट"
   },
   "onboarding": {
     "addFirst": "पहला शेड्यूल जोड़ें",

--- a/messages/hi.json
+++ b/messages/hi.json
@@ -1,181 +1,181 @@
 {
-  "app": {
-    "tagline": "शेड्यूल प्रबंधक",
-    "title": "plan1"
-  },
-  "auth": {
-    "signIn": "Google से साइन इन करें",
-    "signInDescription": "plan1 एक व्यक्तिगत शेड्यूल टूल है जिसमें क्रॉस-डिवाइस सिंक है। शुरू करने के लिए Google से साइन इन करें।",
-    "signInRequired": "plan1 उपयोग करने के लिए साइन इन करें"
-  },
-  "category": {
-    "confirmRemoveLabel": "हटाने की पुष्टि करें ({count})",
-    "confirmRemoveText": "{count} शेड्यूल इसके साथ हटा दिए जाएंगे। पुष्टि करने के लिए फिर से क्लिक करें।",
-    "defaultName": "डिफ़ॉल्ट",
-    "empty": "कोई श्रेणी नहीं।",
-    "fieldColor": "रंग",
-    "fieldName": "नाम",
-    "header": "श्रेणियां",
-    "removeButton": "हटाएं",
-    "scheduleCountSuffix": "{count} शेड्यूल"
-  },
-  "common": {
-    "add": "जोड़ें",
-    "cancel": "रद्द करें",
-    "close": "बंद करें",
-    "confirmDelete": "हटाने की पुष्टि करें",
-    "delete": "हटाएं",
-    "dismiss": "खारिज करें",
-    "now": "अभी",
-    "retry": "पुनः प्रयास करें",
-    "save": "सेव करें"
-  },
-  "confirmation": {
-    "scheduleAdded": "शेड्यूल जोड़ा गया"
-  },
-  "error": {
-    "featureUnavailable": "यह सुविधा अभी उपलब्ध नहीं है ({feature})।",
-    "loadFailedLabel": "लोड विफल:",
-    "mutationFailed": "{action} विफल: {error}",
-    "unknown": "एक अप्रत्याशित त्रुटि हुई। कृपया पुनः प्रयास करें।",
-    "workingHoursInvalid": "अमान्य कार्य घंटे इनपुट ({reason})।"
-  },
-  "loading": "लोड हो रहा है...",
-  "mutation": {
-    "changeTimerType": "टाइमर प्रकार बदलें",
-    "completeSchedule": "पूर्ण शेड्यूल",
-    "extendTimer": "टाइमर बढ़ाएं",
-    "removeCategory": "श्रेणी हटाएं",
-    "setFocus": "फोकस व्यू सेट करें",
-    "setTheme": "थीम सेट करें",
-    "startScheduleNow": "start schedule now",
-    "setZoom": "ज़ूम सेट करें"
-  },
-  "nav": {
-    "categories": "श्रेणियां",
-    "focus10h": "10घं",
-    "focus12h": "12घं",
-    "focus16h": "16घं",
-    "focus20h": "20घं",
-    "focus24h": "24घं",
-    "focus4h": "4घं",
-    "focus6h": "6घं",
-    "focus8h": "8घं",
-    "focusLabel": "फोकस",
-    "newSchedule": "नया",
-    "themeDark": "डार्क",
-    "themeLight": "हल्का",
-    "themeSystem": "ऑटो",
-    "workingHours": "घंटे",
-    "zoomIn": "ज़ूम इन",
-    "zoomOut": "ज़ूम आउट"
-  },
-  "onboarding": {
-    "addFirst": "पहला शेड्यूल जोड़ें",
-    "firstSchedule": "साप्ताहिक ग्रिड, आज की समयरेखा और एनालॉग घड़ी पर देखने के लिए अपना पहला शेड्यूल जोड़ें।",
-    "welcome": "अभी तक कोई शेड्यूल नहीं"
-  },
-  "schedule": {
-    "afterLastNoneHint": "कोई आगामी शेड्यूल नहीं",
-    "buttonAfterLast": "next after last schedule",
-    "buttonMinus10": "-10मि",
-    "buttonMinus30": "-30मि",
-    "buttonPlus10": "+10मि",
-    "buttonPlus30": "+30मि",
-    "buttonPlusHour": "+1घं",
-    "categoryAddOption": "+ श्रेणी जोड़ें",
-    "chainedCheckbox": "पिछले शेड्यूल से जोड़ें",
-    "endLabelV2": "समाप्ति समय",
-    "endPlaceholder": "अवधि चुनें",
-    "fieldCategory": "श्रेणी",
-    "fieldDuration": "अवधि (मिनट)",
-    "fieldName": "नाम",
-    "fieldStartHour": "शुरुआती घंटा",
-    "fieldStartMinute": "शुरुआत मिनट",
-    "headerEdit": "शेड्यूल संपादित करें",
-    "headerNew": "नया शेड्यूल",
-    "hourSuffix": "घं",
-    "hourTodaySuffix": "(आज)",
-    "hourTomorrowSuffix": "(कल)",
-    "minuteSuffix": "मि",
-    "prevChainLabel": "जुड़ा हुआ पिछला शेड्यूल",
-    "titleDefault": "नया शेड्यूल",
-    "warningOverlapLimit": "अधिकतम {limit} शेड्यूल एक ही समय में ओवरलैप हो सकते हैं। शुरुआत/अवधि समायोजित करें या मौजूदा को हटाएं।"
-  },
-  "serverError": {
-    "categoryHasSchedules": "श्रेणी में {scheduleCount} शेड्यूल हैं। हटाने के लिए कैस्केड डिलीट की पुष्टि करें।",
-    "categoryNotFound": "श्रेणी नहीं मिली या स्वामित्व में नहीं है।",
-    "scheduleNotFound": "शेड्यूल नहीं मिला।",
-    "unauthorized": "साइन इन आवश्यक।"
-  },
-  "signIn": {
-    "cta": "साइन इन करें",
-    "description": "अपने शेड्यूल देखने और प्रबंधित करने के लिए अपने cofounder खाते में साइन इन करें।",
-    "title": "साइन इन आवश्यक"
-  },
-  "timer": {
-    "buttonComplete": "पूर्ण",
-    "buttonFocus": "फोकस",
-    "buttonIdle": "निष्क्रिय",
-    "categoryFallback": "?",
-    "idleEmpty": "निष्क्रिय · कोई सक्रिय शेड्यूल नहीं",
-    "labelElapsed": "बीता हुआ",
-    "labelEndAt": "समाप्ति-पर",
-    "labelRemaining": "शेष",
-    "labelTarget": "लक्ष्य",
-    "labelUntilUpcoming": "आगामी तक",
-    "labelUpcoming": "अगला शेड्यूल",
-    "overlapLabel": "ओवरलैप {count}",
-    "simultaneousLabel": "एक साथ · {count}",
-    "tooltipClickToFocus": "फोकस पर स्विच करने के लिए क्लिक करें",
-    "tooltipClickToIdle": "निष्क्रिय पर स्विच करने के लिए क्लिक करें",
-    "typeCountdown": "उलटी गिनती",
-    "typeCountup": "काउंटअप",
-    "typeTimer1": "टाइमर1",
-    "buttonStartNow": "start now"
-  },
-  "topbar": {
-    "back": "पोर्टल पर वापस जाएं",
-    "creditsLabel": "क्रेडिट",
-    "creditsPlaceholder": "—",
-    "guest": "अतिथि",
-    "languageLabel": "भाषा",
-    "logout": "लॉगआउट"
-  },
-  "undo": {
-    "actionLabel": "पूर्ववत उपलब्ध",
-    "button": "पूर्ववत करें"
-  },
-  "wallTime": {
-    "am": "पूर्वाह्न",
-    "pm": "अपराह्न"
-  },
-  "weekdays": [
-    "रवि",
-    "सोम",
-    "मंगल",
-    "बुध",
-    "गुरु",
-    "शुक्र",
-    "शनि"
-  ],
-  "workingHours": {
-    "checkboxAlsoDefault": "डिफ़ॉल्ट के रूप में भी सहेजें",
-    "checkboxWeekdaysOnly": "केवल सप्ताह के दिन (सोम–शुक्र)",
-    "errorEndAfterStart": "समाप्ति समय शुरुआत समय के बाद होना चाहिए।",
-    "errorToAfterFrom": "समाप्ति तिथि शुरुआत तिथि के बराबर या बाद में होनी चाहिए।",
-    "fieldDate": "तिथि",
-    "fieldEndTime": "समाप्ति समय",
-    "fieldFromDate": "से",
-    "fieldStartTime": "शुरुआत समय",
-    "fieldToDate": "तक",
-    "header": "कार्य घंटे",
-    "tabRange": "रेंज",
-    "tabSingle": "एकल",
-    "warningNoDates": "रेंज में लागू करने के लिए कोई तिथि नहीं। (शुरुआत > समाप्ति या केवल-सप्ताह के दिन विरोध)",
-    "warningTruncated": "रेंज {max} दिनों से अधिक है, केवल आंशिक प्रोसेस किया गया। एक संकीर्ण रेंज आज़माएं।"
-  },
-  "header": {
-    "finalEndAtSuffix": "end"
-  }
+    "app": {
+        "tagline": "शेड्यूल प्रबंधक",
+        "title": "प्लान1"
+    },
+    "auth": {
+        "signIn": "Google के साथ साइन इन करें",
+        "signInDescription": "plan1 एक व्यक्तिगत शेड्यूल टूल है जिसमें क्रॉस-डिवाइस सिंक है। शुरू करने के लिए Google के साथ साइन इन करें।",
+        "signInRequired": "plan1 उपयोग करने के लिए साइन इन करें"
+    },
+    "category": {
+        "confirmRemoveLabel": "हटाने की पुष्टि करें ({count})",
+        "confirmRemoveText": "इसके साथ {count} शेड्यूल डिलीट हो जाएंगे। पुष्टि करने के लिए फिर से क्लिक करें।",
+        "defaultName": "डिफ़ॉल्ट",
+        "empty": "कोई श्रेणी नहीं।",
+        "fieldColor": "रंग",
+        "fieldName": "नाम",
+        "header": "श्रेणियां",
+        "removeButton": "हटाएं",
+        "scheduleCountSuffix": "{count} शेड्यूल"
+    },
+    "common": {
+        "add": "जोड़ें",
+        "cancel": "रद्द करें",
+        "close": "बंद करें",
+        "confirmDelete": "डिलीट की पुष्टि करें",
+        "delete": "डिलीट करें",
+        "dismiss": "खारिज करें",
+        "now": "अभी",
+        "retry": "पुनः प्रयास करें",
+        "save": "सहेजें"
+    },
+    "confirmation": {
+        "scheduleAdded": "शेड्यूल जोड़ा गया"
+    },
+    "error": {
+        "featureUnavailable": "यह सुविधा अभी उपलब्ध नहीं है ({feature})।",
+        "loadFailedLabel": "लोड विफल:",
+        "mutationFailed": "{action} विफल रहा: {error}",
+        "unknown": "एक अप्रत्याशित त्रुटि हुई। कृपया पुनः प्रयास करें।",
+        "workingHoursInvalid": "अमान्य कार्य घंटे इनपुट ({reason})।"
+    },
+    "header": {
+        "finalEndAtSuffix": "समाप्त"
+    },
+    "loading": "लोड हो रहा है...",
+    "mutation": {
+        "changeTimerType": "टाइमर प्रकार बदलें",
+        "completeSchedule": "शेड्यूल पूर्ण करें",
+        "extendTimer": "टाइमर बढ़ाएं",
+        "removeCategory": "श्रेणी हटाएं",
+        "setFocus": "फोकस व्यू सेट करें",
+        "setTheme": "थीम सेट करें",
+        "setZoom": "ज़ूम सेट करें",
+        "startScheduleNow": "शेड्यूल अभी शुरू करें"
+    },
+    "nav": {
+        "categories": "श्रेणियां",
+        "focus10h": "10घं",
+        "focus12h": "12घं",
+        "focus16h": "16घं",
+        "focus20h": "20घं",
+        "focus24h": "24घं",
+        "focus4h": "4घं",
+        "focus6h": "6घं",
+        "focus8h": "8घं",
+        "focusLabel": "फ़ोकस",
+        "newSchedule": "नया",
+        "themeDark": "डार्क",
+        "themeLight": "लाइट",
+        "themeSystem": "ऑटो",
+        "workingHours": "घंटे",
+        "zoomIn": "ज़ूम इन",
+        "zoomOut": "ज़ूम आउट"
+    },
+    "onboarding": {
+        "addFirst": "पहला शेड्यूल जोड़ें",
+        "firstSchedule": "साप्ताहिक ग्रिड, आज की टाइमलाइन और एनालॉग घड़ी पर देखने के लिए अपना पहला शेड्यूल जोड़ें।",
+        "welcome": "अभी तक कोई शेड्यूल नहीं"
+    },
+    "schedule": {
+        "afterLastNoneHint": "कोई आगामी शेड्यूल नहीं",
+        "buttonAfterLast": "अंतिम शेड्यूल के बाद अगला",
+        "buttonMinus10": "-10मि",
+        "buttonMinus30": "-30मि",
+        "buttonPlus10": "+10मि",
+        "buttonPlus30": "+30मि",
+        "buttonPlusHour": "+1घं",
+        "categoryAddOption": "+ श्रेणी जोड़ें",
+        "chainedCheckbox": "पिछले शेड्यूल से जोड़ें",
+        "endLabelV2": "समाप्ति समय",
+        "endPlaceholder": "अवधि चुनें",
+        "fieldCategory": "श्रेणी",
+        "fieldDuration": "अवधि (मिनट)",
+        "fieldName": "नाम",
+        "fieldStartHour": "शुरुआती घंटा",
+        "fieldStartMinute": "शुरुआत मिनट",
+        "headerEdit": "शेड्यूल संपादित करें",
+        "headerNew": "नया शेड्यूल",
+        "hourSuffix": "घं",
+        "hourTodaySuffix": "(आज)",
+        "hourTomorrowSuffix": "(कल)",
+        "minuteSuffix": "मि",
+        "prevChainLabel": "पिछला शेड्यूल जुड़ा हुआ",
+        "titleDefault": "नया शेड्यूल",
+        "warningOverlapLimit": "अधिकतम {limit} शेड्यूल एक ही समय पर ओवरलैप हो सकते हैं। शुरुआत/अवधि समायोजित करें या मौजूदा को हटाएं।"
+    },
+    "serverError": {
+        "categoryHasSchedules": "श्रेणी में {scheduleCount} शेड्यूल हैं। हटाने के लिए कैस्केड डिलीट की पुष्टि करें।",
+        "categoryNotFound": "श्रेणी नहीं मिली या स्वामित्व में नहीं।",
+        "scheduleNotFound": "शेड्यूल नहीं मिला।",
+        "unauthorized": "साइन इन आवश्यक।"
+    },
+    "signIn": {
+        "cta": "साइन इन करें",
+        "description": "अपने शेड्यूल देखने और प्रबंधित करने के लिए अपने cofounder खाते में साइन इन करें।",
+        "title": "साइन इन आवश्यक"
+    },
+    "timer": {
+        "buttonComplete": "पूर्ण",
+        "buttonFocus": "फ़ोकस",
+        "buttonIdle": "निष्क्रिय",
+        "buttonStartNow": "अभी शुरू करें",
+        "categoryFallback": "?",
+        "idleEmpty": "निष्क्रिय · कोई सक्रिय शेड्यूल नहीं",
+        "labelElapsed": "बीता हुआ",
+        "labelEndAt": "समाप्ति-पर",
+        "labelRemaining": "शेष",
+        "labelTarget": "लक्ष्य",
+        "labelUntilUpcoming": "आगामी तक",
+        "labelUpcoming": "अगला शेड्यूल",
+        "overlapLabel": "ओवरलैप {count}",
+        "simultaneousLabel": "एक साथ · {count}",
+        "tooltipClickToFocus": "फ़ोकस पर स्विच करने के लिए क्लिक करें",
+        "tooltipClickToIdle": "निष्क्रिय पर स्विच करने के लिए क्लिक करें",
+        "typeCountdown": "काउंटडाउन",
+        "typeCountup": "काउंटअप",
+        "typeTimer1": "टाइमर1"
+    },
+    "topbar": {
+        "back": "पोर्टल पर वापस जाएं",
+        "creditsLabel": "क्रेडिट",
+        "creditsPlaceholder": "—",
+        "guest": "अतिथि",
+        "languageLabel": "भाषा",
+        "logout": "लॉगआउट"
+    },
+    "undo": {
+        "actionLabel": "पूर्ववत उपलब्ध",
+        "button": "पूर्ववत करें"
+    },
+    "wallTime": {
+        "am": "पूर्वाह्न",
+        "pm": "pm"
+    },
+    "weekdays": [
+        "रवि",
+        "सोम",
+        "मंगल",
+        "बुध",
+        "गुरु",
+        "शुक्र",
+        "शनि"
+    ],
+    "workingHours": {
+        "checkboxAlsoDefault": "डिफ़ॉल्ट के रूप में भी सहेजें",
+        "checkboxWeekdaysOnly": "केवल सप्ताह के दिन (सोम–शुक्र)",
+        "errorEndAfterStart": "समाप्ति समय शुरुआती समय के बाद होना चाहिए।",
+        "errorToAfterFrom": "समाप्ति तिथि शुरुआती तिथि को या उसके बाद होनी चाहिए।",
+        "fieldDate": "तारीख",
+        "fieldEndTime": "समाप्ति समय",
+        "fieldFromDate": "से",
+        "fieldStartTime": "शुरुआत का समय",
+        "fieldToDate": "तक",
+        "header": "कार्य घंटे",
+        "tabRange": "रेंज",
+        "tabSingle": "एकल",
+        "warningNoDates": "रेंज में लागू करने के लिए कोई तिथियां नहीं। (शुरुआत > अंत या सप्ताह के दिनों-केवल विरोध)",
+        "warningTruncated": "रेंज {max} दिनों से अधिक है, केवल आंशिक प्रोसेस किया गया। एक संकीर्ण रेंज का प्रयास करें।"
+    }
 }

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -5,19 +5,19 @@
     },
     "auth": {
         "signIn": "Googleでサインイン",
-        "signInDescription": "plan1はデバイス間同期機能を備えた個人用スケジュールツールです。Googleでサインインして始めましょう。",
+        "signInDescription": "plan1はクロスデバイス同期機能付きの個人用スケジュールツールです。Googleでサインインして開始してください。",
         "signInRequired": "plan1を使用するにはサインインしてください"
     },
     "category": {
-        "confirmRemoveLabel": "削除を確認 ({count})",
-        "confirmRemoveText": "{count} 件のスケジュールがこれと共に削除されます。もう一度クリックして確認してください。",
+        "confirmRemoveLabel": "削除確認 ({count})",
+        "confirmRemoveText": "これにより{count}個のスケジュールが削除されます。確認するにはもう一度クリックしてください。",
         "defaultName": "デフォルト",
         "empty": "カテゴリがありません。",
         "fieldColor": "色",
         "fieldName": "名前",
         "header": "カテゴリ",
         "removeButton": "削除",
-        "scheduleCountSuffix": "{count} 件のスケジュール"
+        "scheduleCountSuffix": "{count}個のスケジュール"
     },
     "common": {
         "add": "追加",
@@ -36,9 +36,9 @@
     "error": {
         "featureUnavailable": "この機能はまだ利用できません ({feature})。",
         "loadFailedLabel": "読み込み失敗:",
-        "mutationFailed": "{action} に失敗しました: {error}",
+        "mutationFailed": "{action}に失敗しました: {error}",
         "unknown": "予期しないエラーが発生しました。もう一度お試しください。",
-        "workingHoursInvalid": "無効な稼働時間の入力 ({reason})。"
+        "workingHoursInvalid": "無効な作業時間の入力です ({reason})。"
     },
     "header": {
         "finalEndAtSuffix": "終了"
@@ -64,7 +64,7 @@
         "focus4h": "4時間",
         "focus6h": "6時間",
         "focus8h": "8時間",
-        "focusLabel": "フォーカス",
+        "focusLabel": "集中",
         "newSchedule": "新規",
         "themeDark": "ダーク",
         "themeLight": "ライト",
@@ -76,11 +76,11 @@
     "onboarding": {
         "addFirst": "最初のスケジュールを追加",
         "firstSchedule": "最初のスケジュールを追加すると、週間グリッド、今日のタイムライン、アナログ時計に表示されます。",
-        "welcome": "スケジュールはまだありません"
+        "welcome": "スケジュールがまだありません"
     },
     "schedule": {
-        "afterLastNoneHint": "今後の予定はありません",
-        "buttonAfterLast": "最後のスケジュールの後",
+        "afterLastNoneHint": "今後のスケジュールなし",
+        "buttonAfterLast": "最後のスケジュールの次",
         "buttonMinus10": "-10分",
         "buttonMinus30": "-30分",
         "buttonPlus10": "+10分",
@@ -90,7 +90,7 @@
         "chainedCheckbox": "前のスケジュールに連結",
         "endLabelV2": "終了時刻",
         "endPlaceholder": "期間を選択",
-        "fieldCategory": "カテゴリ",
+        "fieldCategory": "カテゴリー",
         "fieldDuration": "期間 (分)",
         "fieldName": "名前",
         "fieldStartHour": "開始時",
@@ -101,13 +101,13 @@
         "hourTodaySuffix": "(今日)",
         "hourTomorrowSuffix": "(明日)",
         "minuteSuffix": "分",
-        "prevChainLabel": "前のスケジュールに接続しました",
+        "prevChainLabel": "前のスケジュールに接続済み",
         "titleDefault": "新しいスケジュール",
-        "warningOverlapLimit": "同時に重複できるスケジュールは最大 {limit} 件です。開始時刻/期間を調整するか、既存のものを削除してください。"
+        "warningOverlapLimit": "最大{limit}個のスケジュールが同時に重複できます。開始時刻/期間を調整するか、既存のものを削除してください。"
     },
     "serverError": {
-        "categoryHasSchedules": "カテゴリには {scheduleCount} 件のスケジュールがあります。削除するには連鎖削除を確認してください。",
-        "categoryNotFound": "カテゴリが見つからないか、所有されていません。",
+        "categoryHasSchedules": "カテゴリには{scheduleCount}個のスケジュールがあります。削除するにはカスケード削除を確認してください。",
+        "categoryNotFound": "カテゴリーが見つからないか、所有していません。",
         "scheduleNotFound": "スケジュールが見つかりません。",
         "unauthorized": "サインインが必要です。"
     },
@@ -118,7 +118,7 @@
     },
     "timer": {
         "buttonComplete": "完了",
-        "buttonFocus": "フォーカス",
+        "buttonFocus": "集中",
         "buttonIdle": "待機中",
         "buttonStartNow": "今すぐ開始",
         "categoryFallback": "?",
@@ -129,13 +129,13 @@
         "labelTarget": "目標",
         "labelUntilUpcoming": "次の予定まで",
         "labelUpcoming": "次のスケジュール",
-        "overlapLabel": "重複 {count}",
-        "simultaneousLabel": "同時進行 · {count} 件",
+        "overlapLabel": "{count}個重複",
+        "simultaneousLabel": "同時 · {count}",
         "tooltipClickToFocus": "クリックしてフォーカスに切り替え",
         "tooltipClickToIdle": "クリックして待機中に切り替え",
         "typeCountdown": "カウントダウン",
         "typeCountup": "カウントアップ",
-        "typeTimer1": "タイマー1"
+        "typeTimer1": "timer1"
     },
     "topbar": {
         "back": "ポータルに戻る",
@@ -146,7 +146,7 @@
         "logout": "ログアウト"
     },
     "undo": {
-        "actionLabel": "元に戻すが可能です",
+        "actionLabel": "元に戻すことができます",
         "button": "元に戻す"
     },
     "wallTime": {
@@ -169,13 +169,13 @@
         "errorToAfterFrom": "終了日は開始日以降である必要があります。",
         "fieldDate": "日付",
         "fieldEndTime": "終了時刻",
-        "fieldFromDate": "から",
+        "fieldFromDate": "開始",
         "fieldStartTime": "開始時刻",
-        "fieldToDate": "まで",
+        "fieldToDate": "終了",
         "header": "稼働時間",
         "tabRange": "範囲",
         "tabSingle": "単一",
-        "warningNoDates": "範囲内に適用する日付がありません。(開始 > 終了、または平日のみの競合)",
-        "warningTruncated": "範囲が {max} 日を超えています。一部のみ処理されました。範囲を狭めてください。"
+        "warningNoDates": "範囲内に適用する日付がありません。(開始 > 終了 または 平日のみの競合)",
+        "warningTruncated": "範囲が{max}日を超えているため、一部のみ処理されました。より狭い範囲を試してください。"
     }
 }

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -1,29 +1,29 @@
 {
     "app": {
         "tagline": "スケジュール管理",
-        "title": "プラン1"
+        "title": "plan1"
     },
     "auth": {
-        "signIn": "Googleでサインイン",
-        "signInDescription": "plan1はクロスデバイス同期機能付きの個人用スケジュールツールです。Googleでサインインして開始してください。",
-        "signInRequired": "plan1を使用するにはサインインしてください"
+        "signIn": "Googleでログイン",
+        "signInDescription": "plan1はクロスデバイス同期を備えた個人用スケジュールツールです。Googleでログインして始めましょう。",
+        "signInRequired": "plan1を使用するにはログインしてください"
     },
     "category": {
-        "confirmRemoveLabel": "削除確認 ({count})",
-        "confirmRemoveText": "これにより{count}個のスケジュールが削除されます。確認するにはもう一度クリックしてください。",
+        "confirmRemoveLabel": "削除を確認 ({count})",
+        "confirmRemoveText": "{count} 件のスケジュールがこれと共に削除されます。確認するには再度クリックしてください。",
         "defaultName": "デフォルト",
         "empty": "カテゴリがありません。",
         "fieldColor": "色",
         "fieldName": "名前",
         "header": "カテゴリ",
         "removeButton": "削除",
-        "scheduleCountSuffix": "{count}個のスケジュール"
+        "scheduleCountSuffix": "{count} 件のスケジュール"
     },
     "common": {
         "add": "追加",
         "cancel": "キャンセル",
         "close": "閉じる",
-        "confirmDelete": "削除の確認",
+        "confirmDelete": "削除を確認",
         "delete": "削除",
         "dismiss": "閉じる",
         "now": "現在",
@@ -38,7 +38,7 @@
         "loadFailedLabel": "読み込み失敗:",
         "mutationFailed": "{action}に失敗しました: {error}",
         "unknown": "予期しないエラーが発生しました。もう一度お試しください。",
-        "workingHoursInvalid": "無効な作業時間の入力です ({reason})。"
+        "workingHoursInvalid": "無効な作業時間の入力 ({reason})。"
     },
     "header": {
         "finalEndAtSuffix": "終了"
@@ -49,7 +49,7 @@
         "completeSchedule": "スケジュールを完了",
         "extendTimer": "タイマーを延長",
         "removeCategory": "カテゴリを削除",
-        "setFocus": "フォーカスビューを設定",
+        "setFocus": "集中ビューを設定",
         "setTheme": "テーマを設定",
         "setZoom": "ズームを設定",
         "startScheduleNow": "今すぐスケジュールを開始"
@@ -76,11 +76,11 @@
     "onboarding": {
         "addFirst": "最初のスケジュールを追加",
         "firstSchedule": "最初のスケジュールを追加すると、週間グリッド、今日のタイムライン、アナログ時計に表示されます。",
-        "welcome": "スケジュールがまだありません"
+        "welcome": "まだスケジュールがありません"
     },
     "schedule": {
-        "afterLastNoneHint": "今後のスケジュールなし",
-        "buttonAfterLast": "最後のスケジュールの次",
+        "afterLastNoneHint": "予定なし",
+        "buttonAfterLast": "最後のスケジュールの後",
         "buttonMinus10": "-10分",
         "buttonMinus30": "-30分",
         "buttonPlus10": "+10分",
@@ -90,10 +90,10 @@
         "chainedCheckbox": "前のスケジュールに連結",
         "endLabelV2": "終了時刻",
         "endPlaceholder": "期間を選択",
-        "fieldCategory": "カテゴリー",
-        "fieldDuration": "期間 (分)",
+        "fieldCategory": "カテゴリ",
+        "fieldDuration": "期間(分)",
         "fieldName": "名前",
-        "fieldStartHour": "開始時",
+        "fieldStartHour": "開始時刻",
         "fieldStartMinute": "開始分",
         "headerEdit": "スケジュールを編集",
         "headerNew": "新しいスケジュール",
@@ -101,20 +101,20 @@
         "hourTodaySuffix": "(今日)",
         "hourTomorrowSuffix": "(明日)",
         "minuteSuffix": "分",
-        "prevChainLabel": "前のスケジュールに接続済み",
+        "prevChainLabel": "接続された前のスケジュール",
         "titleDefault": "新しいスケジュール",
-        "warningOverlapLimit": "最大{limit}個のスケジュールが同時に重複できます。開始時刻/期間を調整するか、既存のものを削除してください。"
+        "warningOverlapLimit": "同時に重複できるスケジュールは最大 {limit} 件です。開始時刻/期間を調整するか、既存のスケジュールを削除してください。"
     },
     "serverError": {
-        "categoryHasSchedules": "カテゴリには{scheduleCount}個のスケジュールがあります。削除するにはカスケード削除を確認してください。",
-        "categoryNotFound": "カテゴリーが見つからないか、所有していません。",
+        "categoryHasSchedules": "カテゴリには {scheduleCount} 件のスケジュールがあります。削除するには連鎖削除を確認してください。",
+        "categoryNotFound": "カテゴリが見つからないか、所有していません。",
         "scheduleNotFound": "スケジュールが見つかりません。",
-        "unauthorized": "サインインが必要です。"
+        "unauthorized": "ログインが必要です。"
     },
     "signIn": {
-        "cta": "サインイン",
-        "description": "共同創設者アカウントにサインインして、スケジュールを表示および管理してください。",
-        "title": "サインインが必要です"
+        "cta": "ログイン",
+        "description": "cofounderアカウントにログインして、スケジュールを表示および管理してください。",
+        "title": "ログインが必要です"
     },
     "timer": {
         "buttonComplete": "完了",
@@ -129,13 +129,13 @@
         "labelTarget": "目標",
         "labelUntilUpcoming": "次の予定まで",
         "labelUpcoming": "次のスケジュール",
-        "overlapLabel": "{count}個重複",
-        "simultaneousLabel": "同時 · {count}",
-        "tooltipClickToFocus": "クリックしてフォーカスに切り替え",
+        "overlapLabel": "重複 {count}",
+        "simultaneousLabel": "同時進行 · {count}",
+        "tooltipClickToFocus": "クリックして集中に切り替え",
         "tooltipClickToIdle": "クリックして待機中に切り替え",
         "typeCountdown": "カウントダウン",
         "typeCountup": "カウントアップ",
-        "typeTimer1": "timer1"
+        "typeTimer1": "タイマー1"
     },
     "topbar": {
         "back": "ポータルに戻る",
@@ -146,7 +146,7 @@
         "logout": "ログアウト"
     },
     "undo": {
-        "actionLabel": "元に戻すことができます",
+        "actionLabel": "元に戻す可能",
         "button": "元に戻す"
     },
     "wallTime": {
@@ -172,10 +172,10 @@
         "fieldFromDate": "開始",
         "fieldStartTime": "開始時刻",
         "fieldToDate": "終了",
-        "header": "稼働時間",
+        "header": "作業時間",
         "tabRange": "範囲",
         "tabSingle": "単一",
         "warningNoDates": "範囲内に適用する日付がありません。(開始 > 終了 または 平日のみの競合)",
-        "warningTruncated": "範囲が{max}日を超えているため、一部のみ処理されました。より狭い範囲を試してください。"
+        "warningTruncated": "範囲が {max} 日を超えているため、一部のみ処理されました。範囲を狭めてお試しください。"
     }
 }

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -1,181 +1,181 @@
 {
-  "app": {
-    "tagline": "スケジュール管理",
-    "title": "plan1"
-  },
-  "auth": {
-    "signIn": "Googleでログイン",
-    "signInDescription": "plan1はクロスデバイス同期機能を備えた個人用スケジュールツールです。Googleでログインして始めましょう。",
-    "signInRequired": "plan1を使用するにはログインしてください"
-  },
-  "category": {
-    "confirmRemoveLabel": "削除の確認({count}件)",
-    "confirmRemoveText": "{count}件のスケジュールが一緒に削除されます。もう一度クリックして確認してください。",
-    "defaultName": "デフォルト",
-    "empty": "カテゴリがありません。",
-    "fieldColor": "色",
-    "fieldName": "名前",
-    "header": "カテゴリ",
-    "removeButton": "削除",
-    "scheduleCountSuffix": "{count}件のスケジュール"
-  },
-  "common": {
-    "add": "追加",
-    "cancel": "キャンセル",
-    "close": "閉じる",
-    "confirmDelete": "削除の確認",
-    "delete": "削除",
-    "dismiss": "閉じる",
-    "now": "今",
-    "retry": "再試行",
-    "save": "保存"
-  },
-  "confirmation": {
-    "scheduleAdded": "スケジュールを追加しました"
-  },
-  "error": {
-    "featureUnavailable": "この機能はまだ利用できません（{feature}）。",
-    "loadFailedLabel": "読み込み失敗:",
-    "mutationFailed": "{action}に失敗しました: {error}",
-    "unknown": "予期しないエラーが発生しました。もう一度お試しください。",
-    "workingHoursInvalid": "無効な稼働時間の入力({reason})。"
-  },
-  "loading": "読み込み中...",
-  "mutation": {
-    "changeTimerType": "タイマータイプを変更",
-    "completeSchedule": "スケジュールを完了",
-    "extendTimer": "タイマーを延長",
-    "removeCategory": "カテゴリを削除",
-    "setFocus": "フォーカスビューを設定",
-    "setTheme": "テーマを設定",
-    "startScheduleNow": "start schedule now",
-    "setZoom": "ズーム設定"
-  },
-  "nav": {
-    "categories": "カテゴリ",
-    "focus10h": "10時間",
-    "focus12h": "12時間",
-    "focus16h": "16時間",
-    "focus20h": "20時間",
-    "focus24h": "24時間",
-    "focus4h": "4時間",
-    "focus6h": "6時間",
-    "focus8h": "8時間",
-    "focusLabel": "集中",
-    "newSchedule": "新規",
-    "themeDark": "ダーク",
-    "themeLight": "ライト",
-    "themeSystem": "自動",
-    "workingHours": "時間",
-    "zoomIn": "拡大",
-    "zoomOut": "縮小"
-  },
-  "onboarding": {
-    "addFirst": "最初のスケジュールを追加",
-    "firstSchedule": "最初のスケジュールを追加すると、週間グリッド、今日のタイムライン、アナログ時計に表示されます。",
-    "welcome": "スケジュールはまだありません"
-  },
-  "schedule": {
-    "afterLastNoneHint": "今後のスケジュールはありません",
-    "buttonAfterLast": "next after last schedule",
-    "buttonMinus10": "-10分",
-    "buttonMinus30": "-30分",
-    "buttonPlus10": "+10分",
-    "buttonPlus30": "+30分",
-    "buttonPlusHour": "+1時間",
-    "categoryAddOption": "+ カテゴリを追加",
-    "chainedCheckbox": "前のスケジュールに連結",
-    "endLabelV2": "終了時刻",
-    "endPlaceholder": "期間を選択",
-    "fieldCategory": "カテゴリ",
-    "fieldDuration": "期間（分）",
-    "fieldName": "名前",
-    "fieldStartHour": "開始時刻",
-    "fieldStartMinute": "開始分",
-    "headerEdit": "スケジュールを編集",
-    "headerNew": "新しいスケジュール",
-    "hourSuffix": "時間",
-    "hourTodaySuffix": "(今日)",
-    "hourTomorrowSuffix": "(明日)",
-    "minuteSuffix": "分",
-    "prevChainLabel": "前のスケジュールに接続済み",
-    "titleDefault": "新しいスケジュール",
-    "warningOverlapLimit": "最大{limit}件のスケジュールが同時に重複できます。開始時刻/期間を調整するか、既存のものを削除してください。"
-  },
-  "serverError": {
-    "categoryHasSchedules": "カテゴリには{scheduleCount}件のスケジュールがあります。削除するには連鎖削除を確認してください。",
-    "categoryNotFound": "カテゴリが見つからないか、所有していません。",
-    "scheduleNotFound": "スケジュールが見つかりません。",
-    "unauthorized": "ログインが必要です。"
-  },
-  "signIn": {
-    "cta": "ログイン",
-    "description": "スケジュールを表示および管理するには、cofounderアカウントにログインしてください。",
-    "title": "ログインが必要です"
-  },
-  "timer": {
-    "buttonComplete": "完了",
-    "buttonFocus": "集中",
-    "buttonIdle": "待機中",
-    "categoryFallback": "?",
-    "idleEmpty": "待機中 · アクティブなスケジュールなし",
-    "labelElapsed": "経過",
-    "labelEndAt": "終了時刻",
-    "labelRemaining": "残り",
-    "labelTarget": "目標",
-    "labelUntilUpcoming": "次の予定まで",
-    "labelUpcoming": "次のスケジュール",
-    "overlapLabel": "重複 {count}",
-    "simultaneousLabel": "同時 · {count}",
-    "tooltipClickToFocus": "クリックして集中モードに切り替え",
-    "tooltipClickToIdle": "クリックして待機中に切り替え",
-    "typeCountdown": "カウントダウン",
-    "typeCountup": "カウントアップ",
-    "typeTimer1": "タイマー1",
-    "buttonStartNow": "start now"
-  },
-  "topbar": {
-    "back": "ポータルに戻る",
-    "creditsLabel": "クレジット",
-    "creditsPlaceholder": "—",
-    "guest": "ゲスト",
-    "languageLabel": "言語",
-    "logout": "ログアウト"
-  },
-  "undo": {
-    "actionLabel": "元に戻すが可能",
-    "button": "元に戻す"
-  },
-  "wallTime": {
-    "am": "午前",
-    "pm": "午後"
-  },
-  "weekdays": [
-    "日",
-    "月",
-    "火",
-    "水",
-    "木",
-    "金",
-    "土"
-  ],
-  "workingHours": {
-    "checkboxAlsoDefault": "デフォルトとしても保存",
-    "checkboxWeekdaysOnly": "平日のみ（月〜金）",
-    "errorEndAfterStart": "終了時刻は開始時刻より後である必要があります。",
-    "errorToAfterFrom": "終了日は開始日以降である必要があります。",
-    "fieldDate": "日付",
-    "fieldEndTime": "終了時刻",
-    "fieldFromDate": "開始",
-    "fieldStartTime": "開始時刻",
-    "fieldToDate": "終了",
-    "header": "勤務時間",
-    "tabRange": "範囲",
-    "tabSingle": "単一",
-    "warningNoDates": "範囲内に適用する日付がありません。（開始 > 終了 または 平日のみの競合）",
-    "warningTruncated": "範囲が{max}日を超えているため、一部のみ処理されました。範囲を狭めてください。"
-  },
-  "header": {
-    "finalEndAtSuffix": "end"
-  }
+    "app": {
+        "tagline": "スケジュール管理",
+        "title": "プラン1"
+    },
+    "auth": {
+        "signIn": "Googleでサインイン",
+        "signInDescription": "plan1はデバイス間同期機能を備えた個人用スケジュールツールです。Googleでサインインして始めましょう。",
+        "signInRequired": "plan1を使用するにはサインインしてください"
+    },
+    "category": {
+        "confirmRemoveLabel": "削除を確認 ({count})",
+        "confirmRemoveText": "{count} 件のスケジュールがこれと共に削除されます。もう一度クリックして確認してください。",
+        "defaultName": "デフォルト",
+        "empty": "カテゴリがありません。",
+        "fieldColor": "色",
+        "fieldName": "名前",
+        "header": "カテゴリ",
+        "removeButton": "削除",
+        "scheduleCountSuffix": "{count} 件のスケジュール"
+    },
+    "common": {
+        "add": "追加",
+        "cancel": "キャンセル",
+        "close": "閉じる",
+        "confirmDelete": "削除の確認",
+        "delete": "削除",
+        "dismiss": "閉じる",
+        "now": "現在",
+        "retry": "再試行",
+        "save": "保存"
+    },
+    "confirmation": {
+        "scheduleAdded": "スケジュールを追加しました"
+    },
+    "error": {
+        "featureUnavailable": "この機能はまだ利用できません ({feature})。",
+        "loadFailedLabel": "読み込み失敗:",
+        "mutationFailed": "{action} に失敗しました: {error}",
+        "unknown": "予期しないエラーが発生しました。もう一度お試しください。",
+        "workingHoursInvalid": "無効な稼働時間の入力 ({reason})。"
+    },
+    "header": {
+        "finalEndAtSuffix": "終了"
+    },
+    "loading": "読み込み中...",
+    "mutation": {
+        "changeTimerType": "タイマータイプを変更",
+        "completeSchedule": "スケジュールを完了",
+        "extendTimer": "タイマーを延長",
+        "removeCategory": "カテゴリを削除",
+        "setFocus": "フォーカスビューを設定",
+        "setTheme": "テーマを設定",
+        "setZoom": "ズームを設定",
+        "startScheduleNow": "今すぐスケジュールを開始"
+    },
+    "nav": {
+        "categories": "カテゴリ",
+        "focus10h": "10時間",
+        "focus12h": "12時間",
+        "focus16h": "16時間",
+        "focus20h": "20時間",
+        "focus24h": "24時間",
+        "focus4h": "4時間",
+        "focus6h": "6時間",
+        "focus8h": "8時間",
+        "focusLabel": "フォーカス",
+        "newSchedule": "新規",
+        "themeDark": "ダーク",
+        "themeLight": "ライト",
+        "themeSystem": "自動",
+        "workingHours": "時間",
+        "zoomIn": "ズームイン",
+        "zoomOut": "ズームアウト"
+    },
+    "onboarding": {
+        "addFirst": "最初のスケジュールを追加",
+        "firstSchedule": "最初のスケジュールを追加すると、週間グリッド、今日のタイムライン、アナログ時計に表示されます。",
+        "welcome": "スケジュールはまだありません"
+    },
+    "schedule": {
+        "afterLastNoneHint": "今後の予定はありません",
+        "buttonAfterLast": "最後のスケジュールの後",
+        "buttonMinus10": "-10分",
+        "buttonMinus30": "-30分",
+        "buttonPlus10": "+10分",
+        "buttonPlus30": "+30分",
+        "buttonPlusHour": "+1時間",
+        "categoryAddOption": "+ カテゴリを追加",
+        "chainedCheckbox": "前のスケジュールに連結",
+        "endLabelV2": "終了時刻",
+        "endPlaceholder": "期間を選択",
+        "fieldCategory": "カテゴリ",
+        "fieldDuration": "期間 (分)",
+        "fieldName": "名前",
+        "fieldStartHour": "開始時",
+        "fieldStartMinute": "開始分",
+        "headerEdit": "スケジュールを編集",
+        "headerNew": "新しいスケジュール",
+        "hourSuffix": "時間",
+        "hourTodaySuffix": "(今日)",
+        "hourTomorrowSuffix": "(明日)",
+        "minuteSuffix": "分",
+        "prevChainLabel": "前のスケジュールに接続しました",
+        "titleDefault": "新しいスケジュール",
+        "warningOverlapLimit": "同時に重複できるスケジュールは最大 {limit} 件です。開始時刻/期間を調整するか、既存のものを削除してください。"
+    },
+    "serverError": {
+        "categoryHasSchedules": "カテゴリには {scheduleCount} 件のスケジュールがあります。削除するには連鎖削除を確認してください。",
+        "categoryNotFound": "カテゴリが見つからないか、所有されていません。",
+        "scheduleNotFound": "スケジュールが見つかりません。",
+        "unauthorized": "サインインが必要です。"
+    },
+    "signIn": {
+        "cta": "サインイン",
+        "description": "共同創設者アカウントにサインインして、スケジュールを表示および管理してください。",
+        "title": "サインインが必要です"
+    },
+    "timer": {
+        "buttonComplete": "完了",
+        "buttonFocus": "フォーカス",
+        "buttonIdle": "待機中",
+        "buttonStartNow": "今すぐ開始",
+        "categoryFallback": "?",
+        "idleEmpty": "待機中 · アクティブなスケジュールなし",
+        "labelElapsed": "経過",
+        "labelEndAt": "終了時刻",
+        "labelRemaining": "残り",
+        "labelTarget": "目標",
+        "labelUntilUpcoming": "次の予定まで",
+        "labelUpcoming": "次のスケジュール",
+        "overlapLabel": "重複 {count}",
+        "simultaneousLabel": "同時進行 · {count} 件",
+        "tooltipClickToFocus": "クリックしてフォーカスに切り替え",
+        "tooltipClickToIdle": "クリックして待機中に切り替え",
+        "typeCountdown": "カウントダウン",
+        "typeCountup": "カウントアップ",
+        "typeTimer1": "タイマー1"
+    },
+    "topbar": {
+        "back": "ポータルに戻る",
+        "creditsLabel": "クレジット",
+        "creditsPlaceholder": "—",
+        "guest": "ゲスト",
+        "languageLabel": "言語",
+        "logout": "ログアウト"
+    },
+    "undo": {
+        "actionLabel": "元に戻すが可能です",
+        "button": "元に戻す"
+    },
+    "wallTime": {
+        "am": "午前",
+        "pm": "午後"
+    },
+    "weekdays": [
+        "日",
+        "月",
+        "火",
+        "水",
+        "木",
+        "金",
+        "土"
+    ],
+    "workingHours": {
+        "checkboxAlsoDefault": "デフォルトとしても保存",
+        "checkboxWeekdaysOnly": "平日のみ (月–金)",
+        "errorEndAfterStart": "終了時刻は開始時刻より後である必要があります。",
+        "errorToAfterFrom": "終了日は開始日以降である必要があります。",
+        "fieldDate": "日付",
+        "fieldEndTime": "終了時刻",
+        "fieldFromDate": "から",
+        "fieldStartTime": "開始時刻",
+        "fieldToDate": "まで",
+        "header": "稼働時間",
+        "tabRange": "範囲",
+        "tabSingle": "単一",
+        "warningNoDates": "範囲内に適用する日付がありません。(開始 > 終了、または平日のみの競合)",
+        "warningTruncated": "範囲が {max} 日を超えています。一部のみ処理されました。範囲を狭めてください。"
+    }
 }

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -48,7 +48,8 @@
     "removeCategory": "カテゴリを削除",
     "setFocus": "フォーカスビューを設定",
     "setTheme": "テーマを設定",
-    "startScheduleNow": "start schedule now"
+    "startScheduleNow": "start schedule now",
+    "setZoom": "ズーム設定"
   },
   "nav": {
     "categories": "カテゴリ",
@@ -65,7 +66,9 @@
     "themeDark": "ダーク",
     "themeLight": "ライト",
     "themeSystem": "自動",
-    "workingHours": "時間"
+    "workingHours": "時間",
+    "zoomIn": "拡大",
+    "zoomOut": "縮小"
   },
   "onboarding": {
     "addFirst": "最初のスケジュールを追加",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -26,7 +26,9 @@
     "focus12h": "12시간",
     "focus16h": "16시간",
     "focus20h": "20시간",
-    "focus24h": "24시간"
+    "focus24h": "24시간",
+    "zoomIn": "확대",
+    "zoomOut": "축소"
   },
   "common": {
     "cancel": "취소",
@@ -59,6 +61,7 @@
     "changeTimerType": "타이머 타입 변경",
     "setTheme": "테마 설정",
     "setFocus": "집중 보기 설정",
+    "setZoom": "줌 설정",
     "startScheduleNow": "스케줄 즉시 시작"
   },
   "onboarding": {

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -1,23 +1,23 @@
 {
     "app": {
-        "tagline": "gerenciador de agendamentos",
+        "tagline": "gerenciador de cronogramas",
         "title": "plano1"
     },
     "auth": {
         "signIn": "Entrar com Google",
-        "signInDescription": "plan1 é uma ferramenta de agendamento pessoal com sincronização entre dispositivos. Entre com o Google para começar.",
-        "signInRequired": "Entre para usar plano1"
+        "signInDescription": "plan1 é uma ferramenta de cronograma pessoal com sincronização entre dispositivos. Entre com Google para começar.",
+        "signInRequired": "Entre para usar o plan1"
     },
     "category": {
         "confirmRemoveLabel": "confirmar rm ({count})",
-        "confirmRemoveText": "{count} agendamento(s) será(ão) excluído(s) com isso. Clique novamente para confirmar.",
+        "confirmRemoveText": "{count} cronograma(s) será(ão) excluído(s) com isso. Clique novamente para confirmar.",
         "defaultName": "padrão",
         "empty": "Nenhuma categoria.",
         "fieldColor": "cor",
         "fieldName": "nome",
         "header": "categorias",
         "removeButton": "rm",
-        "scheduleCountSuffix": "{count} agendamentos"
+        "scheduleCountSuffix": "{count} cronogramas"
     },
     "common": {
         "add": "adicionar",
@@ -31,28 +31,28 @@
         "save": "salvar"
     },
     "confirmation": {
-        "scheduleAdded": "Agendamento adicionado"
+        "scheduleAdded": "Cronograma adicionado"
     },
     "error": {
         "featureUnavailable": "Este recurso ainda não está disponível ({feature}).",
         "loadFailedLabel": "falha ao carregar:",
         "mutationFailed": "Falha ao {action}: {error}",
         "unknown": "Ocorreu um erro inesperado. Por favor, tente novamente.",
-        "workingHoursInvalid": "Entrada de horas de trabalho inválida ({reason})."
+        "workingHoursInvalid": "Entrada de horário de trabalho inválida ({reason})."
     },
     "header": {
         "finalEndAtSuffix": "fim"
     },
     "loading": "carregando...",
     "mutation": {
-        "changeTimerType": "alterar tipo de temporizador",
-        "completeSchedule": "concluir agendamento",
-        "extendTimer": "estender temporizador",
+        "changeTimerType": "alterar tipo de timer",
+        "completeSchedule": "completar cronograma",
+        "extendTimer": "estender timer",
         "removeCategory": "remover categoria",
         "setFocus": "definir visualização de foco",
         "setTheme": "definir tema",
         "setZoom": "definir zoom",
-        "startScheduleNow": "iniciar agendamento agora"
+        "startScheduleNow": "iniciar cronograma agora"
     },
     "nav": {
         "categories": "categorias",
@@ -70,72 +70,72 @@
         "themeLight": "claro",
         "themeSystem": "automático",
         "workingHours": "horas",
-        "zoomIn": "aumentar zoom",
-        "zoomOut": "diminuir zoom"
+        "zoomIn": "ampliar",
+        "zoomOut": "reduzir"
     },
     "onboarding": {
-        "addFirst": "adicionar primeiro agendamento",
-        "firstSchedule": "Adicione seu primeiro agendamento para vê-lo na grade semanal, na linha do tempo de hoje e no relógio analógico.",
-        "welcome": "Nenhum agendamento ainda"
+        "addFirst": "adicionar primeiro cronograma",
+        "firstSchedule": "Adicione seu primeiro cronograma para vê-lo na grade semanal, linha do tempo de hoje e relógio analógico.",
+        "welcome": "Ainda sem cronogramas"
     },
     "schedule": {
-        "afterLastNoneHint": "nenhum agendamento próximo",
-        "buttonAfterLast": "próximo após o último agendamento",
+        "afterLastNoneHint": "nenhum cronograma próximo",
+        "buttonAfterLast": "próximo após o último cronograma",
         "buttonMinus10": "-10m",
         "buttonMinus30": "-30m",
         "buttonPlus10": "+10m",
         "buttonPlus30": "+30m",
         "buttonPlusHour": "+1h",
         "categoryAddOption": "+ adicionar categoria",
-        "chainedCheckbox": "encadear ao agendamento anterior",
-        "endLabelV2": "horário de término",
+        "chainedCheckbox": "encadear ao cronograma anterior",
+        "endLabelV2": "hora de término",
         "endPlaceholder": "selecionar duração",
         "fieldCategory": "categoria",
         "fieldDuration": "duração (min)",
         "fieldName": "nome",
         "fieldStartHour": "hora de início",
         "fieldStartMinute": "minuto de início",
-        "headerEdit": "editar agendamento",
-        "headerNew": "novo agendamento",
+        "headerEdit": "editar cronograma",
+        "headerNew": "novo cronograma",
         "hourSuffix": "h",
         "hourTodaySuffix": "(hoje)",
         "hourTomorrowSuffix": "(amanhã)",
         "minuteSuffix": "m",
-        "prevChainLabel": "agendamento anterior conectado",
-        "titleDefault": "Novo agendamento",
-        "warningOverlapLimit": "No máximo {limit} agendamentos podem se sobrepor ao mesmo tempo. Ajuste início/duração ou remova um existente."
+        "prevChainLabel": "cronograma anterior conectado",
+        "titleDefault": "Novo cronograma",
+        "warningOverlapLimit": "No máximo {limit} cronogramas podem se sobrepor ao mesmo tempo. Ajuste início/duração ou remova um existente."
     },
     "serverError": {
-        "categoryHasSchedules": "Categoria tem {scheduleCount} agendamentos. Confirme exclusão em cascata para remover.",
+        "categoryHasSchedules": "Categoria tem {scheduleCount} cronogramas. Confirme exclusão em cascata para remover.",
         "categoryNotFound": "Categoria não encontrada ou não pertence a você.",
-        "scheduleNotFound": "Agendamento não encontrado.",
+        "scheduleNotFound": "Cronograma não encontrado.",
         "unauthorized": "Entrada necessária."
     },
     "signIn": {
         "cta": "Entrar",
-        "description": "Entre na sua conta de cofundador para visualizar e gerenciar seus agendamentos.",
+        "description": "Entre na sua conta de cofundador para visualizar e gerenciar seus cronogramas.",
         "title": "Entrada necessária"
     },
     "timer": {
-        "buttonComplete": "concluir",
+        "buttonComplete": "completo",
         "buttonFocus": "foco",
         "buttonIdle": "ocioso",
         "buttonStartNow": "iniciar agora",
         "categoryFallback": "?",
-        "idleEmpty": "ocioso · nenhum agendamento ativo",
+        "idleEmpty": "ocioso · nenhum cronograma ativo",
         "labelElapsed": "decorrido",
-        "labelEndAt": "terminar-às",
+        "labelEndAt": "termina-às",
         "labelRemaining": "restante",
         "labelTarget": "alvo",
         "labelUntilUpcoming": "até o próximo",
-        "labelUpcoming": "próximo agendamento",
+        "labelUpcoming": "próximo cronograma",
         "overlapLabel": "sobreposição {count}",
         "simultaneousLabel": "simultâneo · {count}",
         "tooltipClickToFocus": "clique para mudar para foco",
         "tooltipClickToIdle": "clique para mudar para ocioso",
         "typeCountdown": "contagem regressiva",
-        "typeCountup": "contagem progressiva",
-        "typeTimer1": "temporizador1"
+        "typeCountup": "contagem crescente",
+        "typeTimer1": "timer1"
     },
     "topbar": {
         "back": "voltar ao portal",
@@ -163,19 +163,19 @@
         "sáb"
     ],
     "workingHours": {
-        "checkboxAlsoDefault": "salvar também como padrão",
+        "checkboxAlsoDefault": "também salvar como padrão",
         "checkboxWeekdaysOnly": "apenas dias úteis (seg–sex)",
-        "errorEndAfterStart": "Horário de término deve ser após horário de início.",
+        "errorEndAfterStart": "Hora de término deve ser após hora de início.",
         "errorToAfterFrom": "A data de término deve ser igual ou posterior à data de início.",
         "fieldDate": "data",
-        "fieldEndTime": "horário de término",
+        "fieldEndTime": "hora de término",
         "fieldFromDate": "de",
         "fieldStartTime": "hora de início",
         "fieldToDate": "até",
         "header": "horário de trabalho",
         "tabRange": "intervalo",
         "tabSingle": "único",
-        "warningNoDates": "Nenhuma data para aplicar no intervalo. (início > fim ou conflito de dias úteis)",
-        "warningTruncated": "Intervalo excede {max} dias, apenas parcialmente processado. Tente um intervalo menor."
+        "warningNoDates": "Nenhuma data para aplicar no intervalo. (início > fim ou conflito apenas dias úteis)",
+        "warningTruncated": "O intervalo excede {max} dias, apenas parcialmente processado. Tente um intervalo mais estreito."
     }
 }

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -48,7 +48,8 @@
     "removeCategory": "remover categoria",
     "setFocus": "definir visualização de foco",
     "setTheme": "definir tema",
-    "startScheduleNow": "start schedule now"
+    "startScheduleNow": "start schedule now",
+    "setZoom": "definir zoom"
   },
   "nav": {
     "categories": "categorias",
@@ -65,7 +66,9 @@
     "themeDark": "escuro",
     "themeLight": "claro",
     "themeSystem": "auto",
-    "workingHours": "horas"
+    "workingHours": "horas",
+    "zoomIn": "aumentar",
+    "zoomOut": "diminuir"
   },
   "onboarding": {
     "addFirst": "adicionar primeiro agendamento",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -1,23 +1,23 @@
 {
     "app": {
-        "tagline": "gerenciador de cronogramas",
+        "tagline": "gerenciador de agendamentos",
         "title": "plano1"
     },
     "auth": {
         "signIn": "Entrar com Google",
-        "signInDescription": "plan1 é uma ferramenta de cronograma pessoal com sincronização entre dispositivos. Entre com Google para começar.",
+        "signInDescription": "plan1 é uma ferramenta de agendamento pessoal com sincronização entre dispositivos. Entre com Google para começar.",
         "signInRequired": "Entre para usar o plan1"
     },
     "category": {
-        "confirmRemoveLabel": "confirmar rm ({count})",
-        "confirmRemoveText": "{count} cronograma(s) será(ão) excluído(s) com isso. Clique novamente para confirmar.",
+        "confirmRemoveLabel": "confirmar remoção ({count})",
+        "confirmRemoveText": "{count} agendamento(s) será(ão) excluído(s) com isso. Clique novamente para confirmar.",
         "defaultName": "padrão",
         "empty": "Nenhuma categoria.",
         "fieldColor": "cor",
         "fieldName": "nome",
         "header": "categorias",
         "removeButton": "rm",
-        "scheduleCountSuffix": "{count} cronogramas"
+        "scheduleCountSuffix": "{count} agendamentos"
     },
     "common": {
         "add": "adicionar",
@@ -31,7 +31,7 @@
         "save": "salvar"
     },
     "confirmation": {
-        "scheduleAdded": "Cronograma adicionado"
+        "scheduleAdded": "Agendamento adicionado"
     },
     "error": {
         "featureUnavailable": "Este recurso ainda não está disponível ({feature}).",
@@ -45,14 +45,14 @@
     },
     "loading": "carregando...",
     "mutation": {
-        "changeTimerType": "alterar tipo de timer",
-        "completeSchedule": "completar cronograma",
-        "extendTimer": "estender timer",
+        "changeTimerType": "alterar tipo de temporizador",
+        "completeSchedule": "completar agendamento",
+        "extendTimer": "estender temporizador",
         "removeCategory": "remover categoria",
         "setFocus": "definir visualização de foco",
         "setTheme": "definir tema",
         "setZoom": "definir zoom",
-        "startScheduleNow": "iniciar cronograma agora"
+        "startScheduleNow": "iniciar agendamento agora"
     },
     "nav": {
         "categories": "categorias",
@@ -68,53 +68,53 @@
         "newSchedule": "novo",
         "themeDark": "escuro",
         "themeLight": "claro",
-        "themeSystem": "automático",
+        "themeSystem": "auto",
         "workingHours": "horas",
-        "zoomIn": "ampliar",
-        "zoomOut": "reduzir"
+        "zoomIn": "aumentar zoom",
+        "zoomOut": "reduzir zoom"
     },
     "onboarding": {
-        "addFirst": "adicionar primeiro cronograma",
-        "firstSchedule": "Adicione seu primeiro cronograma para vê-lo na grade semanal, linha do tempo de hoje e relógio analógico.",
-        "welcome": "Ainda sem cronogramas"
+        "addFirst": "adicionar primeiro agendamento",
+        "firstSchedule": "Adicione seu primeiro agendamento para vê-lo na grade semanal, linha do tempo de hoje e relógio analógico.",
+        "welcome": "Nenhum agendamento ainda"
     },
     "schedule": {
-        "afterLastNoneHint": "nenhum cronograma próximo",
-        "buttonAfterLast": "próximo após o último cronograma",
+        "afterLastNoneHint": "nenhum agendamento próximo",
+        "buttonAfterLast": "próximo após último agendamento",
         "buttonMinus10": "-10m",
         "buttonMinus30": "-30m",
         "buttonPlus10": "+10m",
         "buttonPlus30": "+30m",
         "buttonPlusHour": "+1h",
         "categoryAddOption": "+ adicionar categoria",
-        "chainedCheckbox": "encadear ao cronograma anterior",
-        "endLabelV2": "hora de término",
+        "chainedCheckbox": "encadear ao agendamento anterior",
+        "endLabelV2": "horário de término",
         "endPlaceholder": "selecionar duração",
         "fieldCategory": "categoria",
         "fieldDuration": "duração (min)",
         "fieldName": "nome",
         "fieldStartHour": "hora de início",
         "fieldStartMinute": "minuto de início",
-        "headerEdit": "editar cronograma",
-        "headerNew": "novo cronograma",
+        "headerEdit": "editar agendamento",
+        "headerNew": "novo agendamento",
         "hourSuffix": "h",
         "hourTodaySuffix": "(hoje)",
         "hourTomorrowSuffix": "(amanhã)",
         "minuteSuffix": "m",
-        "prevChainLabel": "cronograma anterior conectado",
-        "titleDefault": "Novo cronograma",
-        "warningOverlapLimit": "No máximo {limit} cronogramas podem se sobrepor ao mesmo tempo. Ajuste início/duração ou remova um existente."
+        "prevChainLabel": "agendamento anterior conectado",
+        "titleDefault": "Novo agendamento",
+        "warningOverlapLimit": "No máximo {limit} agendamentos podem se sobrepor ao mesmo tempo. Ajuste início/duração ou remova um existente."
     },
     "serverError": {
-        "categoryHasSchedules": "Categoria tem {scheduleCount} cronogramas. Confirme exclusão em cascata para remover.",
+        "categoryHasSchedules": "Categoria tem {scheduleCount} agendamentos. Confirme exclusão em cascata para remover.",
         "categoryNotFound": "Categoria não encontrada ou não pertence a você.",
-        "scheduleNotFound": "Cronograma não encontrado.",
-        "unauthorized": "Entrada necessária."
+        "scheduleNotFound": "Agendamento não encontrado.",
+        "unauthorized": "Login necessário."
     },
     "signIn": {
         "cta": "Entrar",
-        "description": "Entre na sua conta de cofundador para visualizar e gerenciar seus cronogramas.",
-        "title": "Entrada necessária"
+        "description": "Entre na sua conta de cofundador para visualizar e gerenciar seus agendamentos.",
+        "title": "Login necessário"
     },
     "timer": {
         "buttonComplete": "completo",
@@ -122,19 +122,19 @@
         "buttonIdle": "ocioso",
         "buttonStartNow": "iniciar agora",
         "categoryFallback": "?",
-        "idleEmpty": "ocioso · nenhum cronograma ativo",
+        "idleEmpty": "ocioso · nenhum agendamento ativo",
         "labelElapsed": "decorrido",
-        "labelEndAt": "termina-às",
+        "labelEndAt": "termina-em",
         "labelRemaining": "restante",
-        "labelTarget": "alvo",
-        "labelUntilUpcoming": "até o próximo",
-        "labelUpcoming": "próximo cronograma",
+        "labelTarget": "objetivo",
+        "labelUntilUpcoming": "até próximo",
+        "labelUpcoming": "próximo agendamento",
         "overlapLabel": "sobreposição {count}",
         "simultaneousLabel": "simultâneo · {count}",
-        "tooltipClickToFocus": "clique para mudar para foco",
-        "tooltipClickToIdle": "clique para mudar para ocioso",
+        "tooltipClickToFocus": "clique para alternar para foco",
+        "tooltipClickToIdle": "clique para alternar para ocioso",
         "typeCountdown": "contagem regressiva",
-        "typeCountup": "contagem crescente",
+        "typeCountup": "contagem progressiva",
         "typeTimer1": "timer1"
     },
     "topbar": {
@@ -163,19 +163,19 @@
         "sáb"
     ],
     "workingHours": {
-        "checkboxAlsoDefault": "também salvar como padrão",
-        "checkboxWeekdaysOnly": "apenas dias úteis (seg–sex)",
-        "errorEndAfterStart": "Hora de término deve ser após hora de início.",
+        "checkboxAlsoDefault": "salvar também como padrão",
+        "checkboxWeekdaysOnly": "somente dias úteis (seg–sex)",
+        "errorEndAfterStart": "Horário de término deve ser após horário de início.",
         "errorToAfterFrom": "A data de término deve ser igual ou posterior à data de início.",
         "fieldDate": "data",
-        "fieldEndTime": "hora de término",
+        "fieldEndTime": "horário de término",
         "fieldFromDate": "de",
-        "fieldStartTime": "hora de início",
+        "fieldStartTime": "horário de início",
         "fieldToDate": "até",
         "header": "horário de trabalho",
         "tabRange": "intervalo",
         "tabSingle": "único",
-        "warningNoDates": "Nenhuma data para aplicar no intervalo. (início > fim ou conflito apenas dias úteis)",
-        "warningTruncated": "O intervalo excede {max} dias, apenas parcialmente processado. Tente um intervalo mais estreito."
+        "warningNoDates": "Nenhuma data para aplicar no intervalo. (início > fim ou conflito de somente dias úteis)",
+        "warningTruncated": "Intervalo excede {max} dias, apenas parcialmente processado. Tente um intervalo menor."
     }
 }

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -1,181 +1,181 @@
 {
-  "app": {
-    "tagline": "gerenciador de agendamentos",
-    "title": "plan1"
-  },
-  "auth": {
-    "signIn": "Entrar com Google",
-    "signInDescription": "plan1 é uma ferramenta de agendamento pessoal com sincronização entre dispositivos. Entre com Google para começar.",
-    "signInRequired": "Entre para usar plano1"
-  },
-  "category": {
-    "confirmRemoveLabel": "confirmar rm ({count})",
-    "confirmRemoveText": "{count} agendamento(s) será(ão) excluído(s) com isso. Clique novamente para confirmar.",
-    "defaultName": "padrão",
-    "empty": "Nenhuma categoria.",
-    "fieldColor": "cor",
-    "fieldName": "nome",
-    "header": "categorias",
-    "removeButton": "rm",
-    "scheduleCountSuffix": "{count} agendamentos"
-  },
-  "common": {
-    "add": "adicionar",
-    "cancel": "cancelar",
-    "close": "fechar",
-    "confirmDelete": "confirmar exclusão",
-    "delete": "excluir",
-    "dismiss": "dispensar",
-    "now": "agora",
-    "retry": "tentar novamente",
-    "save": "salvar"
-  },
-  "confirmation": {
-    "scheduleAdded": "Agendamento adicionado"
-  },
-  "error": {
-    "featureUnavailable": "Este recurso ainda não está disponível ({feature}).",
-    "loadFailedLabel": "falha ao carregar:",
-    "mutationFailed": "Falha ao {action}: {error}",
-    "unknown": "Ocorreu um erro inesperado. Por favor, tente novamente.",
-    "workingHoursInvalid": "Entrada de horário de trabalho inválida ({reason})."
-  },
-  "loading": "carregando...",
-  "mutation": {
-    "changeTimerType": "alterar tipo de cronômetro",
-    "completeSchedule": "completar agendamento",
-    "extendTimer": "estender temporizador",
-    "removeCategory": "remover categoria",
-    "setFocus": "definir visualização de foco",
-    "setTheme": "definir tema",
-    "startScheduleNow": "start schedule now",
-    "setZoom": "definir zoom"
-  },
-  "nav": {
-    "categories": "categorias",
-    "focus10h": "10h",
-    "focus12h": "12h",
-    "focus16h": "16h",
-    "focus20h": "20h",
-    "focus24h": "24h",
-    "focus4h": "4h",
-    "focus6h": "6h",
-    "focus8h": "8h",
-    "focusLabel": "foco",
-    "newSchedule": "novo",
-    "themeDark": "escuro",
-    "themeLight": "claro",
-    "themeSystem": "auto",
-    "workingHours": "horas",
-    "zoomIn": "aumentar",
-    "zoomOut": "diminuir"
-  },
-  "onboarding": {
-    "addFirst": "adicionar primeiro agendamento",
-    "firstSchedule": "Adicione seu primeiro agendamento para vê-lo na grade semanal, linha do tempo de hoje e relógio analógico.",
-    "welcome": "Nenhum agendamento ainda"
-  },
-  "schedule": {
-    "afterLastNoneHint": "nenhum agendamento próximo",
-    "buttonAfterLast": "next after last schedule",
-    "buttonMinus10": "-10m",
-    "buttonMinus30": "-30m",
-    "buttonPlus10": "+10m",
-    "buttonPlus30": "+30m",
-    "buttonPlusHour": "+1h",
-    "categoryAddOption": "+ adicionar categoria",
-    "chainedCheckbox": "encadear ao agendamento anterior",
-    "endLabelV2": "hora final",
-    "endPlaceholder": "selecionar duração",
-    "fieldCategory": "categoria",
-    "fieldDuration": "duração (min)",
-    "fieldName": "nome",
-    "fieldStartHour": "hora inicial",
-    "fieldStartMinute": "minuto inicial",
-    "headerEdit": "editar agendamento",
-    "headerNew": "novo agendamento",
-    "hourSuffix": "h",
-    "hourTodaySuffix": "(hoje)",
-    "hourTomorrowSuffix": "(amanhã)",
-    "minuteSuffix": "m",
-    "prevChainLabel": "agendamento anterior conectado",
-    "titleDefault": "Novo agendamento",
-    "warningOverlapLimit": "No máximo {limit} agendamentos podem se sobrepor ao mesmo tempo. Ajuste início/duração ou remova um existente."
-  },
-  "serverError": {
-    "categoryHasSchedules": "Categoria possui {scheduleCount} agendamentos. Confirme exclusão em cascata para remover.",
-    "categoryNotFound": "Categoria não encontrada ou não pertence a você.",
-    "scheduleNotFound": "Agendamento não encontrado.",
-    "unauthorized": "Entrada necessária."
-  },
-  "signIn": {
-    "cta": "Entrar",
-    "description": "Entre na sua conta cofounder para visualizar e gerenciar seus agendamentos.",
-    "title": "Entrada necessária"
-  },
-  "timer": {
-    "buttonComplete": "concluir",
-    "buttonFocus": "foco",
-    "buttonIdle": "ocioso",
-    "categoryFallback": "?",
-    "idleEmpty": "ocioso · nenhum agendamento ativo",
-    "labelElapsed": "decorrido",
-    "labelEndAt": "termina-às",
-    "labelRemaining": "restante",
-    "labelTarget": "meta",
-    "labelUntilUpcoming": "até próximo",
-    "labelUpcoming": "próximo agendamento",
-    "overlapLabel": "sobreposição {count}",
-    "simultaneousLabel": "simultâneos · {count}",
-    "tooltipClickToFocus": "clique para mudar para foco",
-    "tooltipClickToIdle": "clique para mudar para ocioso",
-    "typeCountdown": "contagem regressiva",
-    "typeCountup": "contagem progressiva",
-    "typeTimer1": "temporizador1",
-    "buttonStartNow": "start now"
-  },
-  "topbar": {
-    "back": "voltar ao portal",
-    "creditsLabel": "créditos",
-    "creditsPlaceholder": "—",
-    "guest": "convidado",
-    "languageLabel": "idioma",
-    "logout": "sair"
-  },
-  "undo": {
-    "actionLabel": "desfazer disponível",
-    "button": "desfazer"
-  },
-  "wallTime": {
-    "am": "am",
-    "pm": "pm"
-  },
-  "weekdays": [
-    "dom",
-    "seg",
-    "ter",
-    "qua",
-    "qui",
-    "sex",
-    "sáb"
-  ],
-  "workingHours": {
-    "checkboxAlsoDefault": "salvar também como padrão",
-    "checkboxWeekdaysOnly": "apenas dias úteis (seg–sex)",
-    "errorEndAfterStart": "Hora final deve ser posterior à hora inicial.",
-    "errorToAfterFrom": "Data final deve ser igual ou posterior à data inicial.",
-    "fieldDate": "data",
-    "fieldEndTime": "hora final",
-    "fieldFromDate": "de",
-    "fieldStartTime": "hora de início",
-    "fieldToDate": "até",
-    "header": "horário de trabalho",
-    "tabRange": "intervalo",
-    "tabSingle": "único",
-    "warningNoDates": "Nenhuma data para aplicar no intervalo. (início > fim ou conflito apenas dias úteis)",
-    "warningTruncated": "Intervalo excede {max} dias, apenas parcialmente processado. Tente um intervalo menor."
-  },
-  "header": {
-    "finalEndAtSuffix": "end"
-  }
+    "app": {
+        "tagline": "gerenciador de agendamentos",
+        "title": "plano1"
+    },
+    "auth": {
+        "signIn": "Entrar com Google",
+        "signInDescription": "plan1 é uma ferramenta de agendamento pessoal com sincronização entre dispositivos. Entre com o Google para começar.",
+        "signInRequired": "Entre para usar plano1"
+    },
+    "category": {
+        "confirmRemoveLabel": "confirmar rm ({count})",
+        "confirmRemoveText": "{count} agendamento(s) será(ão) excluído(s) com isso. Clique novamente para confirmar.",
+        "defaultName": "padrão",
+        "empty": "Nenhuma categoria.",
+        "fieldColor": "cor",
+        "fieldName": "nome",
+        "header": "categorias",
+        "removeButton": "rm",
+        "scheduleCountSuffix": "{count} agendamentos"
+    },
+    "common": {
+        "add": "adicionar",
+        "cancel": "cancelar",
+        "close": "fechar",
+        "confirmDelete": "confirmar exclusão",
+        "delete": "excluir",
+        "dismiss": "dispensar",
+        "now": "agora",
+        "retry": "tentar novamente",
+        "save": "salvar"
+    },
+    "confirmation": {
+        "scheduleAdded": "Agendamento adicionado"
+    },
+    "error": {
+        "featureUnavailable": "Este recurso ainda não está disponível ({feature}).",
+        "loadFailedLabel": "falha ao carregar:",
+        "mutationFailed": "Falha ao {action}: {error}",
+        "unknown": "Ocorreu um erro inesperado. Por favor, tente novamente.",
+        "workingHoursInvalid": "Entrada de horas de trabalho inválida ({reason})."
+    },
+    "header": {
+        "finalEndAtSuffix": "fim"
+    },
+    "loading": "carregando...",
+    "mutation": {
+        "changeTimerType": "alterar tipo de temporizador",
+        "completeSchedule": "concluir agendamento",
+        "extendTimer": "estender temporizador",
+        "removeCategory": "remover categoria",
+        "setFocus": "definir visualização de foco",
+        "setTheme": "definir tema",
+        "setZoom": "definir zoom",
+        "startScheduleNow": "iniciar agendamento agora"
+    },
+    "nav": {
+        "categories": "categorias",
+        "focus10h": "10h",
+        "focus12h": "12h",
+        "focus16h": "16h",
+        "focus20h": "20h",
+        "focus24h": "24h",
+        "focus4h": "4h",
+        "focus6h": "6h",
+        "focus8h": "8h",
+        "focusLabel": "foco",
+        "newSchedule": "novo",
+        "themeDark": "escuro",
+        "themeLight": "claro",
+        "themeSystem": "automático",
+        "workingHours": "horas",
+        "zoomIn": "aumentar zoom",
+        "zoomOut": "diminuir zoom"
+    },
+    "onboarding": {
+        "addFirst": "adicionar primeiro agendamento",
+        "firstSchedule": "Adicione seu primeiro agendamento para vê-lo na grade semanal, na linha do tempo de hoje e no relógio analógico.",
+        "welcome": "Nenhum agendamento ainda"
+    },
+    "schedule": {
+        "afterLastNoneHint": "nenhum agendamento próximo",
+        "buttonAfterLast": "próximo após o último agendamento",
+        "buttonMinus10": "-10m",
+        "buttonMinus30": "-30m",
+        "buttonPlus10": "+10m",
+        "buttonPlus30": "+30m",
+        "buttonPlusHour": "+1h",
+        "categoryAddOption": "+ adicionar categoria",
+        "chainedCheckbox": "encadear ao agendamento anterior",
+        "endLabelV2": "horário de término",
+        "endPlaceholder": "selecionar duração",
+        "fieldCategory": "categoria",
+        "fieldDuration": "duração (min)",
+        "fieldName": "nome",
+        "fieldStartHour": "hora de início",
+        "fieldStartMinute": "minuto de início",
+        "headerEdit": "editar agendamento",
+        "headerNew": "novo agendamento",
+        "hourSuffix": "h",
+        "hourTodaySuffix": "(hoje)",
+        "hourTomorrowSuffix": "(amanhã)",
+        "minuteSuffix": "m",
+        "prevChainLabel": "agendamento anterior conectado",
+        "titleDefault": "Novo agendamento",
+        "warningOverlapLimit": "No máximo {limit} agendamentos podem se sobrepor ao mesmo tempo. Ajuste início/duração ou remova um existente."
+    },
+    "serverError": {
+        "categoryHasSchedules": "Categoria tem {scheduleCount} agendamentos. Confirme exclusão em cascata para remover.",
+        "categoryNotFound": "Categoria não encontrada ou não pertence a você.",
+        "scheduleNotFound": "Agendamento não encontrado.",
+        "unauthorized": "Entrada necessária."
+    },
+    "signIn": {
+        "cta": "Entrar",
+        "description": "Entre na sua conta de cofundador para visualizar e gerenciar seus agendamentos.",
+        "title": "Entrada necessária"
+    },
+    "timer": {
+        "buttonComplete": "concluir",
+        "buttonFocus": "foco",
+        "buttonIdle": "ocioso",
+        "buttonStartNow": "iniciar agora",
+        "categoryFallback": "?",
+        "idleEmpty": "ocioso · nenhum agendamento ativo",
+        "labelElapsed": "decorrido",
+        "labelEndAt": "terminar-às",
+        "labelRemaining": "restante",
+        "labelTarget": "alvo",
+        "labelUntilUpcoming": "até o próximo",
+        "labelUpcoming": "próximo agendamento",
+        "overlapLabel": "sobreposição {count}",
+        "simultaneousLabel": "simultâneo · {count}",
+        "tooltipClickToFocus": "clique para mudar para foco",
+        "tooltipClickToIdle": "clique para mudar para ocioso",
+        "typeCountdown": "contagem regressiva",
+        "typeCountup": "contagem progressiva",
+        "typeTimer1": "temporizador1"
+    },
+    "topbar": {
+        "back": "voltar ao portal",
+        "creditsLabel": "créditos",
+        "creditsPlaceholder": "—",
+        "guest": "convidado",
+        "languageLabel": "idioma",
+        "logout": "sair"
+    },
+    "undo": {
+        "actionLabel": "desfazer disponível",
+        "button": "desfazer"
+    },
+    "wallTime": {
+        "am": "am",
+        "pm": "pm"
+    },
+    "weekdays": [
+        "dom",
+        "seg",
+        "ter",
+        "qua",
+        "qui",
+        "sex",
+        "sáb"
+    ],
+    "workingHours": {
+        "checkboxAlsoDefault": "salvar também como padrão",
+        "checkboxWeekdaysOnly": "apenas dias úteis (seg–sex)",
+        "errorEndAfterStart": "Horário de término deve ser após horário de início.",
+        "errorToAfterFrom": "A data de término deve ser igual ou posterior à data de início.",
+        "fieldDate": "data",
+        "fieldEndTime": "horário de término",
+        "fieldFromDate": "de",
+        "fieldStartTime": "hora de início",
+        "fieldToDate": "até",
+        "header": "horário de trabalho",
+        "tabRange": "intervalo",
+        "tabSingle": "único",
+        "warningNoDates": "Nenhuma data para aplicar no intervalo. (início > fim ou conflito de dias úteis)",
+        "warningTruncated": "Intervalo excede {max} dias, apenas parcialmente processado. Tente um intervalo menor."
+    }
 }

--- a/messages/ru.json
+++ b/messages/ru.json
@@ -48,7 +48,8 @@
     "removeCategory": "удалить категорию",
     "setFocus": "установить вид фокуса",
     "setTheme": "установить тему",
-    "startScheduleNow": "start schedule now"
+    "startScheduleNow": "start schedule now",
+    "setZoom": "установить масштаб"
   },
   "nav": {
     "categories": "категории",
@@ -65,7 +66,9 @@
     "themeDark": "тёмная",
     "themeLight": "светлая",
     "themeSystem": "авто",
-    "workingHours": "часы"
+    "workingHours": "часы",
+    "zoomIn": "приблизить",
+    "zoomOut": "отдалить"
   },
   "onboarding": {
     "addFirst": "добавить первое расписание",

--- a/messages/ru.json
+++ b/messages/ru.json
@@ -1,16 +1,16 @@
 {
     "app": {
         "tagline": "менеджер расписаний",
-        "title": "план1"
+        "title": "plan1"
     },
     "auth": {
         "signIn": "Войти через Google",
-        "signInDescription": "plan1 — это персональный инструмент планирования с синхронизацией между устройствами. Войдите через Google, чтобы начать.",
+        "signInDescription": "plan1 - это персональный планировщик с синхронизацией между устройствами. Войдите через Google, чтобы начать.",
         "signInRequired": "Войдите, чтобы использовать plan1"
     },
     "category": {
         "confirmRemoveLabel": "подтвердить удаление ({count})",
-        "confirmRemoveText": "{count} расписание(-й) будет удалено вместе с этим. Нажмите ещё раз для подтверждения.",
+        "confirmRemoveText": "{count} расписание(й) будет удалено. Нажмите еще раз для подтверждения.",
         "defaultName": "по умолчанию",
         "empty": "Нет категорий.",
         "fieldColor": "цвет",
@@ -25,7 +25,7 @@
         "close": "закрыть",
         "confirmDelete": "подтвердить удаление",
         "delete": "удалить",
-        "dismiss": "отклонить",
+        "dismiss": "закрыть",
         "now": "сейчас",
         "retry": "повторить",
         "save": "сохранить"
@@ -49,7 +49,7 @@
         "completeSchedule": "завершить расписание",
         "extendTimer": "продлить таймер",
         "removeCategory": "удалить категорию",
-        "setFocus": "установить режим фокуса",
+        "setFocus": "установить режим фокусировки",
         "setTheme": "установить тему",
         "setZoom": "установить масштаб",
         "startScheduleNow": "начать расписание сейчас"
@@ -66,30 +66,30 @@
         "focus8h": "8ч",
         "focusLabel": "фокус",
         "newSchedule": "новое",
-        "themeDark": "тёмная",
+        "themeDark": "темная",
         "themeLight": "светлая",
         "themeSystem": "авто",
         "workingHours": "часы",
         "zoomIn": "увеличить",
-        "zoomOut": "уменьшить"
+        "zoomOut": "уменьшить масштаб"
     },
     "onboarding": {
         "addFirst": "добавить первое расписание",
-        "firstSchedule": "Добавьте своё первое расписание, чтобы увидеть его в недельной сетке, сегодняшней временной шкале и аналоговых часах.",
-        "welcome": "Пока нет расписаний"
+        "firstSchedule": "Добавьте первое расписание, чтобы увидеть его на недельной сетке, временной шкале сегодня и аналоговых часах.",
+        "welcome": "Расписаний пока нет"
     },
     "schedule": {
-        "afterLastNoneHint": "нет предстоящих расписаний",
-        "buttonAfterLast": "следующий после последнего расписания",
+        "afterLastNoneHint": "нет предстоящего расписания",
+        "buttonAfterLast": "следующее после последнего расписания",
         "buttonMinus10": "-10м",
         "buttonMinus30": "-30м",
         "buttonPlus10": "+10м",
         "buttonPlus30": "+30м",
         "buttonPlusHour": "+1ч",
         "categoryAddOption": "+ добавить категорию",
-        "chainedCheckbox": "привязать к предыдущему расписанию",
+        "chainedCheckbox": "связать с предыдущим расписанием",
         "endLabelV2": "время окончания",
-        "endPlaceholder": "выберите длительность",
+        "endPlaceholder": "выбрать длительность",
         "fieldCategory": "категория",
         "fieldDuration": "длительность (мин)",
         "fieldName": "название",
@@ -103,43 +103,43 @@
         "minuteSuffix": "м",
         "prevChainLabel": "связано с предыдущим расписанием",
         "titleDefault": "Новое расписание",
-        "warningOverlapLimit": "Максимум {limit} расписаний могут пересекаться одновременно. Измените начало/длительность или удалите существующее."
+        "warningOverlapLimit": "Максимум {limit} расписаний могут пересекаться одновременно. Настройте время начала/длительность или удалите существующее."
     },
     "serverError": {
-        "categoryHasSchedules": "У категории {scheduleCount} расписаний. Подтвердите каскадное удаление.",
+        "categoryHasSchedules": "Категория содержит {scheduleCount} расписаний. Подтвердите каскадное удаление.",
         "categoryNotFound": "Категория не найдена или не принадлежит вам.",
         "scheduleNotFound": "Расписание не найдено.",
         "unauthorized": "Требуется вход."
     },
     "signIn": {
         "cta": "Войти",
-        "description": "Войдите в свой аккаунт cofounder, чтобы просматривать и управлять своими расписаниями.",
+        "description": "Войдите в свой аккаунт cofounder для просмотра и управления расписаниями.",
         "title": "Требуется вход"
     },
     "timer": {
         "buttonComplete": "завершить",
         "buttonFocus": "фокус",
-        "buttonIdle": "отдых",
+        "buttonIdle": "простой",
         "buttonStartNow": "начать сейчас",
         "categoryFallback": "?",
-        "idleEmpty": "отдых · нет активного расписания",
+        "idleEmpty": "простой · нет активного расписания",
         "labelElapsed": "прошло",
-        "labelEndAt": "заканчивается в",
+        "labelEndAt": "окончание-в",
         "labelRemaining": "осталось",
         "labelTarget": "цель",
         "labelUntilUpcoming": "до предстоящего",
         "labelUpcoming": "следующее расписание",
-        "overlapLabel": "наложение {count}",
+        "overlapLabel": "пересечение {count}",
         "simultaneousLabel": "одновременно · {count}",
-        "tooltipClickToFocus": "нажмите для переключения в режим фокуса",
-        "tooltipClickToIdle": "нажмите для переключения в режим отдыха",
-        "typeCountdown": "обратный отсчёт",
-        "typeCountup": "отсчёт вверх",
+        "tooltipClickToFocus": "нажмите для переключения в режим фокусировки",
+        "tooltipClickToIdle": "нажмите для переключения в режим ожидания",
+        "typeCountdown": "обратный отсчет",
+        "typeCountup": "прямой отсчет",
         "typeTimer1": "timer1"
     },
     "topbar": {
         "back": "вернуться на портал",
-        "creditsLabel": "благодарности",
+        "creditsLabel": "титры",
         "creditsPlaceholder": "—",
         "guest": "гость",
         "languageLabel": "язык",
@@ -164,18 +164,18 @@
     ],
     "workingHours": {
         "checkboxAlsoDefault": "также сохранить по умолчанию",
-        "checkboxWeekdaysOnly": "только будние дни (пн–пт)",
+        "checkboxWeekdaysOnly": "только будни (пн–пт)",
         "errorEndAfterStart": "Время окончания должно быть после времени начала.",
         "errorToAfterFrom": "Дата окончания должна быть не раньше даты начала.",
         "fieldDate": "дата",
         "fieldEndTime": "время окончания",
-        "fieldFromDate": "с",
+        "fieldFromDate": "от",
         "fieldStartTime": "время начала",
         "fieldToDate": "до",
         "header": "рабочие часы",
         "tabRange": "диапазон",
         "tabSingle": "одиночное",
-        "warningNoDates": "Нет дат для применения в диапазоне. (начало > конца или конфликт только рабочих дней)",
-        "warningTruncated": "Диапазон превышает {max} дней, обработано частично. Попробуйте более узкий диапазон."
+        "warningNoDates": "Нет дат для применения в диапазоне. (начало > конца или конфликт с днями недели)",
+        "warningTruncated": "Диапазон превышает {max} дней, обработано частично. Попробуйте сузить диапазон."
     }
 }

--- a/messages/ru.json
+++ b/messages/ru.json
@@ -1,181 +1,181 @@
 {
-  "app": {
-    "tagline": "менеджер расписания",
-    "title": "plan1"
-  },
-  "auth": {
-    "signIn": "Войти через Google",
-    "signInDescription": "plan1 — это персональный инструмент планирования с синхронизацией между устройствами. Войдите через Google, чтобы начать.",
-    "signInRequired": "Войдите, чтобы использовать plan1"
-  },
-  "category": {
-    "confirmRemoveLabel": "подтвердить удаление ({count})",
-    "confirmRemoveText": "При этом будет удалено {count} расписание(й). Нажмите еще раз для подтверждения.",
-    "defaultName": "по умолчанию",
-    "empty": "Нет категорий.",
-    "fieldColor": "цвет",
-    "fieldName": "название",
-    "header": "категории",
-    "removeButton": "удалить",
-    "scheduleCountSuffix": "{count} расписаний"
-  },
-  "common": {
-    "add": "добавить",
-    "cancel": "отмена",
-    "close": "закрыть",
-    "confirmDelete": "подтвердить удаление",
-    "delete": "удалить",
-    "dismiss": "закрыть",
-    "now": "сейчас",
-    "retry": "повторить",
-    "save": "сохранить"
-  },
-  "confirmation": {
-    "scheduleAdded": "Расписание добавлено"
-  },
-  "error": {
-    "featureUnavailable": "Эта функция пока недоступна ({feature}).",
-    "loadFailedLabel": "ошибка загрузки:",
-    "mutationFailed": "Не удалось выполнить {action}: {error}",
-    "unknown": "Произошла непредвиденная ошибка. Пожалуйста, попробуйте снова.",
-    "workingHoursInvalid": "Неверный ввод рабочих часов ({reason})."
-  },
-  "loading": "загрузка...",
-  "mutation": {
-    "changeTimerType": "изменить тип таймера",
-    "completeSchedule": "завершить расписание",
-    "extendTimer": "продлить таймер",
-    "removeCategory": "удалить категорию",
-    "setFocus": "установить вид фокуса",
-    "setTheme": "установить тему",
-    "startScheduleNow": "start schedule now",
-    "setZoom": "установить масштаб"
-  },
-  "nav": {
-    "categories": "категории",
-    "focus10h": "10ч",
-    "focus12h": "12ч",
-    "focus16h": "16ч",
-    "focus20h": "20ч",
-    "focus24h": "24ч",
-    "focus4h": "4ч",
-    "focus6h": "6ч",
-    "focus8h": "8ч",
-    "focusLabel": "фокус",
-    "newSchedule": "новое",
-    "themeDark": "тёмная",
-    "themeLight": "светлая",
-    "themeSystem": "авто",
-    "workingHours": "часы",
-    "zoomIn": "приблизить",
-    "zoomOut": "отдалить"
-  },
-  "onboarding": {
-    "addFirst": "добавить первое расписание",
-    "firstSchedule": "Добавьте ваше первое расписание, чтобы увидеть его в недельной сетке, на временной шкале сегодня и на аналоговых часах.",
-    "welcome": "Расписаний пока нет"
-  },
-  "schedule": {
-    "afterLastNoneHint": "нет предстоящих расписаний",
-    "buttonAfterLast": "next after last schedule",
-    "buttonMinus10": "-10м",
-    "buttonMinus30": "-30м",
-    "buttonPlus10": "+10м",
-    "buttonPlus30": "+30м",
-    "buttonPlusHour": "+1ч",
-    "categoryAddOption": "+ добавить категорию",
-    "chainedCheckbox": "связать с предыдущим расписанием",
-    "endLabelV2": "время окончания",
-    "endPlaceholder": "выберите длительность",
-    "fieldCategory": "категория",
-    "fieldDuration": "длительность (мин)",
-    "fieldName": "название",
-    "fieldStartHour": "час начала",
-    "fieldStartMinute": "минута начала",
-    "headerEdit": "редактировать расписание",
-    "headerNew": "новое расписание",
-    "hourSuffix": "ч",
-    "hourTodaySuffix": "(сегодня)",
-    "hourTomorrowSuffix": "(завтра)",
-    "minuteSuffix": "м",
-    "prevChainLabel": "связанное предыдущее расписание",
-    "titleDefault": "Новое расписание",
-    "warningOverlapLimit": "Максимум {limit} расписаний могут пересекаться одновременно. Измените начало/длительность или удалите существующее."
-  },
-  "serverError": {
-    "categoryHasSchedules": "У категории {scheduleCount} расписаний. Подтвердите каскадное удаление.",
-    "categoryNotFound": "Категория не найдена или не принадлежит вам.",
-    "scheduleNotFound": "Расписание не найдено.",
-    "unauthorized": "Требуется вход."
-  },
-  "signIn": {
-    "cta": "Войти",
-    "description": "Войдите в свой аккаунт cofounder для просмотра и управления расписаниями.",
-    "title": "Требуется вход"
-  },
-  "timer": {
-    "buttonComplete": "завершить",
-    "buttonFocus": "фокус",
-    "buttonIdle": "простой",
-    "categoryFallback": "?",
-    "idleEmpty": "простой · нет активного расписания",
-    "labelElapsed": "прошло",
-    "labelEndAt": "завершить-в",
-    "labelRemaining": "осталось",
-    "labelTarget": "цель",
-    "labelUntilUpcoming": "до предстоящего",
-    "labelUpcoming": "следующее расписание",
-    "overlapLabel": "наложение {count}",
-    "simultaneousLabel": "одновременно · {count}",
-    "tooltipClickToFocus": "нажмите для переключения в фокус",
-    "tooltipClickToIdle": "нажмите для переключения в простой",
-    "typeCountdown": "обратный отсчёт",
-    "typeCountup": "прямой отсчёт",
-    "typeTimer1": "timer1",
-    "buttonStartNow": "start now"
-  },
-  "topbar": {
-    "back": "вернуться на портал",
-    "creditsLabel": "авторы",
-    "creditsPlaceholder": "—",
-    "guest": "гость",
-    "languageLabel": "язык",
-    "logout": "выход"
-  },
-  "undo": {
-    "actionLabel": "отмена доступна",
-    "button": "отменить"
-  },
-  "wallTime": {
-    "am": "am",
-    "pm": "pm"
-  },
-  "weekdays": [
-    "вс",
-    "пн",
-    "вт",
-    "ср",
-    "чт",
-    "пт",
-    "сб"
-  ],
-  "workingHours": {
-    "checkboxAlsoDefault": "также сохранить по умолчанию",
-    "checkboxWeekdaysOnly": "только будни (пн–пт)",
-    "errorEndAfterStart": "Время окончания должно быть после времени начала.",
-    "errorToAfterFrom": "Дата окончания должна быть не раньше даты начала.",
-    "fieldDate": "дата",
-    "fieldEndTime": "время окончания",
-    "fieldFromDate": "с",
-    "fieldStartTime": "время начала",
-    "fieldToDate": "к",
-    "header": "рабочие часы",
-    "tabRange": "диапазон",
-    "tabSingle": "одиночное",
-    "warningNoDates": "Нет дат для применения в диапазоне. (начало > конца или конфликт только по будням)",
-    "warningTruncated": "Диапазон превышает {max} дней, обработано только частично. Попробуйте более узкий диапазон."
-  },
-  "header": {
-    "finalEndAtSuffix": "end"
-  }
+    "app": {
+        "tagline": "менеджер расписаний",
+        "title": "план1"
+    },
+    "auth": {
+        "signIn": "Войти через Google",
+        "signInDescription": "plan1 — это персональный инструмент планирования с синхронизацией между устройствами. Войдите через Google, чтобы начать.",
+        "signInRequired": "Войдите, чтобы использовать plan1"
+    },
+    "category": {
+        "confirmRemoveLabel": "подтвердить удаление ({count})",
+        "confirmRemoveText": "{count} расписание(-й) будет удалено вместе с этим. Нажмите ещё раз для подтверждения.",
+        "defaultName": "по умолчанию",
+        "empty": "Нет категорий.",
+        "fieldColor": "цвет",
+        "fieldName": "название",
+        "header": "категории",
+        "removeButton": "уд",
+        "scheduleCountSuffix": "{count} расписаний"
+    },
+    "common": {
+        "add": "добавить",
+        "cancel": "отмена",
+        "close": "закрыть",
+        "confirmDelete": "подтвердить удаление",
+        "delete": "удалить",
+        "dismiss": "отклонить",
+        "now": "сейчас",
+        "retry": "повторить",
+        "save": "сохранить"
+    },
+    "confirmation": {
+        "scheduleAdded": "Расписание добавлено"
+    },
+    "error": {
+        "featureUnavailable": "Эта функция пока недоступна ({feature}).",
+        "loadFailedLabel": "ошибка загрузки:",
+        "mutationFailed": "Не удалось {action}: {error}",
+        "unknown": "Произошла непредвиденная ошибка. Пожалуйста, попробуйте снова.",
+        "workingHoursInvalid": "Неверный ввод рабочих часов ({reason})."
+    },
+    "header": {
+        "finalEndAtSuffix": "конец"
+    },
+    "loading": "загрузка...",
+    "mutation": {
+        "changeTimerType": "изменить тип таймера",
+        "completeSchedule": "завершить расписание",
+        "extendTimer": "продлить таймер",
+        "removeCategory": "удалить категорию",
+        "setFocus": "установить режим фокуса",
+        "setTheme": "установить тему",
+        "setZoom": "установить масштаб",
+        "startScheduleNow": "начать расписание сейчас"
+    },
+    "nav": {
+        "categories": "категории",
+        "focus10h": "10ч",
+        "focus12h": "12ч",
+        "focus16h": "16ч",
+        "focus20h": "20ч",
+        "focus24h": "24ч",
+        "focus4h": "4ч",
+        "focus6h": "6ч",
+        "focus8h": "8ч",
+        "focusLabel": "фокус",
+        "newSchedule": "новое",
+        "themeDark": "тёмная",
+        "themeLight": "светлая",
+        "themeSystem": "авто",
+        "workingHours": "часы",
+        "zoomIn": "увеличить",
+        "zoomOut": "уменьшить"
+    },
+    "onboarding": {
+        "addFirst": "добавить первое расписание",
+        "firstSchedule": "Добавьте своё первое расписание, чтобы увидеть его в недельной сетке, сегодняшней временной шкале и аналоговых часах.",
+        "welcome": "Пока нет расписаний"
+    },
+    "schedule": {
+        "afterLastNoneHint": "нет предстоящих расписаний",
+        "buttonAfterLast": "следующий после последнего расписания",
+        "buttonMinus10": "-10м",
+        "buttonMinus30": "-30м",
+        "buttonPlus10": "+10м",
+        "buttonPlus30": "+30м",
+        "buttonPlusHour": "+1ч",
+        "categoryAddOption": "+ добавить категорию",
+        "chainedCheckbox": "привязать к предыдущему расписанию",
+        "endLabelV2": "время окончания",
+        "endPlaceholder": "выберите длительность",
+        "fieldCategory": "категория",
+        "fieldDuration": "длительность (мин)",
+        "fieldName": "название",
+        "fieldStartHour": "час начала",
+        "fieldStartMinute": "минута начала",
+        "headerEdit": "редактировать расписание",
+        "headerNew": "новое расписание",
+        "hourSuffix": "ч",
+        "hourTodaySuffix": "(сегодня)",
+        "hourTomorrowSuffix": "(завтра)",
+        "minuteSuffix": "м",
+        "prevChainLabel": "связано с предыдущим расписанием",
+        "titleDefault": "Новое расписание",
+        "warningOverlapLimit": "Максимум {limit} расписаний могут пересекаться одновременно. Измените начало/длительность или удалите существующее."
+    },
+    "serverError": {
+        "categoryHasSchedules": "У категории {scheduleCount} расписаний. Подтвердите каскадное удаление.",
+        "categoryNotFound": "Категория не найдена или не принадлежит вам.",
+        "scheduleNotFound": "Расписание не найдено.",
+        "unauthorized": "Требуется вход."
+    },
+    "signIn": {
+        "cta": "Войти",
+        "description": "Войдите в свой аккаунт cofounder, чтобы просматривать и управлять своими расписаниями.",
+        "title": "Требуется вход"
+    },
+    "timer": {
+        "buttonComplete": "завершить",
+        "buttonFocus": "фокус",
+        "buttonIdle": "отдых",
+        "buttonStartNow": "начать сейчас",
+        "categoryFallback": "?",
+        "idleEmpty": "отдых · нет активного расписания",
+        "labelElapsed": "прошло",
+        "labelEndAt": "заканчивается в",
+        "labelRemaining": "осталось",
+        "labelTarget": "цель",
+        "labelUntilUpcoming": "до предстоящего",
+        "labelUpcoming": "следующее расписание",
+        "overlapLabel": "наложение {count}",
+        "simultaneousLabel": "одновременно · {count}",
+        "tooltipClickToFocus": "нажмите для переключения в режим фокуса",
+        "tooltipClickToIdle": "нажмите для переключения в режим отдыха",
+        "typeCountdown": "обратный отсчёт",
+        "typeCountup": "отсчёт вверх",
+        "typeTimer1": "timer1"
+    },
+    "topbar": {
+        "back": "вернуться на портал",
+        "creditsLabel": "благодарности",
+        "creditsPlaceholder": "—",
+        "guest": "гость",
+        "languageLabel": "язык",
+        "logout": "выйти"
+    },
+    "undo": {
+        "actionLabel": "отмена доступна",
+        "button": "отменить"
+    },
+    "wallTime": {
+        "am": "am",
+        "pm": "pm"
+    },
+    "weekdays": [
+        "вс",
+        "пн",
+        "вт",
+        "ср",
+        "чт",
+        "пт",
+        "сб"
+    ],
+    "workingHours": {
+        "checkboxAlsoDefault": "также сохранить по умолчанию",
+        "checkboxWeekdaysOnly": "только будние дни (пн–пт)",
+        "errorEndAfterStart": "Время окончания должно быть после времени начала.",
+        "errorToAfterFrom": "Дата окончания должна быть не раньше даты начала.",
+        "fieldDate": "дата",
+        "fieldEndTime": "время окончания",
+        "fieldFromDate": "с",
+        "fieldStartTime": "время начала",
+        "fieldToDate": "до",
+        "header": "рабочие часы",
+        "tabRange": "диапазон",
+        "tabSingle": "одиночное",
+        "warningNoDates": "Нет дат для применения в диапазоне. (начало > конца или конфликт только рабочих дней)",
+        "warningTruncated": "Диапазон превышает {max} дней, обработано частично. Попробуйте более узкий диапазон."
+    }
 }

--- a/messages/ru.json
+++ b/messages/ru.json
@@ -1,16 +1,16 @@
 {
     "app": {
-        "tagline": "менеджер расписаний",
-        "title": "plan1"
+        "tagline": "менеджер расписания",
+        "title": "план1"
     },
     "auth": {
         "signIn": "Войти через Google",
-        "signInDescription": "plan1 - это персональный планировщик с синхронизацией между устройствами. Войдите через Google, чтобы начать.",
-        "signInRequired": "Войдите, чтобы использовать plan1"
+        "signInDescription": "plan1 — это персональный инструмент планирования с синхронизацией между устройствами. Войдите через Google, чтобы начать.",
+        "signInRequired": "Войдите для использования plan1"
     },
     "category": {
-        "confirmRemoveLabel": "подтвердить удаление ({count})",
-        "confirmRemoveText": "{count} расписание(й) будет удалено. Нажмите еще раз для подтверждения.",
+        "confirmRemoveLabel": "подтвердите уд ({count})",
+        "confirmRemoveText": "{count} расписание(й) будет удалено вместе с этим. Нажмите ещё раз для подтверждения.",
         "defaultName": "по умолчанию",
         "empty": "Нет категорий.",
         "fieldColor": "цвет",
@@ -23,7 +23,7 @@
         "add": "добавить",
         "cancel": "отмена",
         "close": "закрыть",
-        "confirmDelete": "подтвердить удаление",
+        "confirmDelete": "подтвердите удаление",
         "delete": "удалить",
         "dismiss": "закрыть",
         "now": "сейчас",
@@ -49,7 +49,7 @@
         "completeSchedule": "завершить расписание",
         "extendTimer": "продлить таймер",
         "removeCategory": "удалить категорию",
-        "setFocus": "установить режим фокусировки",
+        "setFocus": "установить режим фокуса",
         "setTheme": "установить тему",
         "setZoom": "установить масштаб",
         "startScheduleNow": "начать расписание сейчас"
@@ -66,20 +66,20 @@
         "focus8h": "8ч",
         "focusLabel": "фокус",
         "newSchedule": "новое",
-        "themeDark": "темная",
-        "themeLight": "светлая",
+        "themeDark": "тёмная",
+        "themeLight": "свет",
         "themeSystem": "авто",
         "workingHours": "часы",
         "zoomIn": "увеличить",
-        "zoomOut": "уменьшить масштаб"
+        "zoomOut": "уменьшить"
     },
     "onboarding": {
         "addFirst": "добавить первое расписание",
-        "firstSchedule": "Добавьте первое расписание, чтобы увидеть его на недельной сетке, временной шкале сегодня и аналоговых часах.",
-        "welcome": "Расписаний пока нет"
+        "firstSchedule": "Добавьте своё первое расписание, чтобы увидеть его на недельной сетке, временной шкале сегодня и аналоговых часах.",
+        "welcome": "Пока нет расписаний"
     },
     "schedule": {
-        "afterLastNoneHint": "нет предстоящего расписания",
+        "afterLastNoneHint": "нет предстоящих расписаний",
         "buttonAfterLast": "следующее после последнего расписания",
         "buttonMinus10": "-10м",
         "buttonMinus30": "-30м",
@@ -89,31 +89,31 @@
         "categoryAddOption": "+ добавить категорию",
         "chainedCheckbox": "связать с предыдущим расписанием",
         "endLabelV2": "время окончания",
-        "endPlaceholder": "выбрать длительность",
+        "endPlaceholder": "выбрать продолжительность",
         "fieldCategory": "категория",
-        "fieldDuration": "длительность (мин)",
+        "fieldDuration": "продолжительность (мин)",
         "fieldName": "название",
         "fieldStartHour": "час начала",
-        "fieldStartMinute": "минута начала",
+        "fieldStartMinute": "начальная минута",
         "headerEdit": "редактировать расписание",
         "headerNew": "новое расписание",
         "hourSuffix": "ч",
         "hourTodaySuffix": "(сегодня)",
         "hourTomorrowSuffix": "(завтра)",
         "minuteSuffix": "м",
-        "prevChainLabel": "связано с предыдущим расписанием",
+        "prevChainLabel": "связанное предыдущее расписание",
         "titleDefault": "Новое расписание",
-        "warningOverlapLimit": "Максимум {limit} расписаний могут пересекаться одновременно. Настройте время начала/длительность или удалите существующее."
+        "warningOverlapLimit": "Максимум {limit} расписаний могут пересекаться одновременно. Измените время начала/продолжительность или удалите существующее."
     },
     "serverError": {
-        "categoryHasSchedules": "Категория содержит {scheduleCount} расписаний. Подтвердите каскадное удаление.",
+        "categoryHasSchedules": "Категория имеет {scheduleCount} расписаний. Подтвердите каскадное удаление.",
         "categoryNotFound": "Категория не найдена или не принадлежит вам.",
         "scheduleNotFound": "Расписание не найдено.",
         "unauthorized": "Требуется вход."
     },
     "signIn": {
         "cta": "Войти",
-        "description": "Войдите в свой аккаунт cofounder для просмотра и управления расписаниями.",
+        "description": "Войдите в свой аккаунт cofounder для просмотра и управления вашими расписаниями.",
         "title": "Требуется вход"
     },
     "timer": {
@@ -131,19 +131,19 @@
         "labelUpcoming": "следующее расписание",
         "overlapLabel": "пересечение {count}",
         "simultaneousLabel": "одновременно · {count}",
-        "tooltipClickToFocus": "нажмите для переключения в режим фокусировки",
+        "tooltipClickToFocus": "нажмите для переключения в режим фокуса",
         "tooltipClickToIdle": "нажмите для переключения в режим ожидания",
-        "typeCountdown": "обратный отсчет",
-        "typeCountup": "прямой отсчет",
-        "typeTimer1": "timer1"
+        "typeCountdown": "обратный отсчёт",
+        "typeCountup": "прямой отсчёт",
+        "typeTimer1": "таймер1"
     },
     "topbar": {
         "back": "вернуться на портал",
-        "creditsLabel": "титры",
+        "creditsLabel": "кредиты",
         "creditsPlaceholder": "—",
         "guest": "гость",
         "languageLabel": "язык",
-        "logout": "выйти"
+        "logout": "выход"
     },
     "undo": {
         "actionLabel": "отмена доступна",
@@ -151,10 +151,10 @@
     },
     "wallTime": {
         "am": "am",
-        "pm": "pm"
+        "pm": "вечера"
     },
     "weekdays": [
-        "вс",
+        "солнце",
         "пн",
         "вт",
         "ср",
@@ -163,7 +163,7 @@
         "сб"
     ],
     "workingHours": {
-        "checkboxAlsoDefault": "также сохранить по умолчанию",
+        "checkboxAlsoDefault": "также сохранить как значение по умолчанию",
         "checkboxWeekdaysOnly": "только будни (пн–пт)",
         "errorEndAfterStart": "Время окончания должно быть после времени начала.",
         "errorToAfterFrom": "Дата окончания должна быть не раньше даты начала.",
@@ -175,7 +175,7 @@
         "header": "рабочие часы",
         "tabRange": "диапазон",
         "tabSingle": "одиночное",
-        "warningNoDates": "Нет дат для применения в диапазоне. (начало > конца или конфликт с днями недели)",
-        "warningTruncated": "Диапазон превышает {max} дней, обработано частично. Попробуйте сузить диапазон."
+        "warningNoDates": "Нет дат для применения в диапазоне. (начало > конца или конфликт только-будни)",
+        "warningTruncated": "Диапазон превышает {max} дней, обработано только частично. Попробуйте более узкий диапазон."
     }
 }

--- a/messages/zh-CN.json
+++ b/messages/zh-CN.json
@@ -1,181 +1,181 @@
 {
-  "app": {
-    "tagline": "日程管理器",
-    "title": "plan1"
-  },
-  "auth": {
-    "signIn": "使用 Google 登录",
-    "signInDescription": "plan1 是一个支持跨设备同步的个人日程工具。使用 Google 登录以开始使用。",
-    "signInRequired": "登录以使用 plan1"
-  },
-  "category": {
-    "confirmRemoveLabel": "确认删除 ({count})",
-    "confirmRemoveText": "将同时删除 {count} 个日程。再次点击以确认。",
-    "defaultName": "默认",
-    "empty": "暂无类别。",
-    "fieldColor": "颜色",
-    "fieldName": "名称",
-    "header": "类别",
-    "removeButton": "删除",
-    "scheduleCountSuffix": "{count} 个日程"
-  },
-  "common": {
-    "add": "添加",
-    "cancel": "取消",
-    "close": "关闭",
-    "confirmDelete": "确认删除",
-    "delete": "删除",
-    "dismiss": "关闭",
-    "now": "现在",
-    "retry": "重试",
-    "save": "保存"
-  },
-  "confirmation": {
-    "scheduleAdded": "日程已添加"
-  },
-  "error": {
-    "featureUnavailable": "此功能尚未可用 ({feature})。",
-    "loadFailedLabel": "加载失败:",
-    "mutationFailed": "操作失败 {action}: {error}",
-    "unknown": "发生意外错误。请重试。",
-    "workingHoursInvalid": "工作时间输入无效 ({reason})。"
-  },
-  "loading": "加载中...",
-  "mutation": {
-    "changeTimerType": "更改计时器类型",
-    "completeSchedule": "完成日程",
-    "extendTimer": "延长计时器",
-    "removeCategory": "删除类别",
-    "setFocus": "设置专注视图",
-    "setTheme": "设置主题",
-    "startScheduleNow": "start schedule now",
-    "setZoom": "设置缩放"
-  },
-  "nav": {
-    "categories": "类别",
-    "focus10h": "10小时",
-    "focus12h": "12小时",
-    "focus16h": "16小时",
-    "focus20h": "20小时",
-    "focus24h": "24小时",
-    "focus4h": "4小时",
-    "focus6h": "6小时",
-    "focus8h": "8小时",
-    "focusLabel": "专注",
-    "newSchedule": "新建",
-    "themeDark": "深色",
-    "themeLight": "浅色",
-    "themeSystem": "自动",
-    "workingHours": "小时",
-    "zoomIn": "放大",
-    "zoomOut": "缩小"
-  },
-  "onboarding": {
-    "addFirst": "添加第一个日程",
-    "firstSchedule": "添加您的第一个日程,即可在周视图、今日时间线和模拟时钟上看到它。",
-    "welcome": "暂无日程"
-  },
-  "schedule": {
-    "afterLastNoneHint": "无即将到来的日程",
-    "buttonAfterLast": "next after last schedule",
-    "buttonMinus10": "-10分钟",
-    "buttonMinus30": "-30分钟",
-    "buttonPlus10": "+10分钟",
-    "buttonPlus30": "+30分钟",
-    "buttonPlusHour": "+1小时",
-    "categoryAddOption": "+ 添加类别",
-    "chainedCheckbox": "链接到上一个日程",
-    "endLabelV2": "结束时间",
-    "endPlaceholder": "选择时长",
-    "fieldCategory": "类别",
-    "fieldDuration": "时长 (分钟)",
-    "fieldName": "名称",
-    "fieldStartHour": "开始小时",
-    "fieldStartMinute": "开始分钟",
-    "headerEdit": "编辑日程",
-    "headerNew": "新建日程",
-    "hourSuffix": "小时",
-    "hourTodaySuffix": "(今天)",
-    "hourTomorrowSuffix": "(明天)",
-    "minuteSuffix": "分钟",
-    "prevChainLabel": "已连接上一个日程",
-    "titleDefault": "新建日程",
-    "warningOverlapLimit": "最多 {limit} 个日程可以同时重叠。调整开始时间/时长或删除现有日程。"
-  },
-  "serverError": {
-    "categoryHasSchedules": "类别有 {scheduleCount} 个日程。确认级联删除以移除。",
-    "categoryNotFound": "未找到类别或非拥有者。",
-    "scheduleNotFound": "未找到日程。",
-    "unauthorized": "需要登录。"
-  },
-  "signIn": {
-    "cta": "登录",
-    "description": "登录您的 cofounder 账户以查看和管理您的日程。",
-    "title": "需要登录"
-  },
-  "timer": {
-    "buttonComplete": "完成",
-    "buttonFocus": "专注",
-    "buttonIdle": "空闲",
-    "categoryFallback": "?",
-    "idleEmpty": "空闲 · 无活动日程",
-    "labelElapsed": "已过去",
-    "labelEndAt": "结束于",
-    "labelRemaining": "剩余",
-    "labelTarget": "目标",
-    "labelUntilUpcoming": "直到即将到来",
-    "labelUpcoming": "下一个日程",
-    "overlapLabel": "重叠 {count}",
-    "simultaneousLabel": "同时进行 · {count}",
-    "tooltipClickToFocus": "点击切换到专注",
-    "tooltipClickToIdle": "点击切换到空闲",
-    "typeCountdown": "倒计时",
-    "typeCountup": "正计时",
-    "typeTimer1": "timer1",
-    "buttonStartNow": "start now"
-  },
-  "topbar": {
-    "back": "返回门户",
-    "creditsLabel": "制作人员",
-    "creditsPlaceholder": "—",
-    "guest": "访客",
-    "languageLabel": "语言",
-    "logout": "登出"
-  },
-  "undo": {
-    "actionLabel": "可撤销",
-    "button": "撤销"
-  },
-  "wallTime": {
-    "am": "上午",
-    "pm": "下午"
-  },
-  "weekdays": [
-    "周日",
-    "周一",
-    "周二",
-    "周三",
-    "周四",
-    "周五",
-    "周六"
-  ],
-  "workingHours": {
-    "checkboxAlsoDefault": "同时保存为默认",
-    "checkboxWeekdaysOnly": "仅工作日 (周一至周五)",
-    "errorEndAfterStart": "结束时间必须晚于开始时间。",
-    "errorToAfterFrom": "结束日期必须在开始日期当天或之后。",
-    "fieldDate": "日期",
-    "fieldEndTime": "结束时间",
-    "fieldFromDate": "从",
-    "fieldStartTime": "开始时间",
-    "fieldToDate": "到",
-    "header": "工作时间",
-    "tabRange": "范围",
-    "tabSingle": "单次",
-    "warningNoDates": "范围内没有可应用的日期。(开始 > 结束 或 仅工作日冲突)",
-    "warningTruncated": "范围超过 {max} 天,仅处理部分。请尝试更窄的范围。"
-  },
-  "header": {
-    "finalEndAtSuffix": "end"
-  }
+    "app": {
+        "tagline": "日程管理器",
+        "title": "plan1"
+    },
+    "auth": {
+        "signIn": "使用 Google 登录",
+        "signInDescription": "plan1 是一个支持跨设备同步的个人日程工具。使用 Google 登录即可开始使用。",
+        "signInRequired": "登录以使用 plan1"
+    },
+    "category": {
+        "confirmRemoveLabel": "确认删除 ({count})",
+        "confirmRemoveText": "{count} 个日程将随之删除。再次点击以确认。",
+        "defaultName": "默认",
+        "empty": "无分类。",
+        "fieldColor": "颜色",
+        "fieldName": "名称",
+        "header": "分类",
+        "removeButton": "删除",
+        "scheduleCountSuffix": "{count} 个日程"
+    },
+    "common": {
+        "add": "添加",
+        "cancel": "取消",
+        "close": "关闭",
+        "confirmDelete": "确认删除",
+        "delete": "删除",
+        "dismiss": "关闭",
+        "now": "现在",
+        "retry": "重试",
+        "save": "保存"
+    },
+    "confirmation": {
+        "scheduleAdded": "日程已添加"
+    },
+    "error": {
+        "featureUnavailable": "此功能尚未开放 ({feature})。",
+        "loadFailedLabel": "加载失败：",
+        "mutationFailed": "{action} 失败：{error}",
+        "unknown": "发生意外错误。请重试。",
+        "workingHoursInvalid": "工作时间输入无效（{reason}）。"
+    },
+    "header": {
+        "finalEndAtSuffix": "结束"
+    },
+    "loading": "加载中...",
+    "mutation": {
+        "changeTimerType": "更改计时器类型",
+        "completeSchedule": "完成日程",
+        "extendTimer": "延长计时器",
+        "removeCategory": "删除分类",
+        "setFocus": "设置专注视图",
+        "setTheme": "设置主题",
+        "setZoom": "设置缩放",
+        "startScheduleNow": "立即开始日程"
+    },
+    "nav": {
+        "categories": "分类",
+        "focus10h": "10小时",
+        "focus12h": "12小时",
+        "focus16h": "16小时",
+        "focus20h": "20小时",
+        "focus24h": "24小时",
+        "focus4h": "4小时",
+        "focus6h": "6小时",
+        "focus8h": "8小时",
+        "focusLabel": "专注",
+        "newSchedule": "新建",
+        "themeDark": "深色",
+        "themeLight": "浅色",
+        "themeSystem": "自动",
+        "workingHours": "小时",
+        "zoomIn": "放大",
+        "zoomOut": "缩小"
+    },
+    "onboarding": {
+        "addFirst": "添加第一个日程",
+        "firstSchedule": "添加您的第一个日程，以在每周网格、今日时间线和模拟时钟上查看。",
+        "welcome": "暂无日程"
+    },
+    "schedule": {
+        "afterLastNoneHint": "无即将到来的日程",
+        "buttonAfterLast": "在最后一个日程之后",
+        "buttonMinus10": "-10分钟",
+        "buttonMinus30": "-30分钟",
+        "buttonPlus10": "+10分钟",
+        "buttonPlus30": "+30分钟",
+        "buttonPlusHour": "+1小时",
+        "categoryAddOption": "+ 添加分类",
+        "chainedCheckbox": "链接到上一个日程",
+        "endLabelV2": "结束时间",
+        "endPlaceholder": "选择时长",
+        "fieldCategory": "分类",
+        "fieldDuration": "时长（分钟）",
+        "fieldName": "名称",
+        "fieldStartHour": "开始小时",
+        "fieldStartMinute": "开始分钟",
+        "headerEdit": "编辑日程",
+        "headerNew": "新建日程",
+        "hourSuffix": "小时",
+        "hourTodaySuffix": "（今天）",
+        "hourTomorrowSuffix": "（明天）",
+        "minuteSuffix": "分钟",
+        "prevChainLabel": "已连接上一个日程",
+        "titleDefault": "新建日程",
+        "warningOverlapLimit": "最多可同时重叠 {limit} 个日程。请调整开始时间/时长或删除现有日程。"
+    },
+    "serverError": {
+        "categoryHasSchedules": "分类中有 {scheduleCount} 个日程。确认级联删除以移除。",
+        "categoryNotFound": "未找到分类或不属于您。",
+        "scheduleNotFound": "未找到日程。",
+        "unauthorized": "需要登录。"
+    },
+    "signIn": {
+        "cta": "登录",
+        "description": "登录到您的 cofounder 账户以查看和管理您的日程。",
+        "title": "需要登录"
+    },
+    "timer": {
+        "buttonComplete": "完成",
+        "buttonFocus": "专注",
+        "buttonIdle": "空闲",
+        "buttonStartNow": "现在开始",
+        "categoryFallback": "？",
+        "idleEmpty": "空闲 · 无活动日程",
+        "labelElapsed": "已用时",
+        "labelEndAt": "结束于",
+        "labelRemaining": "剩余",
+        "labelTarget": "目标",
+        "labelUntilUpcoming": "直到即将到来",
+        "labelUpcoming": "下一个日程",
+        "overlapLabel": "重叠 {count}",
+        "simultaneousLabel": "同时进行 · {count}",
+        "tooltipClickToFocus": "点击切换到专注",
+        "tooltipClickToIdle": "点击切换到空闲",
+        "typeCountdown": "倒计时",
+        "typeCountup": "正计时",
+        "typeTimer1": "计时器1"
+    },
+    "topbar": {
+        "back": "返回门户",
+        "creditsLabel": "致谢",
+        "creditsPlaceholder": "—",
+        "guest": "访客",
+        "languageLabel": "语言",
+        "logout": "登出"
+    },
+    "undo": {
+        "actionLabel": "可撤销",
+        "button": "撤销"
+    },
+    "wallTime": {
+        "am": "上午",
+        "pm": "下午"
+    },
+    "weekdays": [
+        "周日",
+        "周一",
+        "周二",
+        "周三",
+        "周四",
+        "周五",
+        "周六"
+    ],
+    "workingHours": {
+        "checkboxAlsoDefault": "同时保存为默认值",
+        "checkboxWeekdaysOnly": "仅工作日（周一至周五）",
+        "errorEndAfterStart": "结束时间必须晚于开始时间。",
+        "errorToAfterFrom": "结束日期必须等于或晚于开始日期。",
+        "fieldDate": "日期",
+        "fieldEndTime": "结束时间",
+        "fieldFromDate": "从",
+        "fieldStartTime": "开始时间",
+        "fieldToDate": "到",
+        "header": "工作时间",
+        "tabRange": "范围",
+        "tabSingle": "单次",
+        "warningNoDates": "范围内没有可应用的日期。（开始>结束 或 仅工作日冲突）",
+        "warningTruncated": "范围超过 {max} 天，仅处理部分。请尝试更窄的范围。"
+    }
 }

--- a/messages/zh-CN.json
+++ b/messages/zh-CN.json
@@ -1,22 +1,22 @@
 {
     "app": {
         "tagline": "日程管理器",
-        "title": "plan1"
+        "title": "计划1"
     },
     "auth": {
         "signIn": "使用 Google 登录",
-        "signInDescription": "plan1 是一个支持跨设备同步的个人日程工具。使用 Google 账号登录即可开始使用。",
-        "signInRequired": "登录以使用 plan1"
+        "signInDescription": "plan1 是一个支持跨设备同步的个人日程工具。使用 Google 登录即可开始使用。",
+        "signInRequired": "登录以使用计划1"
     },
     "category": {
         "confirmRemoveLabel": "确认删除 ({count})",
         "confirmRemoveText": "{count} 个日程将随之删除。再次点击以确认。",
         "defaultName": "默认",
-        "empty": "没有类别。",
+        "empty": "无分类。",
         "fieldColor": "颜色",
         "fieldName": "名称",
-        "header": "类别",
-        "removeButton": "删除",
+        "header": "分类",
+        "removeButton": "移除",
         "scheduleCountSuffix": "{count} 个日程"
     },
     "common": {
@@ -34,9 +34,9 @@
         "scheduleAdded": "日程已添加"
     },
     "error": {
-        "featureUnavailable": "此功能尚未开放 ({feature})。",
-        "loadFailedLabel": "加载失败：",
-        "mutationFailed": "操作失败 {action}：{error}",
+        "featureUnavailable": "此功能尚未可用 ({feature})。",
+        "loadFailedLabel": "加载失败:",
+        "mutationFailed": "操作失败 {action}: {error}",
         "unknown": "发生意外错误。请重试。",
         "workingHoursInvalid": "工作时间输入无效 ({reason})。"
     },
@@ -48,14 +48,14 @@
         "changeTimerType": "更改计时器类型",
         "completeSchedule": "完成日程",
         "extendTimer": "延长计时器",
-        "removeCategory": "移除类别",
+        "removeCategory": "删除类别",
         "setFocus": "设置专注视图",
         "setTheme": "设置主题",
         "setZoom": "设置缩放",
         "startScheduleNow": "立即开始日程"
     },
     "nav": {
-        "categories": "类别",
+        "categories": "分类",
         "focus10h": "10小时",
         "focus12h": "12小时",
         "focus16h": "16小时",
@@ -76,44 +76,44 @@
     "onboarding": {
         "addFirst": "添加第一个日程",
         "firstSchedule": "添加您的第一个日程以在周视图、今日时间线和模拟时钟上查看。",
-        "welcome": "还没有日程"
+        "welcome": "暂无日程"
     },
     "schedule": {
-        "afterLastNoneHint": "没有即将到来的日程",
-        "buttonAfterLast": "在最后一个日程之后",
+        "afterLastNoneHint": "无即将到来的日程",
+        "buttonAfterLast": "最后一个日程之后的下一个",
         "buttonMinus10": "-10分钟",
         "buttonMinus30": "-30分钟",
         "buttonPlus10": "+10分钟",
         "buttonPlus30": "+30分钟",
         "buttonPlusHour": "+1小时",
-        "categoryAddOption": "+ 添加类别",
-        "chainedCheckbox": "链接到前一个日程",
+        "categoryAddOption": "+ 添加分类",
+        "chainedCheckbox": "链接到上一个日程",
         "endLabelV2": "结束时间",
-        "endPlaceholder": "选择时长",
-        "fieldCategory": "类别",
-        "fieldDuration": "时长（分钟）",
+        "endPlaceholder": "选择持续时间",
+        "fieldCategory": "分类",
+        "fieldDuration": "持续时间（分钟）",
         "fieldName": "名称",
         "fieldStartHour": "开始小时",
         "fieldStartMinute": "开始分钟",
         "headerEdit": "编辑日程",
         "headerNew": "新建日程",
         "hourSuffix": "小时",
-        "hourTodaySuffix": "（今天）",
+        "hourTodaySuffix": "(今天)",
         "hourTomorrowSuffix": "(明天)",
-        "minuteSuffix": "分钟",
-        "prevChainLabel": "已连接前一个日程",
+        "minuteSuffix": "m",
+        "prevChainLabel": "已连接上一个日程",
         "titleDefault": "新建日程",
-        "warningOverlapLimit": "最多可以有 {limit} 个日程同时重叠。请调整开始时间/时长或删除现有日程。"
+        "warningOverlapLimit": "最多可以同时重叠 {limit} 个日程。请调整开始时间/持续时间或删除现有日程。"
     },
     "serverError": {
-        "categoryHasSchedules": "类别有 {scheduleCount} 个日程。确认级联删除以移除。",
-        "categoryNotFound": "未找到类别或无权访问。",
+        "categoryHasSchedules": "分类有 {scheduleCount} 个日程。确认级联删除以移除。",
+        "categoryNotFound": "未找到分类或不属于您。",
         "scheduleNotFound": "未找到日程。",
         "unauthorized": "需要登录。"
     },
     "signIn": {
         "cta": "登录",
-        "description": "登录到您的 cofounder 账户以查看和管理您的日程。",
+        "description": "登录您的 cofounder 账户以查看和管理您的日程。",
         "title": "需要登录"
     },
     "timer": {
@@ -164,9 +164,9 @@
     ],
     "workingHours": {
         "checkboxAlsoDefault": "同时保存为默认",
-        "checkboxWeekdaysOnly": "仅工作日（周一至周五）",
-        "errorEndAfterStart": "结束时间必须晚于开始时间。",
-        "errorToAfterFrom": "结束日期必须等于或晚于开始日期。",
+        "checkboxWeekdaysOnly": "仅工作日 (周一至周五)",
+        "errorEndAfterStart": "结束时间必须在开始时间之后。",
+        "errorToAfterFrom": "结束日期必须在开始日期当天或之后。",
         "fieldDate": "日期",
         "fieldEndTime": "结束时间",
         "fieldFromDate": "从",
@@ -174,8 +174,8 @@
         "fieldToDate": "到",
         "header": "工作时间",
         "tabRange": "范围",
-        "tabSingle": "单个",
-        "warningNoDates": "范围内没有可应用的日期。（开始 > 结束 或 仅工作日冲突）",
-        "warningTruncated": "范围超过 {max} 天，仅处理部分。请尝试更窄的范围。"
+        "tabSingle": "单次",
+        "warningNoDates": "范围内没有可应用的日期。(开始>结束 或 仅工作日冲突)",
+        "warningTruncated": "范围超过 {max} 天,仅处理部分。请尝试更窄的范围。"
     }
 }

--- a/messages/zh-CN.json
+++ b/messages/zh-CN.json
@@ -48,7 +48,8 @@
     "removeCategory": "删除类别",
     "setFocus": "设置专注视图",
     "setTheme": "设置主题",
-    "startScheduleNow": "start schedule now"
+    "startScheduleNow": "start schedule now",
+    "setZoom": "设置缩放"
   },
   "nav": {
     "categories": "类别",
@@ -65,7 +66,9 @@
     "themeDark": "深色",
     "themeLight": "浅色",
     "themeSystem": "自动",
-    "workingHours": "小时"
+    "workingHours": "小时",
+    "zoomIn": "放大",
+    "zoomOut": "缩小"
   },
   "onboarding": {
     "addFirst": "添加第一个日程",

--- a/messages/zh-CN.json
+++ b/messages/zh-CN.json
@@ -5,17 +5,17 @@
     },
     "auth": {
         "signIn": "使用 Google 登录",
-        "signInDescription": "plan1 是一个支持跨设备同步的个人日程工具。使用 Google 登录即可开始使用。",
+        "signInDescription": "plan1 是一个支持跨设备同步的个人日程工具。使用 Google 账号登录即可开始使用。",
         "signInRequired": "登录以使用 plan1"
     },
     "category": {
         "confirmRemoveLabel": "确认删除 ({count})",
         "confirmRemoveText": "{count} 个日程将随之删除。再次点击以确认。",
         "defaultName": "默认",
-        "empty": "无分类。",
+        "empty": "没有类别。",
         "fieldColor": "颜色",
         "fieldName": "名称",
-        "header": "分类",
+        "header": "类别",
         "removeButton": "删除",
         "scheduleCountSuffix": "{count} 个日程"
     },
@@ -36,9 +36,9 @@
     "error": {
         "featureUnavailable": "此功能尚未开放 ({feature})。",
         "loadFailedLabel": "加载失败：",
-        "mutationFailed": "{action} 失败：{error}",
+        "mutationFailed": "操作失败 {action}：{error}",
         "unknown": "发生意外错误。请重试。",
-        "workingHoursInvalid": "工作时间输入无效（{reason}）。"
+        "workingHoursInvalid": "工作时间输入无效 ({reason})。"
     },
     "header": {
         "finalEndAtSuffix": "结束"
@@ -48,14 +48,14 @@
         "changeTimerType": "更改计时器类型",
         "completeSchedule": "完成日程",
         "extendTimer": "延长计时器",
-        "removeCategory": "删除分类",
+        "removeCategory": "移除类别",
         "setFocus": "设置专注视图",
         "setTheme": "设置主题",
         "setZoom": "设置缩放",
         "startScheduleNow": "立即开始日程"
     },
     "nav": {
-        "categories": "分类",
+        "categories": "类别",
         "focus10h": "10小时",
         "focus12h": "12小时",
         "focus16h": "16小时",
@@ -75,22 +75,22 @@
     },
     "onboarding": {
         "addFirst": "添加第一个日程",
-        "firstSchedule": "添加您的第一个日程，以在每周网格、今日时间线和模拟时钟上查看。",
-        "welcome": "暂无日程"
+        "firstSchedule": "添加您的第一个日程以在周视图、今日时间线和模拟时钟上查看。",
+        "welcome": "还没有日程"
     },
     "schedule": {
-        "afterLastNoneHint": "无即将到来的日程",
+        "afterLastNoneHint": "没有即将到来的日程",
         "buttonAfterLast": "在最后一个日程之后",
         "buttonMinus10": "-10分钟",
         "buttonMinus30": "-30分钟",
         "buttonPlus10": "+10分钟",
         "buttonPlus30": "+30分钟",
         "buttonPlusHour": "+1小时",
-        "categoryAddOption": "+ 添加分类",
-        "chainedCheckbox": "链接到上一个日程",
+        "categoryAddOption": "+ 添加类别",
+        "chainedCheckbox": "链接到前一个日程",
         "endLabelV2": "结束时间",
         "endPlaceholder": "选择时长",
-        "fieldCategory": "分类",
+        "fieldCategory": "类别",
         "fieldDuration": "时长（分钟）",
         "fieldName": "名称",
         "fieldStartHour": "开始小时",
@@ -99,15 +99,15 @@
         "headerNew": "新建日程",
         "hourSuffix": "小时",
         "hourTodaySuffix": "（今天）",
-        "hourTomorrowSuffix": "（明天）",
+        "hourTomorrowSuffix": "(明天)",
         "minuteSuffix": "分钟",
-        "prevChainLabel": "已连接上一个日程",
+        "prevChainLabel": "已连接前一个日程",
         "titleDefault": "新建日程",
-        "warningOverlapLimit": "最多可同时重叠 {limit} 个日程。请调整开始时间/时长或删除现有日程。"
+        "warningOverlapLimit": "最多可以有 {limit} 个日程同时重叠。请调整开始时间/时长或删除现有日程。"
     },
     "serverError": {
-        "categoryHasSchedules": "分类中有 {scheduleCount} 个日程。确认级联删除以移除。",
-        "categoryNotFound": "未找到分类或不属于您。",
+        "categoryHasSchedules": "类别有 {scheduleCount} 个日程。确认级联删除以移除。",
+        "categoryNotFound": "未找到类别或无权访问。",
         "scheduleNotFound": "未找到日程。",
         "unauthorized": "需要登录。"
     },
@@ -120,10 +120,10 @@
         "buttonComplete": "完成",
         "buttonFocus": "专注",
         "buttonIdle": "空闲",
-        "buttonStartNow": "现在开始",
-        "categoryFallback": "？",
+        "buttonStartNow": "立即开始",
+        "categoryFallback": "?",
         "idleEmpty": "空闲 · 无活动日程",
-        "labelElapsed": "已用时",
+        "labelElapsed": "已过",
         "labelEndAt": "结束于",
         "labelRemaining": "剩余",
         "labelTarget": "目标",
@@ -163,7 +163,7 @@
         "周六"
     ],
     "workingHours": {
-        "checkboxAlsoDefault": "同时保存为默认值",
+        "checkboxAlsoDefault": "同时保存为默认",
         "checkboxWeekdaysOnly": "仅工作日（周一至周五）",
         "errorEndAfterStart": "结束时间必须晚于开始时间。",
         "errorToAfterFrom": "结束日期必须等于或晚于开始日期。",
@@ -174,8 +174,8 @@
         "fieldToDate": "到",
         "header": "工作时间",
         "tabRange": "范围",
-        "tabSingle": "单次",
-        "warningNoDates": "范围内没有可应用的日期。（开始>结束 或 仅工作日冲突）",
+        "tabSingle": "单个",
+        "warningNoDates": "范围内没有可应用的日期。（开始 > 结束 或 仅工作日冲突）",
         "warningTruncated": "范围超过 {max} 天，仅处理部分。请尝试更窄的范围。"
     }
 }


### PR DESCRIPTION
## Summary
- 시간별 스케줄 확대/축소 — 폰트 그대로, 시간 간격 (1시간 height px) 만 변경
- 이미지 레이아웃 정합 — 좌: \`5.9(토) 10시 30분 끝\` 통합 / 우: focus dropdown + − + +
- 폰트 크기 통일 — dateLabel = finalEndLabel (text-sm font-medium · 컬러 muted/ink 각각 그대로)
- min/max 도달 시 버튼 흐리게 비활성 처리

## 결정 영역
| 영역 | 값 | 근거 |
|---|---|---|
| default | 50px/hour | FullCalendar v6 default 1.5em × 2 슬롯 추정 (S6 검증 단계 조정 가능) |
| step | ±20px | 대장 명시 |
| min | 50 (default) | 대장 명시 — 줌아웃 - 버튼 비활성 |
| max | 200 | 10분 슬롯 가독성 (10분 row ≥ 33.3px) |
| slotDuration 동적 | pxPerHour ≥ 120 → 10분 / 미만 → 30분 | 10분 row height ≥ 20px (폰트 가독성) |

## 변경 파일 (20 files · +273 / −45)
- \`lib/zoom-helpers.ts\` (신설) — clampZoomPxPerHour · zoomDenseSlotDuration · zoomSlotHeightPx
- \`lib/zoom-helpers.test.ts\` (신설 · 13 tests · EP/BVA · threshold)
- \`lib/db/schema.ts\` · \`lib/domain/types.ts\` · \`lib/store.ts\` — zoomPxPerHour 필드
- \`app/actions/settings.ts\` — patch handler + 서버 사이드 clamp
- \`components/DailyTimeline.tsx\` — 줌 +/- 버튼 + 레이아웃 swap + slotDuration 동적 + 폰트 통일
- \`app/globals.css\` — \`.fc-timegrid-slot\` height CSS variable
- \`messages/{en,ko}.json\` — nav.zoomIn/zoomOut · mutation.setZoom 마스터
- \`messages/{es,pt,fr,de,ja,zh-CN,ru,ar,hi}.json\` — 9 언어 자연 번역
- \`lib/use-run-mutation.ts\` — MutationContextKey 'setZoom' 추가

## DB schema 정합
- portal PR #44 (https://github.com/horaeng0506/cofounder-portal/pull/44) — \`plan1.settings.zoom_px_per_hour\` column 추가
- 의존 순서: portal #44 main merge + prod migration → plan1 PR main merge

## Test plan
- [x] vitest 139/139 PASS (i18n-catalog 9 언어 drift 가드 포함)
- [x] typecheck clean (ownership-guards 선행 에러는 main 동일)
- [x] ESLint clean
- [x] zoom-helpers EP/BVA + threshold 분기 13 tests
- [ ] mutation E2E CI green (Neon ephemeral branch · plan1.settings 테이블에 zoom_px_per_hour column 적용된 portal main 의존)
- [ ] i18n-translate workflow 자동 갱신 (en.json 변경 트리거)
- [ ] 브라우저 검증 (default 50px 가 사용자 화면 변화 X 박는지 · S6 의 \"현재 크기 그대로\" 정합)

🤖 Generated with [Claude Code](https://claude.com/claude-code)