### PR TITLE
test(qa-gate): 미래 날짜 색 마킹 회귀 가드

### DIFF
--- a/tests/qa-gate/calendar-retrospect.spec.ts
+++ b/tests/qa-gate/calendar-retrospect.spec.ts
@@ -40,4 +40,34 @@ test.describe('달력보기 + 되돌아보기', () => {
     // AnalogClock svg 렌더 catch (시계 탭).
     await expect(page.locator('svg.mx-auto').first()).toBeVisible({timeout: 5000});
   });
+
+  // PLAN1-FUTURE-DATE-MARKS-20260601 — 미래 날짜 색 순환 회귀 가드.
+  // 무색 → red → green → blue → 무색. 마지막 무색으로 끝나 DB 행 자동 정리(cleanup 불요).
+  test('미래 날짜 클릭 → 색 순환 (무색→red→green→blue→무색)', async ({page}) => {
+    await page.goto('/project/plan1/');
+    await page.getByTestId('aside-tab-calendar').click();
+    const cal = page.getByTestId('month-calendar');
+    await expect(cal).toBeVisible({timeout: 5000});
+
+    // 다음 달로 이동 → 모든 날짜가 미래 (오늘이 월말인 edge 회피). 헤더 버튼: [prev, next].
+    await cal.locator('.mb-2 button').nth(1).click();
+    const futureDay = cal.locator('.fc-day-future').first();
+    await expect(futureDay).toBeVisible({timeout: 5000});
+
+    // 색 원 = 날짜 숫자 감싸는 rounded-full bg-{color} span (dot 마커와 별개 class).
+    // 1클릭 → 빨강
+    await futureDay.click();
+    await expect(futureDay.locator('span.bg-red-500')).toBeVisible({timeout: 5000});
+    // 2클릭 → 녹색
+    await futureDay.click();
+    await expect(futureDay.locator('span.bg-green-500')).toBeVisible({timeout: 5000});
+    // 3클릭 → 파랑
+    await futureDay.click();
+    await expect(futureDay.locator('span.bg-blue-500')).toBeVisible({timeout: 5000});
+    // 4클릭 → 무색 (색 원 사라짐 · DB 행 삭제)
+    await futureDay.click();
+    await expect(
+      futureDay.locator('span.bg-red-500, span.bg-green-500, span.bg-blue-500')
+    ).toHaveCount(0, {timeout: 5000});
+  });
 });


### PR DESCRIPTION
PLAN1-FUTURE-DATE-MARKS-20260601 회귀 가드 spec.

미래 날짜 클릭 → 무색→red→green→blue→무색 순환 자동 검증. preview gate(Neon ephemeral + preview deploy)에서 실제 색 동작 검증 목적.

기능 본체는 이미 main 배포 완료 (fc9c0d5). 이 PR은 회귀 가드 spec만 추가.