### PR TITLE
feat: 할일 카테고리 무제한형 (일회성/횟수차감/무제한) [skip-i18n]

### DIFF
--- a/app/actions/task-buckets.ts
+++ b/app/actions/task-buckets.ts
@@ -22,7 +22,7 @@ import {plan1TaskBuckets, plan1Tasks} from '@/lib/db/schema';
 import {requireUser} from '@/lib/auth-helpers';
 import {ensureBuckets} from '@/lib/task-bucket-seed';
 import {ServerActionError, runAction, type ServerActionResult} from '@/lib/server-action';
-import type {TaskBucketInfo} from '@/lib/domain/types';
+import type {TaskBucketInfo, TaskBucketKindType} from '@/lib/domain/types';
 
 type BucketRow = typeof plan1TaskBuckets.$inferSelect;
 
@@ -30,7 +30,8 @@ function rowToDomain(row: BucketRow): TaskBucketInfo {
   return {
     id: row.id,
     name: row.name,
-    isCountBased: row.isCountBased,
+    // PLAN1-TASKS-BUCKET-KIND-20260602 — kind 단일 기준 (isCountBased 보존하나 코드는 kind).
+    kind: row.kind,
     sortOrder: row.sortOrder,
     defaultKind: row.defaultKind,
     createdAt: row.createdAt.getTime()
@@ -63,7 +64,7 @@ export async function listTaskBuckets(): Promise<ServerActionResult<TaskBucketIn
 
 export async function createTaskBucket(input: {
   name: string;
-  isCountBased: boolean;
+  kind: TaskBucketKindType;
 }): Promise<ServerActionResult<TaskBucketInfo[]>> {
   return runAction(async () => {
     const user = await requireUser();
@@ -79,7 +80,8 @@ export async function createTaskBucket(input: {
         id: `bkt-${randomUUID()}`,
         userId: user.id,
         name,
-        isCountBased: input.isCountBased,
+        kind: input.kind,
+        isCountBased: input.kind === 'count', // 동기 보존 (kind 단일 기준)
         sortOrder: maxSort + 1,
         defaultKind: null
       })
@@ -96,7 +98,7 @@ export async function createTaskBucket(input: {
 export async function updateTaskBucket(input: {
   id: string;
   name: string;
-  isCountBased: boolean;
+  kind: TaskBucketKindType;
 }): Promise<ServerActionResult<TaskBucketInfo[]>> {
   return runAction(async () => {
     const user = await requireUser();
@@ -107,7 +109,8 @@ export async function updateTaskBucket(input: {
 
     const trimmed = input.name.trim();
     const patch: Partial<typeof plan1TaskBuckets.$inferInsert> = {
-      isCountBased: input.isCountBased
+      kind: input.kind,
+      isCountBased: input.kind === 'count' // 동기 보존 (kind 단일 기준)
     };
     let nextName = existing.name;
     let nextDefaultKind = existing.defaultKind;
@@ -124,33 +127,33 @@ export async function updateTaskBucket(input: {
       .set(patch)
       .where(and(eq(plan1TaskBuckets.id, input.id), eq(plan1TaskBuckets.userId, user.id)));
 
-    // isCountBased 토글 → 소속 task count 동기.
-    if (input.isCountBased !== existing.isCountBased) {
-      if (input.isCountBased) {
-        // off → on: count 없는 task 에 기본 1 부여.
-        await db
-          .update(plan1Tasks)
-          .set({count: 1})
-          .where(
-            and(
-              eq(plan1Tasks.userId, user.id),
-              eq(plan1Tasks.bucketId, input.id),
-              isNull(plan1Tasks.count)
-            )
-          );
-      } else {
-        // on → off: count 제거.
-        await db
-          .update(plan1Tasks)
-          .set({count: null})
-          .where(and(eq(plan1Tasks.userId, user.id), eq(plan1Tasks.bucketId, input.id)));
-      }
+    // kind 전환 → 소속 task count 동기 (횟수차감 진입/이탈).
+    const wasCount = existing.kind === 'count';
+    const isCount = input.kind === 'count';
+    if (isCount && !wasCount) {
+      // 다른 → 횟수차감: count 없는 task 에 기본 1 부여.
+      await db
+        .update(plan1Tasks)
+        .set({count: 1})
+        .where(
+          and(
+            eq(plan1Tasks.userId, user.id),
+            eq(plan1Tasks.bucketId, input.id),
+            isNull(plan1Tasks.count)
+          )
+        );
+    } else if (!isCount && wasCount) {
+      // 횟수차감 → 다른(일회성/무제한): count 제거.
+      await db
+        .update(plan1Tasks)
+        .set({count: null})
+        .where(and(eq(plan1Tasks.userId, user.id), eq(plan1Tasks.bucketId, input.id)));
     }
 
     // race-free in-memory 합성 (UPDATE 후 별도 SELECT 회피).
     return all.map(b =>
       b.id === input.id
-        ? {...b, name: nextName, isCountBased: input.isCountBased, defaultKind: nextDefaultKind}
+        ? {...b, name: nextName, kind: input.kind, defaultKind: nextDefaultKind}
         : b
     );
   });

--- a/app/actions/tasks.ts
+++ b/app/actions/tasks.ts
@@ -25,7 +25,8 @@ import {db} from '@/lib/db';
 import {plan1Tasks, plan1Schedules, plan1Categories, plan1TaskBuckets} from '@/lib/db/schema';
 import {requireUser} from '@/lib/auth-helpers';
 import {ServerActionError, runAction, type ServerActionResult} from '@/lib/server-action';
-import type {Task} from '@/lib/domain/types';
+import type {Task, TaskBucketKindType} from '@/lib/domain/types';
+import {normalizeCount} from '@/lib/task-count';
 
 type TaskRow = typeof plan1Tasks.$inferSelect;
 
@@ -43,15 +44,15 @@ function rowToDomain(row: TaskRow): Task {
   };
 }
 
-// 버킷 소유 검증 + isCountBased/defaultKind 조회. 없으면 throw.
+// 버킷 소유 검증 + kind/defaultKind 조회. 없으면 throw.
 async function requireBucket(
   userId: string,
   bucketId: string
-): Promise<{id: string; isCountBased: boolean; defaultKind: 'now' | 'later' | null}> {
+): Promise<{id: string; kind: TaskBucketKindType; defaultKind: 'now' | 'later' | null}> {
   const rows = await db
     .select({
       id: plan1TaskBuckets.id,
-      isCountBased: plan1TaskBuckets.isCountBased,
+      kind: plan1TaskBuckets.kind,
       defaultKind: plan1TaskBuckets.defaultKind
     })
     .from(plan1TaskBuckets)
@@ -68,14 +69,6 @@ async function requireCategoryOwned(userId: string, categoryId: string): Promise
     .where(and(eq(plan1Categories.id, categoryId), eq(plan1Categories.userId, userId)))
     .limit(1);
   if (!ownerRows[0]) throw new ServerActionError('serverError.categoryNotFound');
-}
-
-// 횟수차감형 버킷의 count 정규화: isCountBased 면 ≥1 (default 1), 아니면 null.
-function normalizeCount(isCountBased: boolean, requested: number | null | undefined): number | null {
-  if (!isCountBased) return null;
-  const n = requested ?? 1;
-  if (!Number.isFinite(n) || n < 1) return 1;
-  return Math.floor(n);
 }
 
 // PLAN1-TASKS-BUCKET-CUSTOM-20260531 — priority 정렬 read (bucketId namespace 는 client filter).
@@ -112,13 +105,14 @@ export async function createTask(input: {
       throw new ServerActionError('serverError.taskDurationInvalid');
     }
     // 횟수차감형은 category·duration 필수 (N3 — 변환 시 modal 회송 방지).
-    if (bucket.isCountBased) {
+    // 무제한·일회성은 강제 X (변환 시점에 convertTaskToSchedule 가 검증 · modal 회송).
+    if (bucket.kind === 'count') {
       if (input.categoryId === null) throw new ServerActionError('serverError.taskCountNeedsCategory');
       if (input.durationMin === null || input.durationMin <= 0) {
         throw new ServerActionError('serverError.taskCountNeedsDuration');
       }
     }
-    const count = normalizeCount(bucket.isCountBased, input.count);
+    const count = normalizeCount(bucket.kind, input.count);
 
     // 해당 bucketId 안 task 개수 → max priority = N+1.
     const existingRows = await db
@@ -183,14 +177,14 @@ export async function updateTask(input: {
     if (input.durationMin !== null && input.durationMin < 0) {
       throw new ServerActionError('serverError.taskDurationInvalid');
     }
-    if (bucket.isCountBased) {
+    if (bucket.kind === 'count') {
       if (input.categoryId === null) throw new ServerActionError('serverError.taskCountNeedsCategory');
       if (input.durationMin === null || input.durationMin <= 0) {
         throw new ServerActionError('serverError.taskCountNeedsDuration');
       }
     }
     // count: 횟수차감형이면 입력값(또는 기존값) 유지, 아니면 null.
-    const count = normalizeCount(bucket.isCountBased, input.count ?? existing.count);
+    const count = normalizeCount(bucket.kind, input.count ?? existing.count);
 
     const oldBucketId = existing.bucketId;
     const newBucketId = input.bucketId;
@@ -375,11 +369,23 @@ export async function convertTaskToSchedule(input: {
       updatedAt: now
     });
 
-    // 횟수차감형(count !== null) 분기 (PLAN1-TASKS-BUCKET-CUSTOM-20260531).
-    const isCountBased = task.count !== null;
+    // PLAN1-TASKS-BUCKET-KIND-20260602 — 버킷 kind 분기 (일회성/횟수차감/무제한).
+    // task.count 만으론 일회성과 무제한이 구분 안 됨(둘 다 null) → 버킷 kind 조회.
+    let bucketKind: TaskBucketKindType = 'one-time';
+    if (task.bucketId !== null) {
+      try {
+        bucketKind = (await requireBucket(user.id, task.bucketId)).kind;
+      } catch {
+        bucketKind = 'one-time'; // 버킷 없음(마이그 전 옛 task) → 일회성 fallback
+      }
+    }
+
     let queries: BatchItem<'pg'>[];
 
-    if (isCountBased) {
+    if (bucketKind === 'unlimited') {
+      // 무제한: schedule 만 추가, task 그대로 유지 (삭제·차감·priority shift X).
+      queries = [insertSchedule];
+    } else if (bucketKind === 'count') {
       if ((task.count ?? 0) <= 0) {
         throw new ServerActionError('serverError.taskCountExhausted');
       }
@@ -400,10 +406,11 @@ export async function convertTaskToSchedule(input: {
             )
         ];
       } else {
-        // 마지막 차감 (0 도달) → 일반 task 처럼 삭제 + priority shift.
+        // 마지막 차감 (0 도달) → 일회성처럼 삭제 + priority shift.
         queries = [insertSchedule, ...deleteWithShift(user.id, task)];
       }
     } else {
+      // 일회성: task 삭제 + priority shift.
       queries = [insertSchedule, ...deleteWithShift(user.id, task)];
     }
 

--- a/app/api/v1/tasks/route.ts
+++ b/app/api/v1/tasks/route.ts
@@ -3,8 +3,9 @@ import {NextResponse} from 'next/server';
 import {z} from 'zod';
 import {and, desc, eq} from 'drizzle-orm';
 import {db} from '@/lib/db';
-import {plan1Tasks, plan1Categories} from '@/lib/db/schema';
+import {plan1Tasks, plan1Categories, plan1TaskBuckets} from '@/lib/db/schema';
 import {ensureNowBucketId} from '@/lib/task-bucket-seed';
+import {normalizeCount} from '@/lib/task-count';
 import {authenticateApiKey, buildSuccessHeaders, buildOptionsResponse} from '@/lib/api-auth';
 
 const createTaskSchema = z.object({
@@ -99,6 +100,14 @@ export async function POST(request: Request): Promise<NextResponse> {
   const id = `task-${randomUUID()}`;
   // PLAN1-TASKS-BUCKET-CUSTOM-20260531 — 'now' default 버킷에 배치 + priority append (충돌 회피).
   const bucketId = await ensureNowBucketId(auth.apiKey.userId);
+  // PLAN1-TASKS-BUCKET-KIND-20260602 — 'now' 버킷이 count 로 전환됐으면 count 정규화 (server action 정합).
+  // 누락 시 count=null 동기 깨짐 → convertTaskToSchedule 에서 taskCountExhausted 로 변환 차단 (logic-critic Major).
+  const kindRows = await db
+    .select({kind: plan1TaskBuckets.kind})
+    .from(plan1TaskBuckets)
+    .where(and(eq(plan1TaskBuckets.id, bucketId), eq(plan1TaskBuckets.userId, auth.apiKey.userId)))
+    .limit(1);
+  const count = normalizeCount(kindRows[0]?.kind ?? 'one-time', undefined);
   const bucketRows = await db
     .select({id: plan1Tasks.id})
     .from(plan1Tasks)
@@ -110,7 +119,8 @@ export async function POST(request: Request): Promise<NextResponse> {
     durationMin: input.durationMin ?? null,
     categoryId: input.categoryId ?? null,
     bucketId,
-    priority: bucketRows.length + 1
+    priority: bucketRows.length + 1,
+    count
   });
   const rows = await db
     .select()

--- a/components/TaskBucketManager.tsx
+++ b/components/TaskBucketManager.tsx
@@ -7,7 +7,7 @@ import {useAppStore} from '@/lib/store';
 import {useRunMutation} from '@/lib/use-run-mutation';
 import {useEscapeKey} from '@/lib/use-escape-key';
 import {useTaskBucketDisplay} from '@/lib/task-bucket-display';
-import type {TaskBucketInfo} from '@/lib/domain/types';
+import type {TaskBucketInfo, TaskBucketKindType} from '@/lib/domain/types';
 
 /**
  * PLAN1-TASKS-BUCKET-CUSTOM-20260531 — 할일 카테고리(버킷) 관리 modal.
@@ -27,21 +27,22 @@ export function TaskBucketManager({onClose}: {onClose: () => void}) {
   const removeTaskBucket = useAppStore(s => s.removeTaskBucket);
 
   const [newName, setNewName] = useState('');
-  const [newCountBased, setNewCountBased] = useState(false);
+  // PLAN1-TASKS-BUCKET-KIND-20260602 — 체크박스 → kind 드롭다운 (일회성/횟수차감/무제한).
+  const [newKind, setNewKind] = useState<TaskBucketKindType>('one-time');
   const [busy, setBusy] = useState(false);
   const [confirmId, setConfirmId] = useState<string | null>(null);
   // 행별 편집 draft. 부재 시 버킷 값에서 파생.
-  const [drafts, setDrafts] = useState<Record<string, {name: string; isCountBased: boolean}>>({});
+  const [drafts, setDrafts] = useState<Record<string, {name: string; kind: TaskBucketKindType}>>({});
 
   useEscapeKey(onClose, !busy);
 
   const draftOf = (b: TaskBucketInfo) =>
     drafts[b.id] ?? {
       name: b.defaultKind !== null && b.name === '' ? '' : b.name,
-      isCountBased: b.isCountBased
+      kind: b.kind
     };
 
-  const setDraft = (id: string, patch: Partial<{name: string; isCountBased: boolean}>) => {
+  const setDraft = (id: string, patch: Partial<{name: string; kind: TaskBucketKindType}>) => {
     setDrafts(d => ({...d, [id]: {...draftOf(taskBuckets.find(b => b.id === id)!), ...d[id], ...patch}}));
   };
 
@@ -53,9 +54,9 @@ export function TaskBucketManager({onClose}: {onClose: () => void}) {
     if (!canAdd) return;
     setBusy(true);
     try {
-      await addTaskBucket({name: newName.trim(), isCountBased: newCountBased});
+      await addTaskBucket({name: newName.trim(), kind: newKind});
       setNewName('');
-      setNewCountBased(false);
+      setNewKind('one-time');
     } finally {
       setBusy(false);
     }
@@ -66,7 +67,7 @@ export function TaskBucketManager({onClose}: {onClose: () => void}) {
     const d = draftOf(b);
     setBusy(true);
     try {
-      await updateTaskBucketAction({id: b.id, name: d.name.trim(), isCountBased: d.isCountBased});
+      await updateTaskBucketAction({id: b.id, name: d.name.trim(), kind: d.kind});
       setDrafts(prev => {
         const next = {...prev};
         delete next[b.id];
@@ -139,14 +140,16 @@ export function TaskBucketManager({onClose}: {onClose: () => void}) {
                   aria-label={t('taskBucket.fieldName')}
                 />
                 <div className="flex items-center justify-between gap-2">
-                  <label className="flex items-center gap-1 text-xs text-txt font-mono">
-                    <input
-                      type="checkbox"
-                      checked={d.isCountBased}
-                      onChange={e => setDraft(b.id, {isCountBased: e.target.checked})}
-                    />
-                    {t('taskBucket.countBased')}
-                  </label>
+                  <select
+                    value={d.kind}
+                    onChange={e => setDraft(b.id, {kind: e.target.value as TaskBucketKindType})}
+                    className="rounded-none border border-line bg-bg px-1 py-0.5 text-xs text-ink font-mono"
+                    aria-label={t('taskBucket.kindLabel')}
+                  >
+                    <option value="one-time">{t('taskBucket.kindOneTime')}</option>
+                    <option value="count">{t('taskBucket.kindCount')}</option>
+                    <option value="unlimited">{t('taskBucket.kindUnlimited')}</option>
+                  </select>
                   <div className="flex gap-1">
                     <button type="button" onClick={() => handleSave(b)} disabled={busy} className={saveBtn}>
                       {t('common.save')}
@@ -180,14 +183,16 @@ export function TaskBucketManager({onClose}: {onClose: () => void}) {
             onChange={e => setNewName(e.target.value)}
             className={fieldCls}
           />
-          <label className="flex items-center gap-1 text-xs text-txt font-mono">
-            <input
-              type="checkbox"
-              checked={newCountBased}
-              onChange={e => setNewCountBased(e.target.checked)}
-            />
-            {t('taskBucket.countBased')}
-          </label>
+          <select
+            value={newKind}
+            onChange={e => setNewKind(e.target.value as TaskBucketKindType)}
+            className="w-full rounded-none border border-line bg-bg px-2 py-1 text-sm text-ink font-mono"
+            aria-label={t('taskBucket.kindLabel')}
+          >
+            <option value="one-time">{t('taskBucket.kindOneTime')}</option>
+            <option value="count">{t('taskBucket.kindCount')}</option>
+            <option value="unlimited">{t('taskBucket.kindUnlimited')}</option>
+          </select>
           <button
             type="button"
             onClick={handleAdd}

--- a/components/TaskModal.tsx
+++ b/components/TaskModal.tsx
@@ -54,7 +54,8 @@ export function TaskModal({mode, task, onClose}: TaskModalProps) {
   // (dropdown 채워지면 자동 정합). 사용자가 dropdown 변경 시 setBucketId 로 state 가 우선.
   const effectiveBucketId = bucketId !== '' ? bucketId : taskBuckets[0]?.id ?? '';
   const selectedBucket = taskBuckets.find(b => b.id === effectiveBucketId);
-  const isCountBased = selectedBucket?.isCountBased ?? false;
+  // PLAN1-TASKS-BUCKET-KIND-20260602 — kind==='count' 가 옛 isCountBased (count 필드 표시 조건).
+  const isCountBased = selectedBucket?.kind === 'count';
 
   // priorityMax 계산 (선택 버킷 기준 · 동적).
   const computeMax = (bId: string): number => {

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -141,6 +141,10 @@ export const plan1TaskBuckets = plan1Schema.table(
       .references(() => user.id, {onDelete: 'cascade'}),
     name: text('name').notNull().default(''),
     isCountBased: boolean('is_count_based').notNull().default(false),
+    // PLAN1-TASKS-BUCKET-KIND-20260602 — 동작 타입: one-time(일회성)/count(횟수차감)/unlimited(무제한).
+    // 무제한 = task→schedule 변환해도 task 유지. isCountBased 는 kind==='count' 동기 보존(drop 후속).
+    // 사양 단일 원천: cofounder-portal/lib/db/schema.ts plan1TaskBuckets.
+    kind: text('kind').$type<'one-time' | 'count' | 'unlimited'>().notNull().default('one-time'),
     sortOrder: integer('sort_order').notNull().default(0),
     defaultKind: text('default_kind').$type<'now' | 'later'>(),
     createdAt: timestamp('created_at', {withTimezone: true})

--- a/lib/domain/types.ts
+++ b/lib/domain/types.ts
@@ -25,11 +25,17 @@ export type TaskBucket = 'now' | 'later';
 export type TaskBucketId = string;
 export type TaskBucketKind = 'now' | 'later';
 
+// PLAN1-TASKS-BUCKET-KIND-20260602 — 버킷 동작 타입.
+//   one-time(일회성): 변환 시 할일 삭제 / count(횟수차감): 변환 시 횟수 -1(0이면 삭제)
+//   / unlimited(무제한): 변환해도 할일 유지.
+export type TaskBucketKindType = 'one-time' | 'count' | 'unlimited';
+
 // PLAN1-TASKS-BUCKET-CUSTOM-20260531 — 사용자 정의 할일 카테고리(버킷) 도메인 타입.
 export interface TaskBucketInfo {
   id: TaskBucketId;
   name: string;
-  isCountBased: boolean;
+  // PLAN1-TASKS-BUCKET-KIND-20260602 — isCountBased(불린) 대체. count = 옛 횟수차감.
+  kind: TaskBucketKindType;
   sortOrder: number;
   // 'now'|'later' = 시드된 기본 버킷 (편집 전 i18n 렌더). null = 사용자 생성 또는 이름 편집됨.
   defaultKind: TaskBucketKind | null;

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -24,6 +24,7 @@ import type {
   Task,
   TaskBucketId,
   TaskBucketInfo,
+  TaskBucketKindType,
   TaskId
 } from './domain/types';
 import * as categoriesApi from '@/app/actions/categories';
@@ -114,8 +115,8 @@ interface AppState {
   convertTaskToSchedule(taskId: TaskId, startAt: number, chainedToPrev?: boolean): Promise<string>;
 
   // PLAN1-TASKS-BUCKET-CUSTOM-20260531 — task bucket actions.
-  addTaskBucket(input: {name: string; isCountBased: boolean}): Promise<void>;
-  updateTaskBucketAction(input: {id: TaskBucketId; name: string; isCountBased: boolean}): Promise<void>;
+  addTaskBucket(input: {name: string; kind: TaskBucketKindType}): Promise<void>;
+  updateTaskBucketAction(input: {id: TaskBucketId; name: string; kind: TaskBucketKindType}): Promise<void>;
   removeTaskBucket(id: TaskBucketId): Promise<void>;
 
   addSchedule(input: Omit<Schedule, 'id' | 'createdAt' | 'updatedAt' | 'status'>): Promise<void>;

--- a/lib/task-bucket-seed.ts
+++ b/lib/task-bucket-seed.ts
@@ -40,8 +40,8 @@ export async function ensureBuckets(userId: string): Promise<BucketRow[]> {
   const inserted = await db
     .insert(plan1TaskBuckets)
     .values([
-      {id: `bkt-${randomUUID()}`, userId, name: '', isCountBased: false, sortOrder: 0, defaultKind: 'now'},
-      {id: `bkt-${randomUUID()}`, userId, name: '', isCountBased: false, sortOrder: 1, defaultKind: 'later'}
+      {id: `bkt-${randomUUID()}`, userId, name: '', kind: 'one-time', isCountBased: false, sortOrder: 0, defaultKind: 'now'},
+      {id: `bkt-${randomUUID()}`, userId, name: '', kind: 'one-time', isCountBased: false, sortOrder: 1, defaultKind: 'later'}
     ])
     .onConflictDoNothing()
     .returning();

--- a/lib/task-count.ts
+++ b/lib/task-count.ts
@@ -1,0 +1,19 @@
+import type {TaskBucketKindType} from './domain/types';
+
+/**
+ * PLAN1-TASKS-BUCKET-KIND-20260602 — 횟수차감형(kind='count') 버킷의 count 정규화.
+ *   count 버킷: ≥1 (default 1) / 일회성·무제한: null.
+ *
+ * 'use server' 밖(sync export) — server action(tasks.ts)과 REST API(route.ts)가 공유.
+ * REST 경로가 count 정규화를 건너뛰면 count 버킷 task 가 count=null 동기 깨짐 → 변환 차단
+ * (logic-critic Major). 단일 원천으로 차단.
+ */
+export function normalizeCount(
+  kind: TaskBucketKindType,
+  requested: number | null | undefined
+): number | null {
+  if (kind !== 'count') return null;
+  const n = requested ?? 1;
+  if (!Number.isFinite(n) || n < 1) return 1;
+  return Math.floor(n);
+}

--- a/messages/ar.json
+++ b/messages/ar.json
@@ -217,9 +217,12 @@
     "taskBucket": {
         "addHeading": "إضافة فئة",
         "confirmRemove": "إزالة؟ ({count} مهام)",
-        "countBased": "مهمة العد التنازلي",
         "fieldName": "الاسم",
         "header": "إدارة فئات المهام",
+        "kindCount": "مهمة بالعدّ",
+        "kindLabel": "نوع المهمة",
+        "kindOneTime": "مهمة لمرة واحدة",
+        "kindUnlimited": "مهمة غير محدودة",
         "remove": "إزالة",
         "taskCountSuffix": "{count} مهام"
     },

--- a/messages/de.json
+++ b/messages/de.json
@@ -217,9 +217,12 @@
     "taskBucket": {
         "addHeading": "Kategorie hinzufügen",
         "confirmRemove": "entfernen? ({count} Aufgaben)",
-        "countBased": "Countdown-Aufgabe",
         "fieldName": "Name",
         "header": "Aufgabenkategorien verwalten",
+        "kindCount": "Abzugsaufgabe",
+        "kindLabel": "Aufgabentyp",
+        "kindOneTime": "einmalige Aufgabe",
+        "kindUnlimited": "unbegrenzte Aufgabe",
         "remove": "entfernen",
         "taskCountSuffix": "{count} Aufgaben"
     },

--- a/messages/en.json
+++ b/messages/en.json
@@ -272,7 +272,10 @@
   "taskBucket": {
     "header": "manage task categories",
     "fieldName": "name",
-    "countBased": "count-down task",
+    "kindLabel": "task type",
+    "kindOneTime": "one-time task",
+    "kindCount": "count-down task",
+    "kindUnlimited": "unlimited task",
     "addHeading": "add category",
     "remove": "remove",
     "confirmRemove": "remove? ({count} tasks)",

--- a/messages/es.json
+++ b/messages/es.json
@@ -217,9 +217,12 @@
     "taskBucket": {
         "addHeading": "agregar categoría",
         "confirmRemove": "¿eliminar? ({count} tareas)",
-        "countBased": "tarea de cuenta regresiva",
         "fieldName": "nombre",
         "header": "administrar categorías de tareas",
+        "kindCount": "tarea con descuento",
+        "kindLabel": "tipo de tarea",
+        "kindOneTime": "tarea única",
+        "kindUnlimited": "tarea ilimitada",
         "remove": "eliminar",
         "taskCountSuffix": "{count} tareas"
     },

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -217,9 +217,12 @@
     "taskBucket": {
         "addHeading": "ajouter une catégorie",
         "confirmRemove": "supprimer? ({count} tâches)",
-        "countBased": "tâche à rebours",
         "fieldName": "nom",
         "header": "gérer les catégories de tâches",
+        "kindCount": "tâche à décompte",
+        "kindLabel": "type de tâche",
+        "kindOneTime": "tâche unique",
+        "kindUnlimited": "tâche illimitée",
         "remove": "supprimer",
         "taskCountSuffix": "{count} tâches"
     },

--- a/messages/hi.json
+++ b/messages/hi.json
@@ -217,9 +217,12 @@
     "taskBucket": {
         "addHeading": "श्रेणी जोड़ें",
         "confirmRemove": "हटाएं? ({count} कार्य)",
-        "countBased": "काउंट-डाउन कार्य",
         "fieldName": "नाम",
         "header": "कार्य श्रेणियां प्रबंधित करें",
+        "kindCount": "गिनती-घटाव कार्य",
+        "kindLabel": "कार्य प्रकार",
+        "kindOneTime": "एकल कार्य",
+        "kindUnlimited": "असीमित कार्य",
         "remove": "हटाएं",
         "taskCountSuffix": "{count} कार्य"
     },

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -217,9 +217,12 @@
     "taskBucket": {
         "addHeading": "カテゴリを追加",
         "confirmRemove": "削除しますか？（{count}件のタスク）",
-        "countBased": "カウントダウンタスク",
         "fieldName": "名前",
         "header": "タスクカテゴリを管理",
+        "kindCount": "回数消費タスク",
+        "kindLabel": "タスクの種類",
+        "kindOneTime": "単発タスク",
+        "kindUnlimited": "無制限タスク",
         "remove": "削除",
         "taskCountSuffix": "{count}件のタスク"
     },

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -272,7 +272,10 @@
   "taskBucket": {
     "header": "할일 카테고리 관리",
     "fieldName": "이름",
-    "countBased": "횟수 차감형 할일",
+    "kindLabel": "할일 타입",
+    "kindOneTime": "일회성 할일",
+    "kindCount": "횟수차감 할일",
+    "kindUnlimited": "무제한 할일",
     "addHeading": "카테고리 추가",
     "remove": "삭제",
     "confirmRemove": "삭제할까요? (할일 {count}개)",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -217,9 +217,12 @@
     "taskBucket": {
         "addHeading": "adicionar categoria",
         "confirmRemove": "remover? ({count} tarefas)",
-        "countBased": "tarefa de contagem regressiva",
         "fieldName": "nome",
         "header": "gerenciar categorias de tarefas",
+        "kindCount": "tarefa com contagem",
+        "kindLabel": "tipo de tarefa",
+        "kindOneTime": "tarefa única",
+        "kindUnlimited": "tarefa ilimitada",
         "remove": "remover",
         "taskCountSuffix": "{count} tarefas"
     },

--- a/messages/ru.json
+++ b/messages/ru.json
@@ -217,9 +217,12 @@
     "taskBucket": {
         "addHeading": "добавить категорию",
         "confirmRemove": "удалить? ({count} задач)",
-        "countBased": "задача с обратным отсчётом",
         "fieldName": "имя",
         "header": "управление категориями задач",
+        "kindCount": "задача со счётчиком",
+        "kindLabel": "тип задачи",
+        "kindOneTime": "разовая задача",
+        "kindUnlimited": "бессрочная задача",
         "remove": "удалить",
         "taskCountSuffix": "{count} задач"
     },

--- a/messages/zh-CN.json
+++ b/messages/zh-CN.json
@@ -217,9 +217,12 @@
     "taskBucket": {
         "addHeading": "添加类别",
         "confirmRemove": "删除?({count}个任务)",
-        "countBased": "倒计时任务",
         "fieldName": "名称",
         "header": "管理任务分类",
+        "kindCount": "次数递减任务",
+        "kindLabel": "任务类型",
+        "kindOneTime": "一次性任务",
+        "kindUnlimited": "无限任务",
         "remove": "移除",
         "taskCountSuffix": "{count}个任务"
     },

--- a/tests/qa-gate/task-bucket-custom.spec.ts
+++ b/tests/qa-gate/task-bucket-custom.spec.ts
@@ -26,7 +26,7 @@ test.describe('task bucket 커스터마이징 + 횟수차감', () => {
 
     // 새 버킷 추가 (횟수차감형 체크)
     await mgr.getByPlaceholder(/name|이름/i).fill(bucketName);
-    await mgr.getByRole('checkbox').last().check();
+    await mgr.getByRole('combobox', {name: /task type|할일 타입/i}).last().selectOption('count');
     await mgr.getByRole('button', {name: /^add$|^추가$/i}).click();
     // add 성공 시 TaskBucketManager 가 add 입력을 clear → toHaveValue('') 로 추가 완료 검증
     // (버킷 이름은 편집 가능한 input value 로 렌더되어 getByText 로 못 찾음).
@@ -53,7 +53,7 @@ test.describe('task bucket 커스터마이징 + 횟수차감', () => {
     const mgr = page.getByTestId('task-bucket-manager');
     await expect(mgr).toBeVisible({timeout: 5000});
     await mgr.getByPlaceholder(/name|이름/i).fill(bucketName);
-    await mgr.getByRole('checkbox').last().check();
+    await mgr.getByRole('combobox', {name: /task type|할일 타입/i}).last().selectOption('count');
     await mgr.getByRole('button', {name: /^add$|^추가$/i}).click();
     // add 성공 시 TaskBucketManager 가 add 입력을 clear → toHaveValue('') 로 추가 완료 검증
     // (버킷 이름은 편집 가능한 input value 로 렌더되어 getByText 로 못 찾음).
@@ -84,5 +84,44 @@ test.describe('task bucket 커스터마이징 + 횟수차감', () => {
     await expect(row).toContainText('[2]', {timeout: 5000});
     const elapsedMs = Date.now() - startMs;
     expect(elapsedMs, `count-decrement SLA — got ${elapsedMs}ms`).toBeLessThan(3000);
+  });
+
+  // PLAN1-TASKS-BUCKET-KIND-20260602 — 무제한 변환 회귀 가드 (변환해도 task 유지 · 3-way 분기 catch).
+  test('무제한 버킷 → 변환 시 task 유지 (count 없음)', async ({page}) => {
+    const tag = Date.now();
+    const bucketName = `unl-bkt-${tag}`;
+    const taskTitle = `unl-task-${tag}`;
+    await page.goto('/project/plan1/');
+
+    // 무제한 버킷 추가 (kind 드롭다운 → unlimited)
+    await page.getByTestId('task-manage-button').click();
+    const mgr = page.getByTestId('task-bucket-manager');
+    await expect(mgr).toBeVisible({timeout: 5000});
+    await mgr.getByPlaceholder(/name|이름/i).fill(bucketName);
+    await mgr.getByRole('combobox', {name: /task type|할일 타입/i}).last().selectOption('unlimited');
+    await mgr.getByRole('button', {name: /^add$|^추가$/i}).click();
+    await expect(mgr.getByPlaceholder(/name|이름/i)).toHaveValue('', {timeout: 5000});
+    await mgr.getByRole('button', {name: /close|닫기/i}).click();
+
+    // 무제한 task 생성 (category·duration — 변환 위해 · count 필드 없음).
+    await page.getByTestId('task-new-button').click();
+    const modal = page.getByTestId('task-modal');
+    await modal.getByLabel(/list|분류/i).selectOption({label: bucketName});
+    await modal.getByLabel(/title|제목/i).fill(taskTitle);
+    await modal.getByLabel(/duration|소요/i).fill('30');
+    await modal.getByLabel(/category|카테고리/i).selectOption({index: 1});
+    await modal.getByRole('button', {name: /add|추가|submit/i}).click();
+
+    const row = page.locator('[data-testid^="task-item-"]', {hasText: taskTitle});
+    await expect(row).toBeVisible({timeout: 5000});
+    // 무제한은 count 뱃지 없음.
+    await expect(row).not.toContainText('[');
+
+    // 변환("지금 시작") → schedule 추가되지만 task 그대로 유지 (삭제·차감 X).
+    await row.getByRole('button', {name: /\+ schedule|\+ 스케줄|schedule/i}).first().click();
+    await row.getByRole('button', {name: /now|지금/i}).click();
+    // 무제한 핵심 catch: 변환 후에도 task 가 목록에 남아있음.
+    await expect(row).toBeVisible({timeout: 5000});
+    await expect(row).toContainText(taskTitle);
   });
 });


### PR DESCRIPTION
isCountBased→kind enum. 무제한=변환해도 할일 유지. critic 1라운드 반영(REST count 정규화·spec 드롭다운·무제한 회귀). DB 직접 SQL 적용 완료. preview gate에서 task-bucket E2E 3종 통과 확인 목적. [skip-i18n]로 9개 수동 번역 보존.