### PR TITLE
fix(spec): mutation E2E selector regex 정정 (PLAN1-TASKS-SPEC-FIX-20260510)

### DIFF
--- a/tests/qa-gate/api-key-auth.spec.ts
+++ b/tests/qa-gate/api-key-auth.spec.ts
@@ -21,12 +21,12 @@ test.describe('API key 발급 + bearer auth chain', () => {
   test('settings page 박힘 + "new API key" 버튼 박힘', async ({page}) => {
     await page.goto('/project/plan1/settings');
     await expect(page.getByText(/api key|API 키/i)).toBeVisible({timeout: 10000});
-    await expect(page.getByRole('button', {name: /new api key|새 API key/i})).toBeVisible();
+    await expect(page.getByRole('button', {name: /^\+ key$|^\+ 키$/i})).toBeVisible();
   });
 
   test('API key 발급 modal — 1회 노출 + "I have saved" checkbox + close 버튼 disabled', async ({page}) => {
     await page.goto('/project/plan1/settings');
-    await page.getByRole('button', {name: /new api key|새 API key/i}).click();
+    await page.getByRole('button', {name: /^\+ key$|^\+ 키$/i}).click();
 
     // modal 박힘
     const modal = page.getByTestId('api-key-modal').or(page.getByRole('dialog'));

--- a/tests/qa-gate/task-add-direct.spec.ts
+++ b/tests/qa-gate/task-add-direct.spec.ts
@@ -22,13 +22,13 @@ test.describe('task 직접 작성 chain', () => {
     // 본 사이클 task UI 박힘 catch — TaskList sidebar AnalogClock 위
     const taskList = page.getByTestId('task-list');
     await expect(taskList).toBeVisible({timeout: 10000});
-    const newTaskButton = page.getByRole('button', {name: /new task|새 task/i});
+    const newTaskButton = page.getByRole('button', {name: /^\+ task$|^\+ 할일$/i});
     await expect(newTaskButton).toBeVisible();
   });
 
   test('new task 클릭 → TaskModal 박힘 (Terminal 톤 단순 form · 시간 영역 X)', async ({page}) => {
     await page.goto('/project/plan1/');
-    await page.getByRole('button', {name: /new task|새 task/i}).click();
+    await page.getByRole('button', {name: /^\+ task$|^\+ 할일$/i}).click();
     // TaskModal 박힘 — 제목·소요·카테고리 3 필드만 (시간 영역 X 정합)
     await expect(page.getByLabel(/title|제목/i)).toBeVisible();
     await expect(page.getByLabel(/duration|소요/i)).toBeVisible();
@@ -40,7 +40,7 @@ test.describe('task 직접 작성 chain', () => {
   test('빈 task 박음 OK (모든 필드 nullable · b 영역 정합)', async ({page}) => {
     await page.goto('/project/plan1/');
     const startMs = Date.now();
-    await page.getByRole('button', {name: /new task|새 task/i}).click();
+    await page.getByRole('button', {name: /^\+ task$|^\+ 할일$/i}).click();
     // 모든 필드 비움 + submit
     await page.getByRole('button', {name: /add|추가|submit/i}).click();
     // task list 안 새 task 박힘 영영 (디폴트 "새 스케줄" title 박음 영영 정합)
@@ -52,7 +52,7 @@ test.describe('task 직접 작성 chain', () => {
 
   test('valid task 박음 (제목·소요·카테고리 모두 박음)', async ({page}) => {
     await page.goto('/project/plan1/');
-    await page.getByRole('button', {name: /new task|새 task/i}).click();
+    await page.getByRole('button', {name: /^\+ task$|^\+ 할일$/i}).click();
     await page.getByLabel(/title|제목/i).fill('test task spec');
     await page.getByLabel(/duration|소요/i).fill('30');
     // 카테고리 영영 = 첫 옵션 박음 영영 (디폴트 categories[0] 영영)
@@ -66,7 +66,7 @@ test.describe('task 직접 작성 chain', () => {
   test('task 삭제 → 즉시 삭제 + undo bar 박음 (Q19 정합)', async ({page}) => {
     await page.goto('/project/plan1/');
     // 사전 task 박음 박음
-    await page.getByRole('button', {name: /new task|새 task/i}).click();
+    await page.getByRole('button', {name: /^\+ task$|^\+ 할일$/i}).click();
     await page.getByLabel(/title|제목/i).fill('to-delete spec');
     await page.getByRole('button', {name: /add|추가|submit/i}).click();
     await expect(page.getByText('to-delete spec')).toBeVisible({timeout: 5000});
@@ -83,7 +83,7 @@ test.describe('task 직접 작성 chain', () => {
   test('"스케줄로 추가" 버튼 → 변형 chain (지금 시작 / 마지막 직후 / 취소)', async ({page}) => {
     await page.goto('/project/plan1/');
     // 사전 task 박음 (분기 1 영영 — 모든 필드 valid)
-    await page.getByRole('button', {name: /new task|새 task/i}).click();
+    await page.getByRole('button', {name: /^\+ task$|^\+ 할일$/i}).click();
     await page.getByLabel(/title|제목/i).fill('to-schedule spec');
     await page.getByLabel(/duration|소요/i).fill('30');
     await page.getByLabel(/category|카테고리/i).selectOption({index: 0});
@@ -91,7 +91,7 @@ test.describe('task 직접 작성 chain', () => {
     await expect(page.getByText('to-schedule spec')).toBeVisible({timeout: 5000});
     // "스케줄로 추가" 클릭 → 변형 chain
     const taskItem = page.getByText('to-schedule spec').locator('..');
-    await taskItem.getByRole('button', {name: /to schedule|스케줄로/i}).click();
+    await taskItem.getByRole('button', {name: /^\+ schedule$|^\+ 스케줄$/i}).click();
     // 변형 chain — 지금 시작 / 마지막 직후 / 취소 3 버튼 박힘
     await expect(taskItem.getByRole('button', {name: /now|지금/i})).toBeVisible();
     await expect(taskItem.getByRole('button', {name: /after last|마지막/i})).toBeVisible();

--- a/tests/qa-gate/task-to-schedule.spec.ts
+++ b/tests/qa-gate/task-to-schedule.spec.ts
@@ -16,7 +16,7 @@ test.describe('task → schedule 분기 chain', () => {
   test('분기 1 — 모든 필드 valid · "지금 시작" 즉시 atomic 추가', async ({page}) => {
     await page.goto('/project/plan1/');
     // 사전 task 박음 (분기 1 영영 — 모든 필드 valid)
-    await page.getByRole('button', {name: /new task|새 task/i}).click();
+    await page.getByRole('button', {name: /^\+ task$|^\+ 할일$/i}).click();
     await page.getByLabel(/title|제목/i).fill('atomic flow spec');
     await page.getByLabel(/duration|소요/i).fill('30');
     await page.getByLabel(/category|카테고리/i).selectOption({index: 0});
@@ -25,7 +25,7 @@ test.describe('task → schedule 분기 chain', () => {
 
     // "스케줄로 추가" 클릭 → 변형 chain
     const taskItem = page.getByText('atomic flow spec').locator('..');
-    await taskItem.getByRole('button', {name: /to schedule|스케줄로/i}).click();
+    await taskItem.getByRole('button', {name: /^\+ schedule$|^\+ 스케줄$/i}).click();
 
     // "지금 시작" 클릭 → atomic chain (NewScheduleModal 안 거침)
     const startMs = Date.now();
@@ -49,7 +49,7 @@ test.describe('task → schedule 분기 chain', () => {
   test('분기 2 — durationMin 누락 · NewScheduleModal 호출 + prefill', async ({page}) => {
     await page.goto('/project/plan1/');
     // 사전 task 박음 (분기 2 영영 — durationMin null)
-    await page.getByRole('button', {name: /new task|새 task/i}).click();
+    await page.getByRole('button', {name: /^\+ task$|^\+ 할일$/i}).click();
     await page.getByLabel(/title|제목/i).fill('modal flow spec');
     // durationMin 박지 X
     await page.getByLabel(/category|카테고리/i).selectOption({index: 0});
@@ -58,7 +58,7 @@ test.describe('task → schedule 분기 chain', () => {
 
     // "스케줄로 추가" → "지금 시작" 클릭
     const taskItem = page.getByText('modal flow spec').locator('..');
-    await taskItem.getByRole('button', {name: /to schedule|스케줄로/i}).click();
+    await taskItem.getByRole('button', {name: /^\+ schedule$|^\+ 스케줄$/i}).click();
     await taskItem.getByRole('button', {name: /now|지금/i}).click();
 
     // NewScheduleModal 박힘 (분기 2 정합 영영)
@@ -73,7 +73,7 @@ test.describe('task → schedule 분기 chain', () => {
   test('분기 2 — categoryId 누락 · NewScheduleModal 호출', async ({page}) => {
     await page.goto('/project/plan1/');
     // 사전 task 박음 (분기 2 영영 — categoryId null)
-    await page.getByRole('button', {name: /new task|새 task/i}).click();
+    await page.getByRole('button', {name: /^\+ task$|^\+ 할일$/i}).click();
     await page.getByLabel(/title|제목/i).fill('no-cat flow spec');
     await page.getByLabel(/duration|소요/i).fill('30');
     // categoryId 박지 X (디폴트 영영 또는 박지 X 영영)
@@ -82,7 +82,7 @@ test.describe('task → schedule 분기 chain', () => {
 
     // "스케줄로 추가" → "지금 시작" 클릭
     const taskItem = page.getByText('no-cat flow spec').locator('..');
-    await taskItem.getByRole('button', {name: /to schedule|스케줄로/i}).click();
+    await taskItem.getByRole('button', {name: /^\+ schedule$|^\+ 스케줄$/i}).click();
     await taskItem.getByRole('button', {name: /now|지금/i}).click();
 
     // NewScheduleModal 박힘 (분기 2 정합 영영)
@@ -92,13 +92,13 @@ test.describe('task → schedule 분기 chain', () => {
 
   test('"취소" 클릭 → 변형 chain 영영 박지 X · task 그대로 박힘', async ({page}) => {
     await page.goto('/project/plan1/');
-    await page.getByRole('button', {name: /new task|새 task/i}).click();
+    await page.getByRole('button', {name: /^\+ task$|^\+ 할일$/i}).click();
     await page.getByLabel(/title|제목/i).fill('cancel flow spec');
     await page.getByRole('button', {name: /add|추가|submit/i}).click();
     await expect(page.getByText('cancel flow spec')).toBeVisible({timeout: 5000});
 
     const taskItem = page.getByText('cancel flow spec').locator('..');
-    await taskItem.getByRole('button', {name: /to schedule|스케줄로/i}).click();
+    await taskItem.getByRole('button', {name: /^\+ schedule$|^\+ 스케줄$/i}).click();
     // "취소" 클릭 → 변형 chain 영영 박지 X
     await taskItem.getByRole('button', {name: /cancel|취소/i}).click();
 
@@ -107,6 +107,6 @@ test.describe('task → schedule 분기 chain', () => {
     // 변형 버튼 박지 X (영영 영역 영영)
     await expect(taskItem.getByRole('button', {name: /now|지금/i})).toHaveCount(0);
     // 원래 버튼 박힘 (스케줄로 + 삭제)
-    await expect(taskItem.getByRole('button', {name: /to schedule|스케줄로/i})).toBeVisible();
+    await expect(taskItem.getByRole('button', {name: /^\+ schedule$|^\+ 스케줄$/i})).toBeVisible();
   });
 });


### PR DESCRIPTION
## Summary

- mutation E2E 17 spec fail catch — selector regex 가 i18n 본문 매칭 X
- root cause: m4pro Qwen3 emit 시점 i18n 본문 X catch (Studio 위임 본문 안 i18n key 명시 X)

## Fix

| 옛 selector | 새 selector | 매칭 본문 |
|---|---|---|
| `new task\|새 task` | `^\+ task$\|^\+ 할일$` | task.newTask `+ task` / `+ 할일` |
| `to schedule\|스케줄로` | `^\+ schedule$\|^\+ 스케줄$` | task.convertToSchedule `+ schedule` / `+ 스케줄` |
| `new api key\|새 API key` | `^\+ key$\|^\+ 키$` | apiKey.create `+ key` / `+ 키` |

## 영향 spec

- task-add-direct.spec.ts (6 tests)
- task-to-schedule.spec.ts (4 tests)
- api-key-auth.spec.ts (7 tests · skip 3 제외 · 4 active)

## 향후 정공

- component testid 박음 + spec `getByTestId` 박음 (i18n 변경 영역 spec 영향 X)
- 본 사이클 단순 selector regex 정정 (빠른 영역 · 별 사이클 testid 박음 후속)

🤖 Generated with [Claude Code](https://claude.com/claude-code)