### PR TITLE
fix(timeline): 시간 라벨 column 30분 점선 박지 X (1시간 칸 병합 효과)

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -172,3 +172,12 @@ body::before {
   /* default inline-block 박음 영역 → block 박음 영역 (full width 가운데 정렬) */
   display: block;
 }
+
+/* PLAN1-ZOOM-LABEL-COLUMN-MERGE-20260509 — 시간 라벨 column 박은 영역 1시간 단위 박음.
+ * 대장 명시 — 왼쪽 column 박은 영역 (시간 라벨) = 30분 점선 영역 박지 X (1시간 영역 칸 병합 효과).
+ * 오른쪽 column 박은 영역 (스케줄 lane) = 30분 점선 보존.
+ * 해결 = label column 박은 영역 의 minor td (30분 시작) 박은 영역 의 border-top 박은 영역 transparent 박음.
+ * lane column 박은 영역 (`.fc-timegrid-slot-lane`) 의 minor border 영역 보존. */
+.fc .fc-timegrid-slot-label.fc-timegrid-slot-minor {
+  border-top-color: transparent;
+}


### PR DESCRIPTION
## Summary
대장 명시 (msg 1502462446512898118):
- 왼쪽 column (시간 라벨) = 1시간 단위 칸 박음 (30분 점선 영역 박지 X)
- 오른쪽 column (스케줄 lane) = 30분 점선 영역 보존

## CSS 박음
\`.fc-timegrid-slot-label.fc-timegrid-slot-minor\` 박은 영역 의 \`border-top-color: transparent\`
- label column 박은 영역의 30분 시작 td (minor) 박은 영역 위 line 박지 X
- 시각적 1시간 영역 한 칸 박음
- lane column 박은 영역 (\`.fc-timegrid-slot-lane\`) minor 박음 영향 X (점선 보존)

## 변경
- \`app/globals.css\` (+9 lines)

## Test plan
- [x] vitest 126/126 PASS
- [x] ESLint clean
- [ ] mutation E2E CI green
- [ ] 대장 사용자 검증 — 왼쪽 1시간 칸 + 오른쪽 30분 점선

🤖 Generated with [Claude Code](https://claude.com/claude-code)