### PR TITLE
fix(ci): TruffleHog BASE=HEAD same commit fail (META-TRUFFLEHOG-WORKFLOW-FIX-20260510)

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -6,6 +6,12 @@
 #   - gitleaks pre-commit (client-side · 4 머신) + TruffleHog CI (server-side · 매 push) 조합
 #   - --only-verified flag: 진짜 작동 token 만 alert (활성 검증 · false positive 0 가까움)
 #   - 발견 시 즉시 PR fail / push 시 main 차단 (branch protection 결합 시)
+#
+# META-TRUFFLEHOG-WORKFLOW-FIX-20260510:
+#   기존 `base: default_branch + head: HEAD` 영역 push 시점 base==head 박혀
+#   "BASE and HEAD are the same commit" fail. 정공 = trigger 별 분리:
+#   - push: base 박지 X (full filesystem scan · main 안 첫 push 보호)
+#   - PR:   base = pull_request.base.sha · head = pull_request.head.sha (incremental)
 
 name: TruffleHog Secret Scan
 
@@ -33,12 +39,18 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Run TruffleHog
+      - name: Run TruffleHog (push · full scan)
+        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
         uses: trufflesecurity/trufflehog@main
         with:
-          base: ${{ github.event.repository.default_branch }}
-          head: HEAD
+          # base/head 박지 X → trufflehog 가 filesystem 전체 scan
+          extra_args: --only-verified
+
+      - name: Run TruffleHog (PR · incremental scan)
+        if: github.event_name == 'pull_request'
+        uses: trufflesecurity/trufflehog@main
+        with:
+          base: ${{ github.event.pull_request.base.sha }}
+          head: ${{ github.event.pull_request.head.sha }}
           # --only-verified: 활성 token 만 (HTTP request 로 실제 verify)
-          # NOTE: trufflesecurity/trufflehog action default 가 이미 --fail 이라
-          # extra_args 에 --fail 추가하면 중복 에러 ("flag 'fail' cannot be repeated")
           extra_args: --only-verified


### PR DESCRIPTION
trigger 별 step 분리 (push=full · PR=incremental). 4 repo cookie-cutter.