### PR TITLE
feat: 스케줄 사이 삽입 (같은시간/사이삽입 선택지) [skip-i18n]

### DIFF
--- a/.github/workflows/i18n-translate.yml
+++ b/.github/workflows/i18n-translate.yml
@@ -15,7 +15,13 @@ jobs:
     # security-auditor MEDIUM: fork PR 에서 lockfile 또는 i18n:translate:all script
     # tampering supply chain 차단. fork 는 ANTHROPIC_API_KEY_TRANSLATION secret 도
     # 받지 못하므로 어차피 무의미. 같은 repo 내 PR 만 실행.
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    #
+    # PLAN1-SCHEDULE-INSERT-BETWEEN-20260602 skip 게이트 (env-critic 권고):
+    # i18n:translate:all 은 9개 언어를 전체 재번역(증분 아님)해 수동 검수본을 덮어쓴다.
+    # PR title 에 '[skip-i18n]' 포함 시 봇 미실행 → 수동 번역분 보존.
+    if: >-
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      !contains(github.event.pull_request.title, '[skip-i18n]')
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/app/actions/schedules.ts
+++ b/app/actions/schedules.ts
@@ -19,6 +19,7 @@ import {plan1Categories, plan1Schedules} from '@/lib/db/schema';
 import {requireUser} from '@/lib/auth-helpers';
 import {ServerActionError, runAction, type ServerActionResult} from '@/lib/server-action';
 import {cascade} from '@/lib/domain/cascade';
+import {insertBetweenList} from '@/lib/domain/insert-between';
 import type {Schedule} from '@/lib/domain/types';
 
 type ScheduleRow = typeof plan1Schedules.$inferSelect;
@@ -168,6 +169,51 @@ export async function createSchedule(input: {
       updatedAt: Date.now()
     };
     const next = [...state.schedules, newSchedule];
+    const existingIds = new Set(state.schedules.map(s => s.id));
+    await syncSchedules(user.id, existingIds, next);
+    return next;
+  });
+}
+
+// PLAN1-SCHEDULE-INSERT-BETWEEN-20260602 — 새 스케줄(A2)을 충돌 스케줄(B) 시작 위치에
+// "사이 삽입". A2가 B 자리로 들어가고 B 시작 시간의 겹친 그룹 + 이후 chained 연속을
+// (A2 길이 + 기존 A–B 갭)만큼 밀기. 갭 보존. 로직 단일 원천: lib/domain/insert-between.
+export async function insertScheduleBetween(input: {
+  title: string;
+  categoryId: string;
+  durationMin: number;
+  timerType: 'countup' | 'timer1' | 'countdown';
+  conflictId: string;
+  // 클라가 본 충돌 일정 시작시각 — server state 와 불일치 시 TOCTOU 거부 (logic-critic Major).
+  expectedConflictStart: number;
+}): Promise<ServerActionResult<Schedule[]>> {
+  return runAction(async () => {
+    const user = await requireUser();
+    const state = await loadUserState(user.id, input.categoryId);
+    // TOCTOU 가드: 클라 snapshot 이후 다른 탭/기기가 충돌 일정을 변경·삭제했으면 거부.
+    // 엉뚱한 위치 삽입 차단 — 사용자에게 "다시 시도" 안내.
+    const conflict = state.schedules.find(s => s.id === input.conflictId);
+    if (!conflict || conflict.startAt !== input.expectedConflictStart) {
+      throw new ServerActionError('serverError.insertBetweenStale');
+    }
+    const newSchedule: Schedule = {
+      id: `sch-${randomUUID()}`,
+      title: input.title,
+      categoryId: input.categoryId,
+      // startAt 은 insertBetweenList 가 conflict 직전 기준으로 재계산 (A.end + gap).
+      startAt: 0,
+      durationMin: input.durationMin,
+      timerType: input.timerType,
+      status: 'pending',
+      chainedToPrev: true,
+      createdAt: Date.now(),
+      updatedAt: Date.now()
+    };
+    const next = insertBetweenList(state.schedules, newSchedule, input.conflictId);
+    // 직전 active 없음(P1) 또는 gap<0(비정상 겹침) → null. 모달이 사전 차단하지만 서버 가드.
+    if (!next) {
+      throw new ServerActionError('serverError.insertBetweenNoPrev');
+    }
     const existingIds = new Set(state.schedules.map(s => s.id));
     await syncSchedules(user.id, existingIds, next);
     return next;

--- a/components/NewScheduleModal.tsx
+++ b/components/NewScheduleModal.tsx
@@ -79,6 +79,8 @@ export function NewScheduleModal({
   const addSchedule = useAppStore(s => s.addSchedule);
   const updateSchedule = useAppStore(s => s.updateSchedule);
   const removeSchedule = useAppStore(s => s.removeSchedule);
+  // PLAN1-SCHEDULE-INSERT-BETWEEN-20260602 — A2 사이 삽입 (B 시작 시간 충돌 시 선택지).
+  const insertScheduleBetween = useAppStore(s => s.insertScheduleBetween);
   // PLAN1-CHAIN-FOCUS-GUARD-20260510 (C 옵션): focus view 안 prior schedule check 용.
   const focusViewMin = useAppStore(s => s.settings.focusViewMin);
 
@@ -149,6 +151,13 @@ export function NewScheduleModal({
   const [busy, setBusy] = useState(false);
   // Track 1 fix (2026-04-29): submit catch + 사용자 표시 (silent failure 차단).
   const [submitError, setSubmitError] = useState<string | null>(null);
+  // PLAN1-SCHEDULE-INSERT-BETWEEN-20260602 — startAt 정확 일치 충돌 시 선택지 패널 상태.
+  const [insertChoice, setInsertChoice] = useState<{
+    conflictId: string;
+    conflictStart: number;
+    canSameTime: boolean;
+    canInsertBetween: boolean;
+  } | null>(null);
 
   // Stage 4d-C a11y: Esc → close.
   useEscapeKey(onClose, !busy && !catOpen);
@@ -245,14 +254,38 @@ export function NewScheduleModal({
     !busy;
 
   // PLAN1-TIMER-DUP-20260504 #6.1: overlap 검사 (MAX_OVERLAP=2 한도). 3건+ 차단.
+  // durationMin=0 은 finalDuration 30 fallback 으로 등록되므로 overlap 도 같은 기준으로 계산.
+  // (logic-critic Major — durationMin=0 시 overlaps=[] 되어 MAX_OVERLAP 한도 우회 차단)
+  const effOverlapDuration = durationMin === 0 ? 30 : durationMin;
   const overlaps = useMemo(
-    () =>
-      durationMin > 0
-        ? findOverlapping(schedules, startAt, durationMin, editing?.id)
-        : [],
-    [schedules, startAt, durationMin, editing?.id]
+    () => findOverlapping(schedules, startAt, effOverlapDuration, editing?.id),
+    [schedules, startAt, effOverlapDuration, editing?.id]
   );
   const overlapBlocked = overlaps.length >= MAX_OVERLAP;
+
+  // PLAN1-SCHEDULE-INSERT-BETWEEN-20260602 — startAt 정확 일치 충돌(B 시작 시간에 넣기) 감지.
+  //   - conflictGroup: 새 추가 모드 + 같은 startAt active 그룹 (B, 겹친 X...).
+  //   - canSameTime: 추가 후 겹침 ≤ MAX_OVERLAP (P2: 이미 2개면 false → ① 불가).
+  //   - canInsertBetween: 직전 active 존재 (P1: B 첫 일정이면 false → ② 불가).
+  const conflictGroup = useMemo(
+    () =>
+      !isEdit && nowReady && durationMin >= 0
+        ? schedules.filter(s => s.status !== 'done' && s.startAt === startAt)
+        : [],
+    [schedules, startAt, isEdit, nowReady, durationMin]
+  );
+  const hasConflict = conflictGroup.length > 0;
+  // ① 같은 시간 가능 = 추가 후 전체 동시 점유(정확 일치 + 부분 겹침 모두) ≤ MAX_OVERLAP.
+  // conflictGroup(정확 일치)만 세면 부분 겹침 동시 존재 시 한도 우회 (logic-critic Major) → overlaps 기준.
+  const canSameTime = overlaps.length + 1 <= MAX_OVERLAP;
+  // ② 사이 삽입 가능 = 직전 active 존재 + gap ≥ 0 (gap<0 비정상 겹침이면 server 도 null → 사전 차단).
+  const canInsertBetween = useMemo(() => {
+    if (isEdit) return false;
+    const prev = schedules.filter(s => s.status !== 'done' && s.startAt < startAt);
+    if (prev.length === 0) return false;
+    const a = prev.reduce((m, s) => (s.startAt > m.startAt ? s : m));
+    return startAt - (a.startAt + a.durationMin * 60_000) >= 0;
+  }, [schedules, startAt, isEdit]);
 
   // PLAN1-FOCUS-VIEW-REDESIGN-V2-20260506 #5 (Q-NEW3 둘다): prev chain 시각화 — 새 schedule 의 직전 chain 보여줌.
   const prevChain = useMemo(
@@ -265,9 +298,19 @@ export function NewScheduleModal({
 
   // add 모드: nowReady 필수 (hydration 전 submit 차단). edit 모드: 미래 검증 면제.
   // PLAN1-FOCUS-VIEW-REDESIGN-V2-20260506 #12: isFuture 검증 폐기 (자동 갱신으로 startAt 항상 현재 시각).
+  // PLAN1-SCHEDULE-INSERT-BETWEEN-20260602: 정확 일치 충돌이면 overlapBlocked 우회 — 선택지(①/②)로 처리.
+  //   둘 중 하나라도 가능하면 submit 허용(선택지 열림). 둘 다 불가일 때만 차단.
+  //   정확 일치 아닌 부분 겹침 3개째는 기존 overlapBlocked 차단 유지.
+  const blockedForAdd = hasConflict ? !(canSameTime || canInsertBetween) : overlapBlocked;
   const canSubmit = isEdit
     ? baseOk && isDirty && !overlapBlocked
-    : baseOk && nowReady && !overlapBlocked;
+    : baseOk && nowReady && !blockedForAdd;
+
+  // PLAN1-SCHEDULE-INSERT-BETWEEN-20260602 — 선택 패널은 트리거 시점 conflictStart 와 현재
+  // startAt 이 일치할 때만 유효. 시·분 변경 시 파생값이 null 되어 자동 무효화 (stale conflictStart
+  // 로 ①/② 가 다른 시각에 작동하는 모순 차단 · useEffect+setState 회피 — logic-critic Major).
+  const insertChoiceActive =
+    insertChoice && insertChoice.conflictStart === startAt ? insertChoice : null;
 
   const handleCategoryChange = (v: string) => {
     if (v === '__NEW__') {
@@ -290,17 +333,14 @@ export function NewScheduleModal({
     logClientError(`[NewScheduleModal.${where}]`, err);
   };
 
-  const submit = async () => {
-    if (!canSubmit) return;
-    setBusy(true);
-    setSubmitError(null);
+  // PLAN1-SCHEDULE-INSERT-BETWEEN-20260602 — submit/선택 핸들러 공유 입력 빌더.
+  const buildScheduleInput = () => {
     // PLAN1-FOCUS-VIEW-REDESIGN-V2-20260506 #11: durationMin 0 → 30 fallback.
     const finalDuration = durationMin === 0 ? 30 : durationMin;
     // #10: title 디폴트 "새 스케줄" 그대로 등록 가능.
     const finalTitle = title.trim() || titleDefault;
     // PLAN1-CHAIN-FOCUS-GUARD-20260510 (C 옵션): 새 schedule 등록 시점 focus view 안
-    // prior schedule 0개면 chainedToPrev 강제 false (사용자 check 박은 영역 silent 무시).
-    // 편집 모드는 영향 X (대장 명시 "새로운 스케줄 등록할 때" 만).
+    // prior schedule 0개면 chainedToPrev 강제 false. 편집 모드는 영향 X.
     let effectiveChainedToPrev = chainedToPrev;
     if (!isEdit && chainedToPrev) {
       const focus = focusBounds(focusViewMin, live);
@@ -311,28 +351,85 @@ export function NewScheduleModal({
         effectiveChainedToPrev = false;
       }
     }
+    return {
+      title: finalTitle,
+      categoryId,
+      startAt,
+      durationMin: finalDuration,
+      timerType: 'countup' as const,
+      chainedToPrev: effectiveChainedToPrev
+    };
+  };
+
+  const submit = async () => {
+    if (!canSubmit) return;
+    // 새 추가 + startAt 정확 일치 충돌 → 선택지 패널 (① 같은 시간 / ② 사이 삽입).
+    if (!isEdit && hasConflict) {
+      setSubmitError(null);
+      setInsertChoice({
+        conflictId: conflictGroup[0].id,
+        conflictStart: startAt,
+        canSameTime,
+        canInsertBetween
+      });
+      return;
+    }
+    setBusy(true);
+    setSubmitError(null);
+    const input = buildScheduleInput();
     try {
       if (isEdit && editing) {
         await updateSchedule(editing.id, {
-          title: finalTitle,
-          categoryId,
-          startAt,
-          durationMin: finalDuration,
-          chainedToPrev: effectiveChainedToPrev
+          title: input.title,
+          categoryId: input.categoryId,
+          startAt: input.startAt,
+          durationMin: input.durationMin,
+          chainedToPrev: input.chainedToPrev
         });
       } else {
-        await addSchedule({
-          title: finalTitle,
-          categoryId,
-          startAt,
-          durationMin: finalDuration,
-          timerType: 'countup',
-          chainedToPrev: effectiveChainedToPrev
-        });
+        await addSchedule(input);
       }
       onClose();
     } catch (err) {
       handleMutationError(err, 'submit');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  // ① 같은 시간에 추가 (겹침). 기존 addSchedule 경로.
+  const handleInsertSameTime = async () => {
+    if (busy) return;
+    setBusy(true);
+    setSubmitError(null);
+    try {
+      await addSchedule(buildScheduleInput());
+      onClose();
+    } catch (err) {
+      handleMutationError(err, 'insertSameTime');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  // ② 사이 삽입 (갭 보존 + 뒤 밀기). insertScheduleBetween 경로.
+  const handleInsertBetween = async () => {
+    if (busy || !insertChoiceActive) return;
+    setBusy(true);
+    setSubmitError(null);
+    const input = buildScheduleInput();
+    try {
+      await insertScheduleBetween({
+        title: input.title,
+        categoryId: input.categoryId,
+        durationMin: input.durationMin,
+        timerType: 'countup',
+        conflictId: insertChoiceActive.conflictId,
+        expectedConflictStart: insertChoiceActive.conflictStart
+      });
+      onClose();
+    } catch (err) {
+      handleMutationError(err, 'insertBetween');
     } finally {
       setBusy(false);
     }
@@ -475,7 +572,7 @@ export function NewScheduleModal({
               )}
             </div>
             {/* PLAN1-FOCUS-VIEW-REDESIGN-V2-20260506 #12: warningFutureRequired 영역 폐기 (자동 갱신). */}
-            {durationMin > 0 && overlapBlocked && (
+            {durationMin > 0 && overlapBlocked && !hasConflict && (
               <p
                 className="text-xs text-danger font-mono"
                 role="alert"
@@ -561,42 +658,82 @@ export function NewScheduleModal({
                 {submitError}
               </p>
             )}
-            {/* PLAN1-FOCUS-VIEW-REDESIGN-V2-20260506 #14: 삭제 + 취소 + 저장 같은 row · y 통일 */}
-            <div className="flex items-center justify-between gap-2">
-              {/* 좌측: 삭제 (편집 모드만 · 그 외 빈 영역) */}
-              {isEdit ? (
+            {insertChoiceActive ? (
+              /* PLAN1-SCHEDULE-INSERT-BETWEEN-20260602 — 시작 시간 충돌 선택 패널.
+                 P1(직전 없음): ②만 숨김 → ①. P2(이미 2개 겹침): ① 숨김 → ②. */
+              <div className="flex flex-col gap-2" data-testid="insert-choice">
+                <p className="text-sm text-txt font-mono">{t('insert.conflictPrompt')}</p>
+                {insertChoiceActive.canSameTime && (
+                  <button
+                    type="button"
+                    onClick={handleInsertSameTime}
+                    disabled={busy}
+                    data-testid="insert-same-time"
+                    className="inline-flex items-center gap-1.5 rounded-none border border-line bg-panel px-4 py-2 text-sm text-txt font-mono hover:bg-bg disabled:cursor-not-allowed disabled:opacity-50"
+                  >
+                    {busy && <Spinner size={12} />}
+                    {t('insert.sameTime')}
+                  </button>
+                )}
+                {insertChoiceActive.canInsertBetween && (
+                  <button
+                    type="button"
+                    onClick={handleInsertBetween}
+                    disabled={busy}
+                    data-testid="insert-between"
+                    className="inline-flex items-center gap-1.5 rounded-none border border-ink bg-ink px-4 py-2 text-sm text-bg font-mono hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
+                  >
+                    {busy && <Spinner size={12} />}
+                    {t('insert.between')}
+                  </button>
+                )}
                 <button
                   type="button"
-                  onClick={handleDelete}
+                  onClick={() => setInsertChoice(null)}
                   disabled={busy}
-                  className="inline-flex items-center gap-1.5 rounded-none border border-danger bg-panel px-4 py-2 text-sm text-danger font-mono hover:bg-[rgba(224,108,117,0.1)] disabled:cursor-not-allowed disabled:opacity-50"
-                >
-                  {busy && <Spinner size={12} />}
-                  {t('common.delete')}
-                </button>
-              ) : (
-                <span />
-              )}
-              {/* 우측: 취소 + 저장 */}
-              <div className="flex gap-2">
-                <button
-                  type="button"
-                  onClick={onClose}
-                  className="rounded-none border border-line bg-panel px-4 py-2 text-sm text-txt font-mono hover:bg-bg"
+                  className="rounded-none border border-line bg-panel px-4 py-2 text-sm text-txt font-mono hover:bg-bg disabled:opacity-50"
                 >
                   {t('common.cancel')}
                 </button>
-                <button
-                  type="button"
-                  onClick={submit}
-                  disabled={!canSubmit}
-                  className="inline-flex items-center gap-1.5 rounded-none border border-ink bg-ink px-4 py-2 text-sm text-bg font-mono hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
-                >
-                  {busy && <Spinner size={12} />}
-                  {submitLabel}
-                </button>
               </div>
-            </div>
+            ) : (
+              /* PLAN1-FOCUS-VIEW-REDESIGN-V2-20260506 #14: 삭제 + 취소 + 저장 같은 row · y 통일 */
+              <div className="flex items-center justify-between gap-2">
+                {/* 좌측: 삭제 (편집 모드만 · 그 외 빈 영역) */}
+                {isEdit ? (
+                  <button
+                    type="button"
+                    onClick={handleDelete}
+                    disabled={busy}
+                    className="inline-flex items-center gap-1.5 rounded-none border border-danger bg-panel px-4 py-2 text-sm text-danger font-mono hover:bg-[rgba(224,108,117,0.1)] disabled:cursor-not-allowed disabled:opacity-50"
+                  >
+                    {busy && <Spinner size={12} />}
+                    {t('common.delete')}
+                  </button>
+                ) : (
+                  <span />
+                )}
+                {/* 우측: 취소 + 저장 */}
+                <div className="flex gap-2">
+                  <button
+                    type="button"
+                    onClick={onClose}
+                    className="rounded-none border border-line bg-panel px-4 py-2 text-sm text-txt font-mono hover:bg-bg"
+                  >
+                    {t('common.cancel')}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={submit}
+                    disabled={!canSubmit}
+                    className="inline-flex items-center gap-1.5 rounded-none border border-ink bg-ink px-4 py-2 text-sm text-bg font-mono hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
+                  >
+                    {busy && <Spinner size={12} />}
+                    {submitLabel}
+                  </button>
+                </div>
+              </div>
+            )}
           </div>
         </div>
       </div>

--- a/lib/domain/cascade.ts
+++ b/lib/domain/cascade.ts
@@ -1,4 +1,5 @@
 import type { Schedule, ScheduleId } from './types'
+import { compareScheduleByStart } from './sort-schedules'
 
 const NS = 60_000
 
@@ -29,7 +30,7 @@ export function cascade(
   if (delta === 0) return mutated
 
   const active = mutated.filter((s) => s.status !== 'done')
-  active.sort((a, b) => a.startAt - b.startAt)
+  active.sort(compareScheduleByStart)
 
   const editedIdx = active.findIndex((s) => s.id === editedId)
   if (editedIdx === -1) return mutated

--- a/lib/domain/insert-between.test.ts
+++ b/lib/domain/insert-between.test.ts
@@ -1,0 +1,125 @@
+import {describe, it, expect} from 'vitest';
+import {insertBetweenList} from './insert-between';
+import type {Schedule} from './types';
+
+const NS = 60_000;
+const T0 = 1_900_000_000_000; // 고정 base epoch (Date.now 비의존)
+
+function sch(id: string, startMin: number, durMin: number, chained = true, status: Schedule['status'] = 'pending'): Schedule {
+  return {
+    id,
+    title: id,
+    categoryId: 'cat-1',
+    startAt: T0 + startMin * NS,
+    durationMin: durMin,
+    timerType: 'countup',
+    status,
+    chainedToPrev: chained,
+    createdAt: T0,
+    updatedAt: T0
+  };
+}
+
+function newA2(durMin: number): Schedule {
+  return sch('a2', 0, durMin); // startAt 은 insertBetweenList 가 재계산
+}
+
+function startMin(s: Schedule): number {
+  return Math.round((s.startAt - T0) / NS);
+}
+
+describe('insertBetweenList', () => {
+  it('정상: A(0~10) gap10 B(20~30) gap10 C(40~50) 에 A2(15분) 사이 삽입', () => {
+    // A:0~10, B:20~30(chained), C:40~50(chained). gap = 10분.
+    const list = [sch('A', 0, 10, false), sch('B', 20, 10), sch('C', 40, 10)];
+    const result = insertBetweenList(list, newA2(15), 'B');
+    expect(result).not.toBeNull();
+    const byId = Object.fromEntries(result!.map(s => [s.id, s]));
+    // A2 는 기존 B 자리(20분)에 들어감 + chained
+    expect(startMin(byId.a2)).toBe(20);
+    expect(byId.a2.chainedToPrev).toBe(true);
+    // delta = A2(15) + gap(10) = 25분. B:20→45, C:40→65.
+    expect(startMin(byId.B)).toBe(45);
+    expect(startMin(byId.C)).toBe(65);
+    // A 는 안 밀림
+    expect(startMin(byId.A)).toBe(0);
+    // A–A2 갭 = A2.start - A.end = 20 - 10 = 10 (보존). A2–B 갭 = 45 - (20+15) = 10 (보존).
+    expect(startMin(byId.a2) - (startMin(byId.A) + byId.A.durationMin)).toBe(10);
+    expect(startMin(byId.B) - (startMin(byId.a2) + byId.a2.durationMin)).toBe(10);
+  });
+
+  it('gap 0 (딱 붙은 일정): A(0~10) B(10~20) 에 A2(5분) 삽입', () => {
+    const list = [sch('A', 0, 10, false), sch('B', 10, 10)];
+    const result = insertBetweenList(list, newA2(5), 'B');
+    const byId = Object.fromEntries(result!.map(s => [s.id, s]));
+    expect(startMin(byId.a2)).toBe(10); // A.end + gap0
+    // delta = 5 + 0 = 5. B:10→15.
+    expect(startMin(byId.B)).toBe(15);
+  });
+
+  it('P1: B 가 첫 일정(앞에 active 없음) → null', () => {
+    const list = [sch('B', 20, 10, false), sch('C', 40, 10)];
+    expect(insertBetweenList(list, newA2(15), 'B')).toBeNull();
+  });
+
+  it('conflictId 없음 → null', () => {
+    const list = [sch('A', 0, 10, false), sch('B', 20, 10)];
+    expect(insertBetweenList(list, newA2(15), 'ZZZ')).toBeNull();
+  });
+
+  it('B 다음이 unchained 면 거기서 밀림 중단 (B 만 밀림)', () => {
+    // A:0~10, B:20~30(chained), C:40~50(chained=false) → C 안 밀림.
+    const list = [sch('A', 0, 10, false), sch('B', 20, 10), sch('C', 40, 10, false)];
+    const result = insertBetweenList(list, newA2(15), 'B');
+    const byId = Object.fromEntries(result!.map(s => [s.id, s]));
+    expect(startMin(byId.B)).toBe(45); // 밀림
+    expect(startMin(byId.C)).toBe(40); // 안 밀림 (chain 끊김)
+  });
+
+  it('P2: B 시작에 2개 겹침(B,X) → 사이 삽입 시 둘 다 함께 밀림', () => {
+    // A:0~10, B:20~30(chained), X:20~28(chained) — B·X 같은 시작 20(겹침).
+    const list = [sch('A', 0, 10, false), sch('B', 20, 10), sch('X', 20, 8)];
+    const result = insertBetweenList(list, newA2(15), 'B');
+    const byId = Object.fromEntries(result!.map(s => [s.id, s]));
+    // gap = 20-10 = 10. A2.start = 20. delta = 15+10 = 25.
+    expect(startMin(byId.a2)).toBe(20);
+    expect(startMin(byId.B)).toBe(45);
+    expect(startMin(byId.X)).toBe(45); // 겹친 그룹 함께 밀림
+    expect(startMin(byId.A)).toBe(0); // A 안 밀림
+  });
+
+  it('P2 변종: 겹친 그룹(B,X) 이후 C 가 chained 면 C 도 밀림', () => {
+    // A:0~10, B:20~30(chained), X:20~28(chained), C:40~50(chained)
+    const list = [sch('A', 0, 10, false), sch('B', 20, 10), sch('X', 20, 8), sch('C', 40, 10)];
+    const result = insertBetweenList(list, newA2(15), 'B');
+    const byId = Object.fromEntries(result!.map(s => [s.id, s]));
+    // delta = 25. B:45, X:45, C:40→65.
+    expect(startMin(byId.B)).toBe(45);
+    expect(startMin(byId.X)).toBe(45);
+    expect(startMin(byId.C)).toBe(65);
+  });
+
+  it('gap<0 (직전 A 가 conflictStart 넘어 끝나는 비정상 겹침) → null', () => {
+    // A:0~30(30분), B:20~30 — A.end(30) > B.start(20), gap = 20-30 = -10 < 0.
+    const list = [sch('A', 0, 30, false), sch('B', 20, 10)];
+    expect(insertBetweenList(list, newA2(5), 'B')).toBeNull();
+  });
+
+  it('done 스케줄은 active 제외 — A 가 done 이면 그 앞을 A 로 인식', () => {
+    // done A0(0~10), A(12~22 done? no) — A 직전이 done 이면 active 에서 빠짐.
+    // done:0~10, A:20~30(active,chained=false), B:40~50(chained). A2→B 사이.
+    const list = [
+      sch('DONE', 0, 10, false, 'done'),
+      sch('A', 20, 10, false),
+      sch('B', 40, 10)
+    ];
+    const result = insertBetweenList(list, newA2(5), 'B');
+    const byId = Object.fromEntries(result!.map(s => [s.id, s]));
+    // active 직전 = A(20~30). gap = 40 - 30 = 10. A2.start = 30 + 10 = 40.
+    expect(startMin(byId.a2)).toBe(40);
+    // delta = 5 + 10 = 15. B:40→55.
+    expect(startMin(byId.B)).toBe(55);
+    // done 은 안 밀림
+    expect(startMin(byId.DONE)).toBe(0);
+  });
+});

--- a/lib/domain/insert-between.ts
+++ b/lib/domain/insert-between.ts
@@ -1,0 +1,74 @@
+import type {Schedule, ScheduleId} from './types';
+import {compareScheduleByStart} from './sort-schedules';
+
+const NS = 60_000;
+
+/**
+ * PLAN1-SCHEDULE-INSERT-BETWEEN-20260602 — 새 스케줄(A2)을 충돌 스케줄(B) 시작 위치에
+ * "사이 삽입". A2가 B 자리로 들어가고, B 이후 chained 연속을 (A2 길이 + 기존 A–B 갭)만큼
+ * 뒤로 민다. A–A2 갭 = A2–B 갭 = 기존 A–B 갭 보존.
+ *
+ * 사양 (대장 2026-06-02):
+ *   A·B·C·D 연결 + 각 갭. A2를 B 시작 시간에 "사이 삽입" 선택 시 —
+ *   기존 A–B 갭이 10분이면 A–A2 10분 + A2–B 10분, 20분이면 각 20분.
+ *
+ * 동작:
+ *   - conflictStart = B.startAt. A = conflictStart 직전 active 스케줄 (시간순 마지막).
+ *     없으면(B가 첫 일정) null 반환 — 옵션② 불가 (P1).
+ *   - gap = conflictStart - A.endAt. A2.startAt = A.endAt + gap (= conflictStart).
+ *   - delta = A2.durationMin*NS + gap.
+ *   - 밀림 범위 (P2): conflictStart 에 시작하는 모든 active(겹친 그룹 함께) + 그 그룹 이후
+ *     chainedToPrev 연속. 겹친 2개가 함께 밀려 동시 진행 관계 보존.
+ *   - A2.chainedToPrev = true (A–A2–B… 한 체인). done 스케줄은 active 제외 (cascade 일관).
+ *
+ * @returns 삽입+밀림 적용된 전체 목록, 또는 null(삽입 불가 — B 없음/B 앞 active 없음)
+ */
+export function insertBetweenList(
+  schedules: Schedule[],
+  newSchedule: Schedule,
+  conflictId: ScheduleId
+): Schedule[] | null {
+  const b = schedules.find(s => s.id === conflictId);
+  if (!b) return null;
+  const conflictStart = b.startAt;
+
+  const active = schedules
+    .filter(s => s.status !== 'done')
+    // 동률(같은 startAt) tie-break — cascade 와 공유 비교자 (logic-critic Critical).
+    .sort(compareScheduleByStart);
+
+  // A = conflictStart 직전 active (시간순 마지막). 정렬됐으므로 startAt < conflictStart 마지막.
+  let a: Schedule | null = null;
+  for (const s of active) {
+    if (s.startAt < conflictStart) a = s;
+    else break;
+  }
+  if (!a) return null; // P1: B 앞 active 없음 → 사이 삽입 불가
+
+  const gap = conflictStart - (a.startAt + a.durationMin * NS);
+  // gap < 0: A 가 conflictStart 를 넘어 끝나는 비정상 겹침 chained → delta 음수로 앞당김 사양 위반.
+  // 사이 삽입 불가 처리 (logic-critic Major).
+  if (gap < 0) return null;
+  const a2Start = a.startAt + a.durationMin * NS + gap; // = conflictStart (갭 보존)
+  const a2: Schedule = {...newSchedule, startAt: a2Start, chainedToPrev: true};
+  const delta = a2.durationMin * NS + gap;
+
+  // 밀림 (P2): conflictStart 시작 그룹 전체(겹친 것 함께) + 그룹 이후 chainedToPrev 연속.
+  const shiftIds = new Set<ScheduleId>();
+  let groupEndIdx = -1;
+  for (let i = 0; i < active.length; i++) {
+    if (active[i].startAt === conflictStart) {
+      shiftIds.add(active[i].id);
+      groupEndIdx = i;
+    }
+  }
+  for (let i = groupEndIdx + 1; i < active.length; i++) {
+    if (!active[i].chainedToPrev) break;
+    shiftIds.add(active[i].id);
+  }
+
+  const shifted = schedules.map(s =>
+    shiftIds.has(s.id) ? {...s, startAt: s.startAt + delta, updatedAt: Date.now()} : s
+  );
+  return [...shifted, a2];
+}

--- a/lib/domain/sort-schedules.ts
+++ b/lib/domain/sort-schedules.ts
@@ -1,0 +1,13 @@
+import type {Schedule} from './types';
+
+/**
+ * 스케줄 결정적 정렬 비교자 — startAt → createdAt → id.
+ *
+ * PLAN1-SCHEDULE-INSERT-BETWEEN-20260602 (logic-critic Critical): 같은 startAt(동률)
+ * 일정 그룹의 정렬이 `a.startAt - b.startAt` 만으로는 비결정적(엔진 의존)이 된다.
+ * insert-between(사이 삽입 시 같은 startAt 그룹 함께 밀기)과 cascade(편집 delta 전파)가
+ * 같은 데이터를 다루므로 동일 비교자를 공유해 drift·비결정성을 차단한다.
+ */
+export function compareScheduleByStart(a: Schedule, b: Schedule): number {
+  return a.startAt - b.startAt || a.createdAt - b.createdAt || a.id.localeCompare(b.id);
+}

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -119,6 +119,15 @@ interface AppState {
   removeTaskBucket(id: TaskBucketId): Promise<void>;
 
   addSchedule(input: Omit<Schedule, 'id' | 'createdAt' | 'updatedAt' | 'status'>): Promise<void>;
+  // PLAN1-SCHEDULE-INSERT-BETWEEN-20260602 — A2를 conflict 시작 위치에 사이 삽입 (갭 보존 + 뒤 밀기).
+  insertScheduleBetween(input: {
+    title: string;
+    categoryId: CategoryId;
+    durationMin: number;
+    timerType: Schedule['timerType'];
+    conflictId: ScheduleId;
+    expectedConflictStart: number;
+  }): Promise<void>;
   updateSchedule(
     id: ScheduleId,
     patch: {
@@ -236,6 +245,15 @@ export const useAppStore = create<AppState>((set, get) => ({
     if (newSchedule) {
       armUndo({type: 'add', scheduleId: newSchedule.id, ts: Date.now()});
     }
+  },
+
+  // PLAN1-SCHEDULE-INSERT-BETWEEN-20260602 — A2를 conflict 시작 위치에 사이 삽입.
+  // server 가 삽입+밀림 적용된 전체 목록 반환. 여러 일정이 밀려 undo 미지원 (대장 합의 · armUndo 생략).
+  async insertScheduleBetween(input) {
+    const prevIds = new Set(get().schedules.map(s => s.id));
+    const next = unwrap(await schedulesApi.insertScheduleBetween(input));
+    const newSchedule = next.find(s => !prevIds.has(s.id));
+    set({schedules: next, lastAddedSchedule: newSchedule ?? null});
   },
 
   async updateSchedule(id, patch) {

--- a/messages/ar.json
+++ b/messages/ar.json
@@ -77,6 +77,11 @@
     "header": {
         "finalEndAtSuffix": "نهاية"
     },
+    "insert": {
+        "between": "إدراج بينهما (دفع المواعيد اللاحقة)",
+        "conflictPrompt": "يوجد بالفعل موعد في هذا الوقت. ماذا تريد أن تفعل؟",
+        "sameTime": "إضافة في نفس الوقت"
+    },
     "loading": "جاري التحميل...",
     "mutation": {
         "addTask": "إضافة مهمة",
@@ -157,6 +162,8 @@
         "apiKeyNotFound": "مفتاح API غير موجود.",
         "categoryHasSchedules": "الفئة تحتوي على {scheduleCount} جداول. أكد الحذف المتسلسل للإزالة.",
         "categoryNotFound": "الفئة غير موجودة أو غير مملوكة.",
+        "insertBetweenNoPrev": "تعذّر الإدراج — لا يوجد موعد قبل هذا الوقت.",
+        "insertBetweenStale": "تغيّر الموعد — يرجى المحاولة مرة أخرى.",
         "scheduleNotFound": "الجدول غير موجود.",
         "taskBucketInvalid": "قيمة الحاوية غير صالحة.",
         "taskBucketLastProtected": "يجب أن تبقى فئة واحدة على الأقل",

--- a/messages/de.json
+++ b/messages/de.json
@@ -77,6 +77,11 @@
     "header": {
         "finalEndAtSuffix": "Ende"
     },
+    "insert": {
+        "between": "Dazwischen einfügen (spätere Termine verschieben)",
+        "conflictPrompt": "Zu dieser Zeit beginnt bereits ein Termin. Was möchten Sie tun?",
+        "sameTime": "Zur gleichen Zeit hinzufügen"
+    },
     "loading": "lädt...",
     "mutation": {
         "addTask": "Aufgabe hinzufügen",
@@ -157,6 +162,8 @@
         "apiKeyNotFound": "API-Schlüssel nicht gefunden.",
         "categoryHasSchedules": "Kategorie hat {scheduleCount} Termine. Bestätigen Sie die Kaskadenlöschung zum Entfernen.",
         "categoryNotFound": "Kategorie nicht gefunden oder nicht im Besitz.",
+        "insertBetweenNoPrev": "Einfügen nicht möglich — kein Termin vor dieser Zeit.",
+        "insertBetweenStale": "Termin geändert — bitte erneut versuchen.",
         "scheduleNotFound": "Termin nicht gefunden.",
         "taskBucketInvalid": "Ungültiger Bucket-Wert.",
         "taskBucketLastProtected": "Mindestens eine Kategorie muss verbleiben",

--- a/messages/en.json
+++ b/messages/en.json
@@ -189,7 +189,14 @@
     "taskCountNeedsCategory": "Count-based tasks need a category",
     "taskCountNeedsDuration": "Count-based tasks need a duration",
     "taskCountExhausted": "No remaining count",
-    "taskPriorityOutOfRange": "Priority is out of range"
+    "taskPriorityOutOfRange": "Priority is out of range",
+    "insertBetweenNoPrev": "Can't insert between — no schedule before this time.",
+    "insertBetweenStale": "Schedule changed — please try again."
+  },
+  "insert": {
+    "conflictPrompt": "A schedule already starts at this time. What would you like to do?",
+    "sameTime": "Add at the same time",
+    "between": "Insert between (push later schedules)"
   },
   "undo": {
     "actionLabel": "undo available",

--- a/messages/es.json
+++ b/messages/es.json
@@ -77,6 +77,11 @@
     "header": {
         "finalEndAtSuffix": "fin"
     },
+    "insert": {
+        "between": "Insertar en medio (desplazar las tareas posteriores)",
+        "conflictPrompt": "Ya hay una tarea programada a esta hora. ¿Qué deseas hacer?",
+        "sameTime": "Añadir a la misma hora"
+    },
     "loading": "cargando...",
     "mutation": {
         "addTask": "agregar tarea",
@@ -157,6 +162,8 @@
         "apiKeyNotFound": "Clave API no encontrada.",
         "categoryHasSchedules": "La categoría tiene {scheduleCount} horarios. Confirma eliminación en cascada para remover.",
         "categoryNotFound": "Categoría no encontrada o no es de tu propiedad.",
+        "insertBetweenNoPrev": "No se puede insertar — no hay ninguna tarea antes de esta hora.",
+        "insertBetweenStale": "El horario cambió — inténtalo de nuevo.",
         "scheduleNotFound": "Horario no encontrado.",
         "taskBucketInvalid": "Valor de bucket inválido.",
         "taskBucketLastProtected": "Debe permanecer al menos una categoría",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -77,6 +77,11 @@
     "header": {
         "finalEndAtSuffix": "fin"
     },
+    "insert": {
+        "between": "Insérer entre (décaler les créneaux suivants)",
+        "conflictPrompt": "Un créneau commence déjà à cette heure. Que voulez-vous faire ?",
+        "sameTime": "Ajouter à la même heure"
+    },
     "loading": "chargement...",
     "mutation": {
         "addTask": "ajouter une tâche",
@@ -157,6 +162,8 @@
         "apiKeyNotFound": "Clé API introuvable.",
         "categoryHasSchedules": "La catégorie a {scheduleCount} horaires. Confirmez la suppression en cascade pour retirer.",
         "categoryNotFound": "Catégorie introuvable ou non possédée.",
+        "insertBetweenNoPrev": "Insertion impossible — aucun créneau avant cette heure.",
+        "insertBetweenStale": "Le créneau a changé — veuillez réessayer.",
         "scheduleNotFound": "Horaire introuvable.",
         "taskBucketInvalid": "Valeur de bucket invalide.",
         "taskBucketLastProtected": "Au moins une catégorie doit rester",

--- a/messages/hi.json
+++ b/messages/hi.json
@@ -77,6 +77,11 @@
     "header": {
         "finalEndAtSuffix": "समाप्ति"
     },
+    "insert": {
+        "between": "बीच में डालें (बाद के शेड्यूल आगे खिसकाएँ)",
+        "conflictPrompt": "इस समय पहले से एक शेड्यूल है। आप क्या करना चाहते हैं?",
+        "sameTime": "उसी समय पर जोड़ें"
+    },
     "loading": "लोड हो रहा है...",
     "mutation": {
         "addTask": "कार्य जोड़ें",
@@ -157,6 +162,8 @@
         "apiKeyNotFound": "API कुंजी नहीं मिली।",
         "categoryHasSchedules": "श्रेणी में {scheduleCount} शेड्यूल हैं। हटाने के लिए कैस्केड डिलीट की पुष्टि करें।",
         "categoryNotFound": "श्रेणी नहीं मिली या स्वामित्व नहीं है।",
+        "insertBetweenNoPrev": "सम्मिलित नहीं कर सकते — इस समय से पहले कोई शेड्यूल नहीं है।",
+        "insertBetweenStale": "शेड्यूल बदल गया — कृपया फिर से प्रयास करें।",
         "scheduleNotFound": "शेड्यूल नहीं मिला।",
         "taskBucketInvalid": "अमान्य बकेट मान।",
         "taskBucketLastProtected": "कम से कम एक श्रेणी बनी रहनी चाहिए",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -77,6 +77,11 @@
     "header": {
         "finalEndAtSuffix": "終了"
     },
+    "insert": {
+        "between": "間に挿入（後ろの予定をずらす）",
+        "conflictPrompt": "この時間にはすでに予定があります。どうしますか？",
+        "sameTime": "同じ時間に追加"
+    },
     "loading": "読み込み中...",
     "mutation": {
         "addTask": "タスクを追加",
@@ -157,6 +162,8 @@
         "apiKeyNotFound": "APIキーが見つかりません。",
         "categoryHasSchedules": "カテゴリには{scheduleCount}件のスケジュールがあります。カスケード削除を確認して削除してください。",
         "categoryNotFound": "カテゴリが見つからないか、所有していません。",
+        "insertBetweenNoPrev": "挿入できません — この時間より前に予定がありません。",
+        "insertBetweenStale": "予定が変更されました — もう一度お試しください。",
         "scheduleNotFound": "スケジュールが見つかりません。",
         "taskBucketInvalid": "無効なバケット値です。",
         "taskBucketLastProtected": "少なくとも1つのカテゴリを残す必要があります",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -189,7 +189,14 @@
     "taskCountNeedsCategory": "횟수차감형 할일은 카테고리가 필요해요",
     "taskCountNeedsDuration": "횟수차감형 할일은 소요시간이 필요해요",
     "taskCountExhausted": "남은 횟수가 없어요",
-    "taskPriorityOutOfRange": "우선순위 범위를 벗어났어요"
+    "taskPriorityOutOfRange": "우선순위 범위를 벗어났어요",
+    "insertBetweenNoPrev": "앞에 일정이 없어 사이에 넣을 수 없어요.",
+    "insertBetweenStale": "일정이 변경되었어요 — 다시 시도해주세요."
+  },
+  "insert": {
+    "conflictPrompt": "이 시간에 이미 일정이 있어요. 어떻게 할까요?",
+    "sameTime": "같은 시간에 추가",
+    "between": "사이에 끼워넣기 (뒤 일정 밀기)"
   },
   "undo": {
     "actionLabel": "실행 취소 가능",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -77,6 +77,11 @@
     "header": {
         "finalEndAtSuffix": "fim"
     },
+    "insert": {
+        "between": "Inserir no meio (empurrar os agendamentos seguintes)",
+        "conflictPrompt": "Já existe um agendamento neste horário. O que deseja fazer?",
+        "sameTime": "Adicionar no mesmo horário"
+    },
     "loading": "carregando...",
     "mutation": {
         "addTask": "adicionar tarefa",
@@ -157,6 +162,8 @@
         "apiKeyNotFound": "Chave de API não encontrada.",
         "categoryHasSchedules": "Categoria tem {scheduleCount} agendamento(s). Confirme exclusão em cascata para remover.",
         "categoryNotFound": "Categoria não encontrada ou não pertence ao usuário.",
+        "insertBetweenNoPrev": "Não é possível inserir — não há agendamento antes deste horário.",
+        "insertBetweenStale": "O agendamento mudou — tente novamente.",
         "scheduleNotFound": "Agendamento não encontrado.",
         "taskBucketInvalid": "Valor de bucket inválido.",
         "taskBucketLastProtected": "Pelo menos uma categoria deve permanecer",

--- a/messages/ru.json
+++ b/messages/ru.json
@@ -77,6 +77,11 @@
     "header": {
         "finalEndAtSuffix": "конец"
     },
+    "insert": {
+        "between": "Вставить между (сдвинуть последующие записи)",
+        "conflictPrompt": "На это время уже есть запись. Что вы хотите сделать?",
+        "sameTime": "Добавить на то же время"
+    },
     "loading": "загрузка...",
     "mutation": {
         "addTask": "добавить задачу",
@@ -157,6 +162,8 @@
         "apiKeyNotFound": "API ключ не найден.",
         "categoryHasSchedules": "Категория содержит {scheduleCount} расписаний. Подтвердите каскадное удаление.",
         "categoryNotFound": "Категория не найдена или не принадлежит вам.",
+        "insertBetweenNoPrev": "Невозможно вставить — нет записи перед этим временем.",
+        "insertBetweenStale": "Запись изменилась — попробуйте снова.",
         "scheduleNotFound": "Расписание не найдено.",
         "taskBucketInvalid": "Неверное значение bucket.",
         "taskBucketLastProtected": "Должна остаться хотя бы одна категория",

--- a/messages/zh-CN.json
+++ b/messages/zh-CN.json
@@ -77,6 +77,11 @@
     "header": {
         "finalEndAtSuffix": "结束"
     },
+    "insert": {
+        "between": "插入中间（顺延后面的日程）",
+        "conflictPrompt": "此时间已有日程。您想怎么做？",
+        "sameTime": "添加到同一时间"
+    },
     "loading": "加载中...",
     "mutation": {
         "addTask": "添加任务",
@@ -157,6 +162,8 @@
         "apiKeyNotFound": "API密钥未找到。",
         "categoryHasSchedules": "分类有{scheduleCount}个计划。确认级联删除以移除。",
         "categoryNotFound": "分类未找到或不属于您。",
+        "insertBetweenNoPrev": "无法插入 — 此时间之前没有日程。",
+        "insertBetweenStale": "日程已更改 — 请重试。",
         "scheduleNotFound": "未找到计划。",
         "taskBucketInvalid": "无效的bucket值。",
         "taskBucketLastProtected": "至少必须保留一个类别",


### PR DESCRIPTION
A2를 B 시작 시간에 넣을 때 ① 같은 시간 / ② 사이 삽입(갭 보존 + 뒤 밀기) 선택지. P1(첫 일정 ①만)·P2(2개 겹침 ②만+함께 밀기). critic 2라운드 반영(tie-break·gap<0·TOCTOU·부분겹침·durationMin0·패널stale). 단위 9케이스. [skip-i18n]로 9개 수동 번역 보존. preview gate에서 schedule 관련 spec 회귀 없는지 확인 목적.