### PR TITLE
fix(plan1): topbar.settingsLink i18n 키 추가 (11개 언어)

### DIFF
--- a/messages/ar.json
+++ b/messages/ar.json
@@ -253,7 +253,8 @@
         "creditsPlaceholder": "—",
         "guest": "ضيف",
         "languageLabel": "اللغة",
-        "logout": "تسجيل الخروج"
+        "logout": "تسجيل الخروج",
+        "settingsLink": "الإعدادات"
     },
     "undo": {
         "actionLabel": "التراجع متاح",

--- a/messages/de.json
+++ b/messages/de.json
@@ -253,7 +253,8 @@
         "creditsPlaceholder": "—",
         "guest": "Gast",
         "languageLabel": "Sprache",
-        "logout": "Abmelden"
+        "logout": "Abmelden",
+        "settingsLink": "Einstellungen"
     },
     "undo": {
         "actionLabel": "Rückgängig verfügbar",

--- a/messages/en.json
+++ b/messages/en.json
@@ -9,7 +9,8 @@
     "creditsPlaceholder": "—",
     "guest": "guest",
     "logout": "logout",
-    "languageLabel": "language"
+    "languageLabel": "language",
+    "settingsLink": "settings"
   },
   "nav": {
     "newSchedule": "new",

--- a/messages/es.json
+++ b/messages/es.json
@@ -253,7 +253,8 @@
         "creditsPlaceholder": "—",
         "guest": "invitado",
         "languageLabel": "idioma",
-        "logout": "cerrar sesión"
+        "logout": "cerrar sesión",
+        "settingsLink": "configuración"
     },
     "undo": {
         "actionLabel": "deshacer disponible",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -253,7 +253,8 @@
         "creditsPlaceholder": "—",
         "guest": "invité",
         "languageLabel": "langue",
-        "logout": "déconnexion"
+        "logout": "déconnexion",
+        "settingsLink": "paramètres"
     },
     "undo": {
         "actionLabel": "annulation disponible",

--- a/messages/hi.json
+++ b/messages/hi.json
@@ -253,7 +253,8 @@
         "creditsPlaceholder": "—",
         "guest": "अतिथि",
         "languageLabel": "भाषा",
-        "logout": "लॉगआउट"
+        "logout": "लॉगआउट",
+        "settingsLink": "सेटिंग्स"
     },
     "undo": {
         "actionLabel": "पूर्ववत उपलब्ध",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -253,7 +253,8 @@
         "creditsPlaceholder": "—",
         "guest": "ゲスト",
         "languageLabel": "言語",
-        "logout": "ログアウト"
+        "logout": "ログアウト",
+        "settingsLink": "設定"
     },
     "undo": {
         "actionLabel": "元に戻すが可能です",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -9,7 +9,8 @@
     "creditsPlaceholder": "—",
     "guest": "게스트",
     "logout": "로그아웃",
-    "languageLabel": "언어"
+    "languageLabel": "언어",
+    "settingsLink": "설정"
   },
   "nav": {
     "newSchedule": "새 스케줄",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -253,7 +253,8 @@
         "creditsPlaceholder": "—",
         "guest": "convidado",
         "languageLabel": "idioma",
-        "logout": "sair"
+        "logout": "sair",
+        "settingsLink": "configurações"
     },
     "undo": {
         "actionLabel": "desfazer disponível",

--- a/messages/ru.json
+++ b/messages/ru.json
@@ -253,7 +253,8 @@
         "creditsPlaceholder": "—",
         "guest": "гость",
         "languageLabel": "язык",
-        "logout": "выйти"
+        "logout": "выйти",
+        "settingsLink": "настройки"
     },
     "undo": {
         "actionLabel": "отмена доступна",

--- a/messages/zh-CN.json
+++ b/messages/zh-CN.json
@@ -253,7 +253,8 @@
         "creditsPlaceholder": "—",
         "guest": "访客",
         "languageLabel": "语言",
-        "logout": "登出"
+        "logout": "登出",
+        "settingsLink": "设置"
     },
     "undo": {
         "actionLabel": "可撤销",


### PR DESCRIPTION
## 문제
상단바 설정 링크(Header title·aria-label = `t('settingsLink')`)의 i18n 키가 11개 언어 전부 누락 → 링크 라벨에 키 원문 노출 + next-intl `MISSING_MESSAGE` 콘솔 에러. 설정 페이지 신설(PR #84) 때부터.

## 수정 (대장 '웹버전 기준' 결정)
각 locale 의 기존 `settings.heading` 값(웹 자체 용어)을 `topbar.settingsLink` 로 재사용 — 머신 임의 번역 아님. en/ko 2-space, 자동번역 9개 4-space 포맷 유지 → diff 는 키 1줄씩.

## 검증
i18n-catalog drift test 11/11 green · MISSING_MESSAGE 0 · 클라 messages blob 해석 확인 · build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)