### PR TITLE
perf: 앱 초기 로드 6 server action → initApp() 통합

### DIFF
--- a/app/actions/init.ts
+++ b/app/actions/init.ts
@@ -1,0 +1,52 @@
+'use server';
+
+/**
+ * PLAN1-INIT-CONSOLIDATE-20260602 — 앱 초기 로드 통합 server action.
+ *
+ * 배경 (성능 진단 2026-06-02): store.init() 이 6개 server action(listSchedules·
+ * listCategories·getSettings·listTasks·listTaskBuckets·listDateMarks)을 Promise.all
+ * 로 호출했으나, Next.js 는 server action 을 클라이언트에서 순차(sequential) 처리한다
+ * (의도된 설계 · vercel/next.js#69265). 사용자(한국)↔서버(sin1) RTT 가 6번 직렬로 쌓여
+ * 초기 로드가 느렸다.
+ *
+ * 정공: 단일 initApp() 1요청으로 통합. 클라↔서버 POST 6→1 (사용자 RTT 직격).
+ * 서버 내부에서는 기존 6 함수를 Promise.all 로 호출 — 서버↔Neon 은 같은 region(sin1↔
+ * ap-southeast-1)이라 병렬 query RTT 가 작다. 기존 함수의 seed/upsert 로직을 그대로
+ * 재사용해 회귀 위험을 최소화 (각 함수 내부 requireUser 는 같은 서버 프로세스 안 호출 ·
+ * JWKS 모듈 캐시 재사용이라 JWT verify CPU 비용만 발생, 네트워크 왕복 아님).
+ */
+
+import {listSchedules} from './schedules';
+import {listCategories} from './categories';
+import {getSettings} from './settings';
+import {listTasks} from './tasks';
+import {listTaskBuckets} from './task-buckets';
+import {listDateMarks} from './date-marks';
+import {
+  runAction,
+  unwrapServerActionResult as unwrap,
+  type ServerActionResult
+} from '@/lib/server-action';
+import type {InitData} from '@/lib/domain/types';
+
+export async function initApp(): Promise<ServerActionResult<InitData>> {
+  return runAction(async () => {
+    const [schedulesR, categoriesR, settingsR, tasksR, bucketsR, dateMarksR] = await Promise.all([
+      listSchedules(),
+      listCategories(),
+      getSettings(),
+      listTasks(),
+      listTaskBuckets(),
+      listDateMarks()
+    ]);
+    // 하나라도 실패(unauthorized 등)면 unwrap 이 throw → runAction 이 errorKey 로 전파.
+    return {
+      schedules: unwrap(schedulesR),
+      categories: unwrap(categoriesR),
+      settings: unwrap(settingsR),
+      tasks: unwrap(tasksR),
+      taskBuckets: unwrap(bucketsR),
+      dateMarks: unwrap(dateMarksR)
+    };
+  });
+}

--- a/lib/domain/types.ts
+++ b/lib/domain/types.ts
@@ -60,6 +60,17 @@ export interface DateMark {
   color: DateMarkColor;
 }
 
+// PLAN1-INIT-CONSOLIDATE-20260602 — 앱 초기 로드 통합 페이로드.
+// 6개 개별 server action(Promise.all) → 단일 initApp() 1요청으로 통합 (클라↔서버 POST 6→1).
+export interface InitData {
+  schedules: Schedule[];
+  categories: Category[];
+  settings: AppSettings;
+  tasks: Task[];
+  taskBuckets: TaskBucketInfo[];
+  dateMarks: DateMark[];
+}
+
 export type Theme = 'light' | 'dark' | 'system';
 export interface AppSettings {
   theme: Theme;

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -32,6 +32,7 @@ import * as settingsApi from '@/app/actions/settings';
 import * as tasksApi from '@/app/actions/tasks';
 import * as taskBucketsApi from '@/app/actions/task-buckets';
 import * as dateMarksApi from '@/app/actions/date-marks';
+import {initApp} from '@/app/actions/init';
 import {unwrapServerActionResult as unwrap, ServerActionError} from './server-action';
 import {armUndo} from './undo-store';
 
@@ -165,20 +166,9 @@ export const useAppStore = create<AppState>((set, get) => ({
     set({loading: true, error: null, errorKey: null});
     initInflight = (async () => {
       try {
-        const [schedulesR, categoriesR, settingsR, tasksR, bucketsR, dateMarksR] = await Promise.all([
-          schedulesApi.listSchedules(),
-          categoriesApi.listCategories(),
-          settingsApi.getSettings(),
-          tasksApi.listTasks(),
-          taskBucketsApi.listTaskBuckets(),
-          dateMarksApi.listDateMarks()
-        ]);
-        const schedules = unwrap(schedulesR);
-        const categories = unwrap(categoriesR);
-        const settings = unwrap(settingsR);
-        const tasks = unwrap(tasksR);
-        const taskBuckets = unwrap(bucketsR);
-        const dateMarks = unwrap(dateMarksR);
+        // PLAN1-INIT-CONSOLIDATE-20260602 — 6 server action(순차 POST) → 단일 initApp() 1요청.
+        const data = unwrap(await initApp());
+        const {schedules, categories, settings, tasks, taskBuckets, dateMarks} = data;
         // PLAN1-TASKS-BUCKET-CUSTOM-20260531 — 매 init 마다 listTasks 재조회 폐기 (latency 회귀 fix).
         // 첫 시드 시점 backfill 후 신규 task 는 항상 bucketId 보유. 마이그 직후 첫 로드의 옛 task 는
         // 다음 mutation refresh 로 정합 (store mutation 들이 최신 tasks 반환).


### PR DESCRIPTION
성능 진단(2026-06-02) 후속 ①. store.init 6 server action 순차 POST → 단일 initApp() 1요청. 사용자 RTT 6→1. seed 로직 무손상(기존 함수 서버 내부 재사용). preview gate에서 init/login/calendar spec 통과 확인 목적.