### PR TITLE
perf: 미래 날짜 색 마킹 낙관적 UI

### DIFF
--- a/app/actions/date-marks.ts
+++ b/app/actions/date-marks.ts
@@ -20,20 +20,14 @@ import {db} from '@/lib/db';
 import {plan1FutureDateMarks} from '@/lib/db/schema';
 import {requireUser} from '@/lib/auth-helpers';
 import {runAction, type ServerActionResult} from '@/lib/server-action';
-import type {DateMark, DateMarkColor} from '@/lib/domain/types';
+import {NEXT_DATE_MARK_COLOR} from '@/lib/date-mark-rotation';
+import type {DateMark} from '@/lib/domain/types';
 
 type Row = typeof plan1FutureDateMarks.$inferSelect;
 
 function rowToDomain(row: Row): DateMark {
   return {dateKey: row.dateKey, color: row.color};
 }
-
-// 색 순환 다음 단계. blue → null = 무색(행 삭제).
-const NEXT_COLOR: Record<DateMarkColor, DateMarkColor | null> = {
-  red: 'green',
-  green: 'blue',
-  blue: null
-};
 
 export async function listDateMarks(): Promise<ServerActionResult<DateMark[]>> {
   return runAction(async () => {
@@ -79,7 +73,7 @@ export async function rotateDateMark(input: {
       return [...rows.map(rowToDomain), {dateKey, color: 'red'}];
     }
 
-    const next = NEXT_COLOR[existing.color];
+    const next = NEXT_DATE_MARK_COLOR[existing.color];
     if (next === null) {
       // blue → 무색 DELETE.
       await db

--- a/lib/date-mark-rotation.ts
+++ b/lib/date-mark-rotation.ts
@@ -1,0 +1,27 @@
+/**
+ * PLAN1-FUTURE-DATE-MARKS 색 순환 단일 원천.
+ *
+ * 클라이언트(낙관적 UI · store.rotateDateMark)와 서버(app/actions/date-marks.ts)가
+ * 같은 순환 규칙을 공유해 drift 를 차단한다. 무색(마크 없음) → red → green → blue → 무색.
+ */
+
+import type {DateMark, DateMarkColor} from './domain/types';
+
+// 색 순환 다음 단계. blue → null = 무색(마크 제거).
+export const NEXT_DATE_MARK_COLOR: Record<DateMarkColor, DateMarkColor | null> = {
+  red: 'green',
+  green: 'blue',
+  blue: null
+};
+
+/**
+ * 한 날짜 클릭 시 다음 마크 목록을 계산 (순수 함수 · 낙관적 UI 즉시 반영용).
+ * 서버 rotateDateMark 의 INSERT/UPDATE/DELETE 와 동일한 결과를 메모리에서 산출.
+ */
+export function rotateDateMarkList(marks: DateMark[], dateKey: string): DateMark[] {
+  const existing = marks.find(m => m.dateKey === dateKey);
+  if (!existing) return [...marks, {dateKey, color: 'red'}];
+  const next = NEXT_DATE_MARK_COLOR[existing.color];
+  if (next === null) return marks.filter(m => m.dateKey !== dateKey);
+  return marks.map(m => (m.dateKey === dateKey ? {dateKey, color: next} : m));
+}

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -33,6 +33,7 @@ import * as tasksApi from '@/app/actions/tasks';
 import * as taskBucketsApi from '@/app/actions/task-buckets';
 import * as dateMarksApi from '@/app/actions/date-marks';
 import {initApp} from '@/app/actions/init';
+import {rotateDateMarkList} from './date-mark-rotation';
 import {unwrapServerActionResult as unwrap, ServerActionError} from './server-action';
 import {armUndo} from './undo-store';
 
@@ -57,6 +58,10 @@ export const DEFAULT_CATEGORIES: Category[] = [];
 
 // Strict Mode 이중 mount race 가드용 inflight promise 캐시 (init 만 사용).
 let initInflight: Promise<void> | null = null;
+
+// PLAN1-FUTURE-DATE-MARKS 낙관적 UI — 미래 날짜 색 회전의 서버 동기화 직렬 체인.
+// 연속 클릭 시 서버 호출 순서를 보장(무색→red→green→blue 순환 정확성) + UI 는 낙관적 즉시 반영.
+let dateMarkRotateChain: Promise<void> = Promise.resolve();
 
 interface AppState {
   schedules: Schedule[];
@@ -153,11 +158,22 @@ export const useAppStore = create<AppState>((set, get) => ({
     set({lastAddedSchedule: null});
   },
 
-  // PLAN1-FUTURE-DATE-MARKS-20260601 — 미래 날짜 클릭 → 다음 색 회전. server 가
-  // 전체 마크 목록 반환 (race-free) → state 교체.
+  // PLAN1-FUTURE-DATE-MARKS-20260601 — 미래 날짜 클릭 → 다음 색 회전.
+  // PLAN1-PERF-20260602 낙관적 UI: 클릭 즉시 로컬 색 반영(0ms 체감) + 서버 저장은 백그라운드.
+  // 서버 RTT(209~688ms 변동)를 사용자에게 노출하지 않는다.
   async rotateDateMark(dateKey) {
-    const dateMarks = unwrap(await dateMarksApi.rotateDateMark({dateKey}));
-    set({dateMarks});
+    // 1) 낙관적 즉시 반영 — 클라/서버 공유 순환 로직(rotateDateMarkList).
+    set({dateMarks: rotateDateMarkList(get().dateMarks, dateKey)});
+    // 2) 서버 동기화 직렬 체인 — 연속 클릭 순서 보장. 성공 시 서버 결과가 낙관적과
+    //    동일(같은 순환 + 직렬 순서)이라 set 생략(깜빡임 0). 실패 시에만 서버 truth 재조회.
+    dateMarkRotateChain = dateMarkRotateChain.then(async () => {
+      const r = await dateMarksApi.rotateDateMark({dateKey});
+      if (!r.ok) {
+        const fresh = await dateMarksApi.listDateMarks();
+        if (fresh.ok) set({dateMarks: fresh.data});
+      }
+    });
+    return dateMarkRotateChain;
   },
 
   async init() {


### PR DESCRIPTION
달력 미래 날짜 클릭 서버 RTT 209~688ms 변동 → 낙관적 UI로 클릭 즉시 색 반영. 순환 로직 클라/서버 공유(drift 차단) + 직렬 체인 순서 보장. preview gate 색 순환 spec 통과 확인 목적.