### PR TITLE
A4-1: 웹 server action → 공유 코어 통합 (동작 불변)

### DIFF
--- a/app/actions/categories.ts
+++ b/app/actions/categories.ts
@@ -3,65 +3,31 @@
 /**
  * 카테고리 CRUD server actions.
  *
- * 보안: 모든 action 진입 시 requireUser() 강제. 모든 query 에 WHERE user_id = session.user.id.
- * 정책 (PRD Stage 5):
- *   - 동일 사용자 안에서 카테고리 이름 중복 금지 (DB UNIQUE INDEX 로 enforce)
- *   - 카테고리 삭제 시 그 카테고리 소속 스케줄 동반 삭제 (DB cascade — Stage 21·critic 결정 2)
- *   - 사용자 실수 방지는 클라이언트 confirm 모달 책임 (Stage 3f)
+ * A4-1 (2026-06-17): 로직을 `lib/server/category-core` 단일 코어로 통합.
+ *   - listCategoriesCore 의 SELECT-then-INSERT seed (neon-http read-after-write race 회피) 포함.
+ *   - 코어 ApiError → ServerActionError 변환은 callCore 어댑터.
+ *   - ⚡ 동작 불변: create/update 의 이름 중복(category_name_exists)은 웹 기존 action 이 미처리
+ *     (DB 에러 → error.unknown) 였으므로, 어댑터가 category_name_exists → error.unknown 으로
+ *     보존한다. 전용 에러 메시지 개선은 A4-2.
  *
- * Stage 5.1 part 2: 사용자 facing error 는 ServerActionError throw → runAction 이
- * discriminated union return 으로 변환 (Next.js prod redact 회피). Next.js 14 'use server'
- * 정합성 위해 export 는 `async function` 형태 유지 (HOF wrap 금지).
+ * 보안: 코어 모든 query 에 WHERE user_id. 삭제 시 소속 스케줄 있으면 force=true 강제(409).
  */
 
-import {randomUUID} from 'node:crypto';
-import {and, count, eq} from 'drizzle-orm';
-import {db} from '@/lib/db';
-import {plan1Categories, plan1Schedules} from '@/lib/db/schema';
 import {requireUser} from '@/lib/auth-helpers';
-import {ServerActionError, runAction, type ServerActionResult} from '@/lib/server-action';
+import {runAction, type ServerActionResult} from '@/lib/server-action';
+import {callCore} from '@/lib/server/action-error-adapter';
+import {
+  listCategoriesCore,
+  createCategoryCore,
+  updateCategoryCore,
+  deleteCategoryCore
+} from '@/lib/server/category-core';
 import type {Category} from '@/lib/domain/types';
-
-function rowToDomain(row: typeof plan1Categories.$inferSelect): Category {
-  return {
-    id: row.id,
-    name: row.name,
-    color: row.color,
-    createdAt: row.createdAt.getTime()
-  };
-}
 
 export async function listCategories(): Promise<ServerActionResult<Category[]>> {
   return runAction(async () => {
     const user = await requireUser();
-    // Track 1 fix (2026-04-29 · env-critic 채택): SELECT-then-INSERT 패턴.
-    // 1) 매 호출 INSERT 부하 제거 (이미 시드된 user 는 INSERT 안 침)
-    // 2) Neon HTTP driver per-query connection 의 read-after-write race 회피
-    //    (INSERT 후 SELECT 가 별도 connection 이면 commit visibility 약함 → 빈 array 가능)
-    // 3) onConflictDoNothing target 을 (user_id, name) UNIQUE INDEX 로 명시 — id PK 등
-    //    의도 외 충돌 흡수 차단
-    let rows = await db
-      .select()
-      .from(plan1Categories)
-      .where(eq(plan1Categories.userId, user.id));
-    if (rows.length === 0) {
-      await db
-        .insert(plan1Categories)
-        .values({
-          id: `cat-${randomUUID()}`,
-          userId: user.id,
-          name: 'default',
-          color: '#6b7280'
-        })
-        .onConflictDoNothing({
-          target: [plan1Categories.userId, plan1Categories.name]
-        });
-      rows = await db
-        .select()
-        .from(plan1Categories)
-        .where(eq(plan1Categories.userId, user.id));
-    }
-    return rows.map(rowToDomain);
+    return callCore(() => listCategoriesCore(user.id));
   });
 }
 
@@ -70,17 +36,7 @@ export async function createCategory(
 ): Promise<ServerActionResult<Category>> {
   return runAction(async () => {
     const user = await requireUser();
-    const id = `cat-${randomUUID()}`;
-    const [row] = await db
-      .insert(plan1Categories)
-      .values({
-        id,
-        userId: user.id,
-        name: input.name.trim(),
-        color: input.color
-      })
-      .returning();
-    return rowToDomain(row);
+    return callCore(() => createCategoryCore(user.id, input));
   });
 }
 
@@ -89,16 +45,7 @@ export async function updateCategory(
 ): Promise<ServerActionResult<Category>> {
   return runAction(async () => {
     const user = await requireUser();
-    const patch: Partial<typeof plan1Categories.$inferInsert> = {};
-    if (input.name !== undefined) patch.name = input.name.trim();
-    if (input.color !== undefined) patch.color = input.color;
-    const [row] = await db
-      .update(plan1Categories)
-      .set(patch)
-      .where(and(eq(plan1Categories.id, input.id), eq(plan1Categories.userId, user.id)))
-      .returning();
-    if (!row) throw new ServerActionError('serverError.categoryNotFound');
-    return rowToDomain(row);
+    return callCore(() => updateCategoryCore(user.id, input));
   });
 }
 
@@ -107,22 +54,6 @@ export async function deleteCategory(
 ): Promise<ServerActionResult<void>> {
   return runAction(async () => {
     const user = await requireUser();
-    // cascade DELETE: schedules.category_id -> categories.id ON DELETE CASCADE
-    // logic-critic Major: server-side 가드 — schedule 1개 이상이면 force=true 명시 강제.
-    // 클라이언트 confirm 모달이 force=true 로 재호출 책임 (Stage 3f).
-    if (!input.force) {
-      const [{value: scheduleCount}] = await db
-        .select({value: count()})
-        .from(plan1Schedules)
-        .where(
-          and(eq(plan1Schedules.userId, user.id), eq(plan1Schedules.categoryId, input.id))
-        );
-      if (scheduleCount > 0) {
-        throw new ServerActionError('serverError.categoryHasSchedules', {scheduleCount});
-      }
-    }
-    await db
-      .delete(plan1Categories)
-      .where(and(eq(plan1Categories.id, input.id), eq(plan1Categories.userId, user.id)));
+    return callCore(() => deleteCategoryCore(user.id, input));
   });
 }

--- a/app/actions/schedules.ts
+++ b/app/actions/schedules.ts
@@ -1,146 +1,37 @@
 'use server';
 
 /**
- * 스케줄 CRUD + cascade(Stage 18) server actions.
+ * 스케줄 CRUD + cascade server actions.
  *
- * PLAN1-WH-FOCUS-20260504 — splitByWorkingHours 폐기 (working hours 기능 자체 제거).
- * PLAN1-FOCUS-VIEW-REDESIGN-20260506 (Q25) — splitFrom · cleanOrphans · is-split-cont 잔존 코드 일괄 폐기.
- * schema 의 splitFrom column 은 S12 portal repo 에서 drop 예정 — 그 전엔 INSERT/SELECT 코드 영역만 폐기.
+ * A4-1 (2026-06-17): 비즈니스 로직을 `lib/server/schedule-core` 단일 코어로 통합 (정공법).
+ *   - 이전: 자체 loadUserState·syncSchedules·rowToDomain·cascade 직접 호출 → 코어와 거의 복붙 중복.
+ *   - 지금: 코어 *Core 함수 호출 + `WEB_GUARDS`(overlap·concurrency guard off) → **기존 웹 동작 불변**.
+ *   - 코어의 `ApiError(code)` 는 `callCore` 어댑터가 `ServerActionError(i18n key)` 로 변환
+ *     (정상 에러가 runAction catch-all 에서 error.unknown 으로 뭉개지는 것 차단).
+ *   - guard 도입(동작 개선)은 A4-2 별도 사이클 (lock-out 사전 실측 + 클라 409 핸들링 + i18n).
  *
- * Stage 5.1 part 2: 사용자 facing error 는 ServerActionError throw → runAction 이
- * discriminated union return 으로 변환 (Next.js prod redact 회피).
+ * Stage 5.1 part 2: 사용자 facing error 는 ServerActionError 로 표면화 → runAction 이
+ *   discriminated union return 으로 변환 (Next.js prod redact 회피).
  */
 
-import {randomUUID} from 'node:crypto';
-import {and, eq} from 'drizzle-orm';
-import type {BatchItem} from 'drizzle-orm/batch';
-import {db} from '@/lib/db';
-import {plan1Categories, plan1Schedules} from '@/lib/db/schema';
 import {requireUser} from '@/lib/auth-helpers';
-import {ServerActionError, runAction, type ServerActionResult} from '@/lib/server-action';
-import {cascade} from '@/lib/domain/cascade';
-import {insertBetweenList} from '@/lib/domain/insert-between';
+import {runAction, type ServerActionResult} from '@/lib/server-action';
+import {callCore} from '@/lib/server/action-error-adapter';
+import {
+  createScheduleCore,
+  updateScheduleCore,
+  deleteScheduleCore,
+  completeScheduleCore,
+  insertScheduleBetweenCore,
+  listSchedulesCore,
+  WEB_GUARDS
+} from '@/lib/server/schedule-core';
 import type {Schedule} from '@/lib/domain/types';
-
-type ScheduleRow = typeof plan1Schedules.$inferSelect;
-
-function rowToDomain(row: ScheduleRow): Schedule {
-  return {
-    id: row.id,
-    title: row.title,
-    categoryId: row.categoryId,
-    startAt: row.startAt.getTime(),
-    durationMin: row.durationMin,
-    actualDurationMin: row.actualDurationMin ?? undefined,
-    timerType: row.timerType,
-    status: row.status,
-    chainedToPrev: row.chainedToPrev,
-    createdAt: row.createdAt.getTime(),
-    updatedAt: row.updatedAt.getTime()
-  };
-}
-
-async function loadUserState(
-  userId: string,
-  ownerCategoryId?: string
-): Promise<{schedules: Schedule[]}> {
-  if (ownerCategoryId !== undefined) {
-    const [ownerRows, scheduleRows] = await db.batch([
-      db
-        .select({id: plan1Categories.id})
-        .from(plan1Categories)
-        .where(
-          and(eq(plan1Categories.id, ownerCategoryId), eq(plan1Categories.userId, userId))
-        )
-        .limit(1),
-      db.select().from(plan1Schedules).where(eq(plan1Schedules.userId, userId))
-    ]);
-    if (!ownerRows[0]) throw new ServerActionError('serverError.categoryNotFound');
-    return {schedules: scheduleRows.map(rowToDomain)};
-  }
-
-  const scheduleRows = await db
-    .select()
-    .from(plan1Schedules)
-    .where(eq(plan1Schedules.userId, userId));
-  return {schedules: scheduleRows.map(rowToDomain)};
-}
-
-/**
- * cascade 결과 schedule[] 을 DB 와 동기화.
- * 신규 = INSERT, 기존 = UPDATE → 통합 UPSERT. DB 에 있으나 결과에 없는 것 = DELETE.
- *
- * Track 1.5 fix (2026-04-29): db.transaction → db.batch (1 round-trip atomic · rollback 보장)
- *
- * logic-critic [높] race fix (2026-04-29): existingIds (loadUserState 시점 snapshot)
- * 에 의존하던 INSERT/UPDATE 분기를 `INSERT ... ON CONFLICT (id) DO UPDATE` 통합 UPSERT 로 변경.
- */
-async function syncSchedules(
-  userId: string,
-  dbExistingIds: Set<string>,
-  next: Schedule[]
-): Promise<void> {
-  const nextIds = new Set(next.map(s => s.id));
-  const queries: BatchItem<'pg'>[] = [];
-
-  for (const id of Array.from(dbExistingIds)) {
-    if (!nextIds.has(id)) {
-      queries.push(
-        db
-          .delete(plan1Schedules)
-          .where(and(eq(plan1Schedules.id, id), eq(plan1Schedules.userId, userId)))
-      );
-    }
-  }
-
-  for (const s of next) {
-    const values = {
-      id: s.id,
-      userId,
-      title: s.title,
-      categoryId: s.categoryId,
-      startAt: new Date(s.startAt),
-      durationMin: s.durationMin,
-      actualDurationMin: s.actualDurationMin ?? null,
-      timerType: s.timerType,
-      status: s.status,
-      // PLAN1-FOCUS-VIEW-REDESIGN-20260506 (Q6): chainedToPrev 디폴트 true
-      chainedToPrev: s.chainedToPrev ?? true,
-      updatedAt: new Date()
-    };
-    queries.push(
-      db
-        .insert(plan1Schedules)
-        .values(values)
-        .onConflictDoUpdate({
-          target: plan1Schedules.id,
-          set: {
-            title: values.title,
-            categoryId: values.categoryId,
-            startAt: values.startAt,
-            durationMin: values.durationMin,
-            actualDurationMin: values.actualDurationMin,
-            timerType: values.timerType,
-            status: values.status,
-            chainedToPrev: values.chainedToPrev,
-            updatedAt: values.updatedAt
-          }
-        })
-    );
-  }
-
-  if (queries.length === 0) return;
-  await db.batch(queries as [BatchItem<'pg'>, ...BatchItem<'pg'>[]]);
-}
 
 export async function listSchedules(): Promise<ServerActionResult<Schedule[]>> {
   return runAction(async () => {
     const user = await requireUser();
-    const rows = await db
-      .select()
-      .from(plan1Schedules)
-      .where(eq(plan1Schedules.userId, user.id));
-    return rows.map(rowToDomain);
+    return callCore(() => listSchedulesCore(user.id));
   });
 }
 
@@ -154,69 +45,24 @@ export async function createSchedule(input: {
 }): Promise<ServerActionResult<Schedule[]>> {
   return runAction(async () => {
     const user = await requireUser();
-    const state = await loadUserState(user.id, input.categoryId);
-    const newSchedule: Schedule = {
-      id: `sch-${randomUUID()}`,
-      title: input.title,
-      categoryId: input.categoryId,
-      startAt: input.startAt,
-      durationMin: input.durationMin,
-      timerType: input.timerType,
-      status: 'pending',
-      // PLAN1-FOCUS-VIEW-REDESIGN-20260506 (Q6): chainedToPrev 디폴트 true (모든 새 schedule chain).
-      chainedToPrev: input.chainedToPrev ?? true,
-      createdAt: Date.now(),
-      updatedAt: Date.now()
-    };
-    const next = [...state.schedules, newSchedule];
-    const existingIds = new Set(state.schedules.map(s => s.id));
-    await syncSchedules(user.id, existingIds, next);
-    return next;
+    return callCore(() => createScheduleCore(user.id, input, WEB_GUARDS));
   });
 }
 
-// PLAN1-SCHEDULE-INSERT-BETWEEN-20260602 — 새 스케줄(A2)을 충돌 스케줄(B) 시작 위치에
-// "사이 삽입". A2가 B 자리로 들어가고 B 시작 시간의 겹친 그룹 + 이후 chained 연속을
-// (A2 길이 + 기존 A–B 갭)만큼 밀기. 갭 보존. 로직 단일 원천: lib/domain/insert-between.
+// PLAN1-SCHEDULE-INSERT-BETWEEN-20260602 — 새 스케줄(A2)을 충돌 스케줄(B) 시작 위치에 "사이 삽입".
+// 로직 단일 원천: lib/domain/insert-between (코어 insertScheduleBetweenCore 경유).
 export async function insertScheduleBetween(input: {
   title: string;
   categoryId: string;
   durationMin: number;
   timerType: 'countup' | 'timer1' | 'countdown';
   conflictId: string;
-  // 클라가 본 충돌 일정 시작시각 — server state 와 불일치 시 TOCTOU 거부 (logic-critic Major).
+  // 클라가 본 충돌 일정 시작시각 — server state 와 불일치 시 TOCTOU 거부 (코어가 검증).
   expectedConflictStart: number;
 }): Promise<ServerActionResult<Schedule[]>> {
   return runAction(async () => {
     const user = await requireUser();
-    const state = await loadUserState(user.id, input.categoryId);
-    // TOCTOU 가드: 클라 snapshot 이후 다른 탭/기기가 충돌 일정을 변경·삭제했으면 거부.
-    // 엉뚱한 위치 삽입 차단 — 사용자에게 "다시 시도" 안내.
-    const conflict = state.schedules.find(s => s.id === input.conflictId);
-    if (!conflict || conflict.startAt !== input.expectedConflictStart) {
-      throw new ServerActionError('serverError.insertBetweenStale');
-    }
-    const newSchedule: Schedule = {
-      id: `sch-${randomUUID()}`,
-      title: input.title,
-      categoryId: input.categoryId,
-      // startAt 은 insertBetweenList 가 conflict 직전 기준으로 재계산 (A.end + gap).
-      startAt: 0,
-      durationMin: input.durationMin,
-      timerType: input.timerType,
-      status: 'pending',
-      chainedToPrev: true,
-      createdAt: Date.now(),
-      updatedAt: Date.now()
-    };
-    const next = insertBetweenList(state.schedules, newSchedule, input.conflictId);
-    // 직전 active 없음(P1) 또는 gap<0(비정상 겹침) → null. 모달이 사전 차단하지만 서버 가드.
-    if (!next) {
-      throw new ServerActionError('serverError.insertBetweenNoPrev');
-    }
-    const existingIds = new Set(state.schedules.map(s => s.id));
-    await syncSchedules(user.id, existingIds, next);
-    return next;
+    return callCore(() => insertScheduleBetweenCore(user.id, input, WEB_GUARDS));
   });
 }
 
@@ -231,40 +77,14 @@ export async function updateSchedule(input: {
 }): Promise<ServerActionResult<Schedule[]>> {
   return runAction(async () => {
     const user = await requireUser();
-    const state = await loadUserState(user.id, input.categoryId);
-    const target = state.schedules.find(s => s.id === input.id);
-    if (!target) throw new ServerActionError('serverError.scheduleNotFound');
-
-    // logic-critic Major: 메타 patch 를 cascade 전에 적용 (chainedToPrev 변경이 cascade 에 즉시 반영)
-    const metaPatched = state.schedules.map(s =>
-      s.id === input.id
-        ? {
-            ...s,
-            title: input.title ?? s.title,
-            categoryId: input.categoryId ?? s.categoryId,
-            timerType: input.timerType ?? s.timerType,
-            chainedToPrev: input.chainedToPrev ?? s.chainedToPrev
-          }
-        : s
-    );
-
-    // cascade 는 startAt/duration 변경 시만 의미. 기타 필드만 patch 인 경우 cascade 가 delta=0 이라 noop.
-    const newStartAt = input.startAt ?? target.startAt;
-    const newDuration = input.durationMin ?? target.durationMin;
-    const cascaded = cascade(metaPatched, input.id, newStartAt, newDuration);
-
-    const existingIds = new Set(state.schedules.map(s => s.id));
-    await syncSchedules(user.id, existingIds, cascaded);
-    return cascaded;
+    return callCore(() => updateScheduleCore(user.id, input, WEB_GUARDS));
   });
 }
 
 export async function deleteSchedule(id: string): Promise<ServerActionResult<void>> {
   return runAction(async () => {
     const user = await requireUser();
-    await db
-      .delete(plan1Schedules)
-      .where(and(eq(plan1Schedules.id, id), eq(plan1Schedules.userId, user.id)));
+    return callCore(() => deleteScheduleCore(user.id, id));
   });
 }
 
@@ -274,38 +94,6 @@ export async function completeSchedule(input: {
 }): Promise<ServerActionResult<Schedule[]>> {
   return runAction(async () => {
     const user = await requireUser();
-    const state = await loadUserState(user.id);
-    const target = state.schedules.find(s => s.id === input.id);
-    if (!target) throw new ServerActionError('serverError.scheduleNotFound');
-
-    const originalDuration = target.durationMin;
-    const actualMin = Math.max(0, Math.round((input.completeAtMs - target.startAt) / 60_000));
-
-    // cascade 는 delta 계산 위해 actualMin 을 newDuration 으로 받음 (뒤 chain shift).
-    // 그러나 edited schedule 자체는 durationMin 원래 값 보존 + actualDurationMin 별도 patch
-    // (logic-critic Critical #3 — planned vs actual 비교 데이터 보존).
-    const cascaded = cascade(state.schedules, input.id, target.startAt, actualMin).map(s =>
-      s.id === input.id
-        ? {
-            ...s,
-            durationMin: originalDuration,
-            status: 'done' as const,
-            actualDurationMin: actualMin
-          }
-        : s
-    );
-
-    const existingIds = new Set(state.schedules.map(s => s.id));
-    await syncSchedules(user.id, existingIds, cascaded);
-    // PLAN1-TASKS-BUCKET-CUSTOM-20260531 (N5) — 완료 시각 기록 (되돌아보기 모달 표시용).
-    // syncSchedules 가 도메인 기준 write(completedAt 미포함) 하므로 그 뒤 타겟 UPDATE 로 보강.
-    await db
-      .update(plan1Schedules)
-      .set({completedAt: new Date(input.completeAtMs)})
-      .where(and(eq(plan1Schedules.id, input.id), eq(plan1Schedules.userId, user.id)));
-    return cascaded;
+    return callCore(() => completeScheduleCore(user.id, input, WEB_GUARDS));
   });
 }
-
-// PLAN1-FOCUS-VIEW-REDESIGN-20260506 (Q25): cleanOrphans 함수 폐기 (split 메커니즘 자체 폐기).
-// 옛 splitFrom row 는 S12 portal repo column drop 시 자연 삭제 (FK CASCADE).

--- a/app/actions/settings.ts
+++ b/app/actions/settings.ts
@@ -1,71 +1,25 @@
 'use server';
 
 /**
- * 사용자 설정 (1:1) — theme · weekViewSpan · weeklyPanelHidden · focusViewMin · pinnedActiveId.
+ * 사용자 설정 (1:1) — theme · focusViewMin.
  *
- * PLAN1-WH-FOCUS-20260504:
- *   - defaultWorkingHours 폐기 (working hours 기능 자체 제거)
- *   - focusViewMin 신규 (집중 보기 모드 · null = 전체 보기)
- *
- * 정책:
- *   - PK = user_id (한 사용자 = 1행). 첫 호출 시 default 로 upsert.
- *   - pinnedActiveId FK set null — 스케줄 삭제 시 자동 해제 (DB enforce, Stage 20)
- *
- * Stage 5.1 part 2: 사용자 facing error 는 ServerActionError throw → runAction 변환.
- * `getSettings` 가 같은 모듈의 `updateSettings` 에서도 호출되므로 internal helper
- * `getSettingsImpl` 분리. 'use server' 모듈의 unexported async function 은 server
- * action 으로 노출 안 됨 (Next.js 14 동작) → 안전.
+ * A4-1 (2026-06-17): 로직을 `lib/server/settings-core` 단일 코어로 통합.
+ *   - PK = userId (한 사용자 1행). 첫 접근 시 default upsert (race-safe onConflictDoNothing).
+ *   - patch 가능 필드 = theme · focusViewMin (zoomPxPerHour 는 UI 변경 폐기 · column 보존만).
+ *   - settings 는 도메인 에러 없음(단순 upsert) → 어댑터는 방어적으로만 적용.
  */
 
-import {eq} from 'drizzle-orm';
-import {db} from '@/lib/db';
-import {plan1Settings} from '@/lib/db/schema';
 import {requireUser} from '@/lib/auth-helpers';
 import {runAction, type ServerActionResult} from '@/lib/server-action';
+import {callCore} from '@/lib/server/action-error-adapter';
+import {getSettingsCore, updateSettingsCore} from '@/lib/server/settings-core';
 import type {AppSettings} from '@/lib/domain/types';
 
-// PLAN1-FOCUS-VIEW-REDESIGN-20260506:
-//   - focusViewMin default 720 (12h)
-//   - weekViewSpan / weeklyPanelHidden / pinnedActiveId 는 코드에서 안 읽지만 schema 호환을 위해 INSERT 시 보존 (S12 portal repo column drop 후 정리)
-const DEFAULT_SETTINGS = {
-  theme: 'system' as const,
-  weekViewSpan: 1 as const,         // S12 column drop 까지 INSERT 호환 유지
-  weeklyPanelHidden: false,          // S12 column drop 까지 INSERT 호환 유지
-  focusViewMin: 720 as number,
-  zoomPxPerHour: 90 as number,       // PLAN1-ZOOM-DEFAULT-90-20260509 (UI +/- 폐기)
-  pinnedActiveId: null as string | null  // S12 column drop 까지 INSERT 호환 유지
-};
-
-function rowToDomain(row: typeof plan1Settings.$inferSelect): AppSettings {
-  return {
-    theme: row.theme,
-    // 옛 row null fallback (S12 backfill 전까지 안전망 · NOT NULL DEFAULT 720 박힌 후엔 무관)
-    focusViewMin: row.focusViewMin ?? 720,
-    // PLAN1-ZOOM-DEFAULT-90-20260509: 옛 row 부재 fallback (NOT NULL DEFAULT 90)
-    zoomPxPerHour: row.zoomPxPerHour ?? 90
-  };
-}
-
-// internal — 같은 모듈 안에서 다른 server action 이 직접 호출 (wrap 우회).
-// 'use server' 모듈의 unexported async function 은 RSC endpoint 로 노출 안 됨.
-async function getSettingsImpl(): Promise<AppSettings> {
-  const user = await requireUser();
-  // race-safe upsert: 동시 호출 2건이 INSERT 충돌해도 PK conflict 무시 (logic-critic Minor)
-  await db
-    .insert(plan1Settings)
-    .values({userId: user.id, ...DEFAULT_SETTINGS})
-    .onConflictDoNothing();
-  const rows = await db
-    .select()
-    .from(plan1Settings)
-    .where(eq(plan1Settings.userId, user.id))
-    .limit(1);
-  if (!rows[0]) throw new Error('settings upsert failed (unexpected)');
-  return rowToDomain(rows[0]);
-}
-
 export async function getSettings(): Promise<ServerActionResult<AppSettings>> {
-  return runAction(getSettingsImpl);
+  return runAction(async () => {
+    const user = await requireUser();
+    return callCore(() => getSettingsCore(user.id));
+  });
 }
 
 export async function updateSettings(
@@ -73,20 +27,6 @@ export async function updateSettings(
 ): Promise<ServerActionResult<AppSettings>> {
   return runAction(async () => {
     const user = await requireUser();
-    // settings 행이 없으면 default 먼저 upsert (internal helper 사용 — wrap 우회)
-    await getSettingsImpl();
-
-    const dbPatch: Partial<typeof plan1Settings.$inferInsert> = {updatedAt: new Date()};
-    if (patch.theme !== undefined) dbPatch.theme = patch.theme;
-    if (patch.focusViewMin !== undefined) dbPatch.focusViewMin = patch.focusViewMin;
-    // PLAN1-ZOOM-DEFAULT-90-20260509: zoomPxPerHour patch handler 폐기 (UI +/- 박음 폐기 · 사용자 변경 영역 X).
-    // column 보존 — 향후 재도입 시 박음.
-
-    const [updated] = await db
-      .update(plan1Settings)
-      .set(dbPatch)
-      .where(eq(plan1Settings.userId, user.id))
-      .returning();
-    return rowToDomain(updated);
+    return callCore(() => updateSettingsCore(user.id, patch));
   });
 }

--- a/lib/server/action-error-adapter.test.ts
+++ b/lib/server/action-error-adapter.test.ts
@@ -1,0 +1,103 @@
+/**
+ * A4-1 characterization / 회귀 가드 — ApiError → ServerActionError 어댑터 + write guard 상수.
+ *
+ * 목적:
+ *   ① 코어 ApiError(code) 가 웹 i18n errorKey 로 정확히 변환되는지 (정상 에러가 error.unknown
+ *      으로 뭉개지지 않음 — critic Critical).
+ *   ② A4-1 동작 불변: overlap_exceeded·concurrency_conflict·category_name_exists 는 웹에서
+ *      error.unknown 으로 보존 (전환 전 웹 동작과 동일).
+ *   ③ category_has_schedules 의 params(scheduleCount) 보존.
+ *   ④ WEB_GUARDS off / REST_GUARDS on (웹 동작 불변 · REST 기존 동작 보존).
+ */
+import {describe, it, expect} from 'vitest';
+import {ApiError} from '@/lib/server/api-error';
+import {rethrowAsServerActionError, callCore} from '@/lib/server/action-error-adapter';
+import {isServerActionError, type ServerActionError} from '@/lib/server-action';
+import {WEB_GUARDS, REST_GUARDS} from '@/lib/server/schedule-guards';
+
+function caught(fn: () => unknown): unknown {
+  try {
+    fn();
+  } catch (e) {
+    return e;
+  }
+  throw new Error('expected throw but none happened');
+}
+
+describe('action-error-adapter — ApiError → ServerActionError', () => {
+  it('schedule_not_found → serverError.scheduleNotFound', () => {
+    const e = caught(() => rethrowAsServerActionError(new ApiError('schedule_not_found', 404)));
+    expect(isServerActionError(e)).toBe(true);
+    expect((e as ServerActionError).errorKey).toBe('serverError.scheduleNotFound');
+  });
+
+  it('category_not_found → serverError.categoryNotFound', () => {
+    const e = caught(() => rethrowAsServerActionError(new ApiError('category_not_found', 404)));
+    expect((e as ServerActionError).errorKey).toBe('serverError.categoryNotFound');
+  });
+
+  it('insert_between_stale / no_prev → 각 i18n 키', () => {
+    const stale = caught(() => rethrowAsServerActionError(new ApiError('insert_between_stale', 409)));
+    expect((stale as ServerActionError).errorKey).toBe('serverError.insertBetweenStale');
+    const noPrev = caught(() => rethrowAsServerActionError(new ApiError('insert_between_no_prev', 422)));
+    expect((noPrev as ServerActionError).errorKey).toBe('serverError.insertBetweenNoPrev');
+  });
+
+  it('category_has_schedules → params(scheduleCount) 보존', () => {
+    const e = caught(() =>
+      rethrowAsServerActionError(new ApiError('category_has_schedules', 409, 'msg', {scheduleCount: 3}))
+    );
+    expect((e as ServerActionError).errorKey).toBe('serverError.categoryHasSchedules');
+    expect((e as ServerActionError).params).toEqual({scheduleCount: 3});
+  });
+
+  // A4-1 동작 불변 — 웹에서 발생 안 함(guard off) 또는 기존 generic 보존.
+  it.each(['overlap_exceeded', 'concurrency_conflict', 'category_name_exists'])(
+    '%s → error.unknown (A4-1 동작 불변)',
+    code => {
+      const e = caught(() => rethrowAsServerActionError(new ApiError(code, 409)));
+      expect((e as ServerActionError).errorKey).toBe('error.unknown');
+    }
+  );
+
+  it('매핑 없는 code → error.unknown (안전 fallback)', () => {
+    const e = caught(() => rethrowAsServerActionError(new ApiError('totally_unknown', 500)));
+    expect((e as ServerActionError).errorKey).toBe('error.unknown');
+  });
+
+  it('non-ApiError 는 원본 그대로 re-throw (runAction catch-all 로)', () => {
+    const orig = new Error('boom');
+    const e = caught(() => rethrowAsServerActionError(orig));
+    expect(e).toBe(orig);
+    expect(isServerActionError(e)).toBe(false);
+  });
+});
+
+describe('callCore', () => {
+  it('성공 시 결과 반환', async () => {
+    await expect(callCore(async () => 42)).resolves.toBe(42);
+  });
+
+  it('ApiError 면 ServerActionError 로 변환해 throw', async () => {
+    let thrown: unknown;
+    try {
+      await callCore(async () => {
+        throw new ApiError('schedule_not_found', 404);
+      });
+    } catch (e) {
+      thrown = e;
+    }
+    expect(isServerActionError(thrown)).toBe(true);
+    expect((thrown as ServerActionError).errorKey).toBe('serverError.scheduleNotFound');
+  });
+});
+
+describe('A4 write guards (동작 분기 고정)', () => {
+  it('WEB_GUARDS — overlap·concurrency 둘 다 off (웹 동작 불변)', () => {
+    expect(WEB_GUARDS).toEqual({enforceOverlap: false, enforceConcurrency: false});
+  });
+
+  it('REST_GUARDS — 둘 다 on (REST 기존 동작 보존)', () => {
+    expect(REST_GUARDS).toEqual({enforceOverlap: true, enforceConcurrency: true});
+  });
+});

--- a/lib/server/action-error-adapter.ts
+++ b/lib/server/action-error-adapter.ts
@@ -1,0 +1,48 @@
+/**
+ * A4 — REST 코어의 ApiError(code) 를 웹 server action 의 ServerActionError(i18n key) 로 변환.
+ *
+ * 웹 server action 이 schedule-core/category-core 를 호출하면 코어는 `ApiError`(snake_case code)
+ * 를 throw 한다. 그런데 `runAction` 의 catch-all 은 `isServerActionError` brand 만 errorKey 로
+ * 매핑하고 나머지는 전부 `error.unknown` 으로 redact 한다 → 코어 도메인 에러(일정 없음 등)가
+ * 그대로 통과하면 사용자에게 "알 수 없는 오류"로 뭉개진다 (logic/env critic Critical).
+ * 이 어댑터가 ApiError 를 i18n ServerActionError 로 바꿔 정상 에러 메시지를 보존한다.
+ *
+ * A4-1 동작 불변: overlap_exceeded·concurrency_conflict 는 웹이 guard off 라 발생하지 않고,
+ *   category_name_exists 는 웹 기존 action 이 미처리(error.unknown) 였으므로 그 동작을 보존한다.
+ *   세 code 는 A4-2 에서 전용 i18n 키 + 클라 핸들링을 갖춘 뒤 개선한다.
+ */
+import {ApiError} from '@/lib/server/api-error';
+import {ServerActionError} from '@/lib/server-action';
+
+const API_ERROR_KEY: Record<string, string> = {
+  category_not_found: 'serverError.categoryNotFound',
+  schedule_not_found: 'serverError.scheduleNotFound',
+  insert_between_stale: 'serverError.insertBetweenStale',
+  insert_between_no_prev: 'serverError.insertBetweenNoPrev',
+  category_has_schedules: 'serverError.categoryHasSchedules',
+  // A4-1 동작 불변 — 웹 경로 미발생(guard off) 또는 기존 generic 보존. A4-2 개선 예정.
+  overlap_exceeded: 'error.unknown',
+  concurrency_conflict: 'error.unknown',
+  category_name_exists: 'error.unknown'
+};
+
+/**
+ * ApiError 면 i18n ServerActionError 로 변환해 throw. 그 외(non-ApiError)는 그대로 re-throw
+ * (runAction 이 error.unknown 으로 처리 + 서버 로깅 보존). never — catch 블록에서 호출.
+ */
+export function rethrowAsServerActionError(err: unknown): never {
+  if (err instanceof ApiError) {
+    const key = API_ERROR_KEY[err.code] ?? 'error.unknown';
+    throw new ServerActionError(key, err.params ?? {});
+  }
+  throw err;
+}
+
+/** 코어 호출을 try/catch 로 감싸 ApiError → ServerActionError 변환 후 결과 반환. */
+export async function callCore<T>(fn: () => Promise<T>): Promise<T> {
+  try {
+    return await fn();
+  } catch (err) {
+    rethrowAsServerActionError(err);
+  }
+}

--- a/lib/server/api-error.ts
+++ b/lib/server/api-error.ts
@@ -5,11 +5,20 @@
 export class ApiError extends Error {
   readonly code: string;
   readonly status: number;
-  constructor(code: string, status: number, message?: string) {
+  /** 사용자 facing 메시지에 끼울 구조화 파라미터 (예: category_has_schedules 의 scheduleCount).
+   *  A4 웹 전환 시 ServerActionError 의 i18n params 로 보존된다. */
+  readonly params?: Record<string, string | number>;
+  constructor(
+    code: string,
+    status: number,
+    message?: string,
+    params?: Record<string, string | number>
+  ) {
     super(message ?? code);
     this.name = 'ApiError';
     this.code = code;
     this.status = status;
+    this.params = params;
   }
 }
 

--- a/lib/server/category-core.ts
+++ b/lib/server/category-core.ts
@@ -105,7 +105,8 @@ export async function deleteCategoryCore(
       throw new ApiError(
         'category_has_schedules',
         409,
-        `Category has ${scheduleCount} schedule(s); pass force=true to cascade delete`
+        `Category has ${scheduleCount} schedule(s); pass force=true to cascade delete`,
+        {scheduleCount}
       );
     }
   }

--- a/lib/server/schedule-core.ts
+++ b/lib/server/schedule-core.ts
@@ -28,6 +28,7 @@ import {
   isConcurrencyConflict,
   type SnapshotRow
 } from '@/lib/server/concurrency-guard';
+import {type WriteGuards, REST_GUARDS, WEB_GUARDS} from '@/lib/server/schedule-guards';
 
 type ScheduleRow = typeof plan1Schedules.$inferSelect;
 
@@ -55,6 +56,10 @@ export class ScheduleError extends ApiError {
     this.name = 'ScheduleError';
   }
 }
+
+// write guard 토글 (db 의존 없는 순수 상수 — schedule-guards 로 분리해 단위 test import 안전).
+// 웹 schedules.ts 등 기존 import 경로 보존 위해 re-export.
+export {type WriteGuards, REST_GUARDS, WEB_GUARDS};
 
 function rowToDomain(row: ScheduleRow): Schedule {
   return {
@@ -112,10 +117,12 @@ function snapshotRows(schedules: Schedule[]): SnapshotRow[] {
 async function writeSchedules(
   userId: string,
   snapshot: Schedule[],
-  next: Schedule[]
+  next: Schedule[],
+  guards: WriteGuards
 ): Promise<void> {
   // 서버측 overlap 검증 — MAX_OVERLAP 위반 결과는 거부 (API 우회 무방비 차단).
-  if (exceedsMaxOverlap(next, MAX_OVERLAP)) {
+  // A4-1 웹은 off (기존 동작 불변 · 클라 모달이 차단 · prod 기존 데이터 lock-out 회피).
+  if (guards.enforceOverlap && exceedsMaxOverlap(next, MAX_OVERLAP)) {
     throw new ScheduleError('overlap_exceeded');
   }
 
@@ -124,7 +131,10 @@ async function writeSchedules(
   const queries: BatchItem<'pg'>[] = [];
 
   // [0] 낙관적 동시성 guard — 스냅샷과 현재 DB 집합 불일치 시 batch 전체 롤백.
-  queries.push(db.execute(buildConcurrencyGuardSql(userId, snapshotRows(snapshot))));
+  // A4-1 웹은 off (기존 last-write-wins 동작 불변).
+  if (guards.enforceConcurrency) {
+    queries.push(db.execute(buildConcurrencyGuardSql(userId, snapshotRows(snapshot))));
+  }
 
   // DELETE: 스냅샷에 있었으나 결과에 없는 것.
   for (const id of snapshotIds) {
@@ -173,10 +183,13 @@ async function writeSchedules(
     );
   }
 
+  // guard off + DELETE/UPSERT 둘 다 없는 경우 (이론상 next 비고 snapshot 비면) no-op.
+  if (queries.length === 0) return;
+
   try {
     await db.batch(queries as [BatchItem<'pg'>, ...BatchItem<'pg'>[]]);
   } catch (e) {
-    if (isConcurrencyConflict(e)) {
+    if (guards.enforceConcurrency && isConcurrencyConflict(e)) {
       throw new ScheduleError('concurrency_conflict');
     }
     throw e;
@@ -206,7 +219,8 @@ export interface CreateScheduleInput {
 
 export async function createScheduleCore(
   userId: string,
-  input: CreateScheduleInput
+  input: CreateScheduleInput,
+  guards: WriteGuards = REST_GUARDS
 ): Promise<Schedule[]> {
   const state = await loadUserState(userId, input.categoryId);
   const now = Date.now();
@@ -223,7 +237,7 @@ export async function createScheduleCore(
     updatedAt: now
   };
   const next = [...state.schedules, newSchedule];
-  await writeSchedules(userId, state.schedules, next);
+  await writeSchedules(userId, state.schedules, next, guards);
   return next;
 }
 
@@ -239,7 +253,8 @@ export interface UpdateScheduleInput {
 
 export async function updateScheduleCore(
   userId: string,
-  input: UpdateScheduleInput
+  input: UpdateScheduleInput,
+  guards: WriteGuards = REST_GUARDS
 ): Promise<Schedule[]> {
   const state = await loadUserState(userId, input.categoryId);
   const target = state.schedules.find(s => s.id === input.id);
@@ -262,7 +277,7 @@ export async function updateScheduleCore(
   const newDuration = input.durationMin ?? target.durationMin;
   const cascaded = cascade(metaPatched, input.id, newStartAt, newDuration);
 
-  await writeSchedules(userId, state.schedules, cascaded);
+  await writeSchedules(userId, state.schedules, cascaded, guards);
   return cascaded;
 }
 
@@ -280,7 +295,8 @@ export interface CompleteScheduleInput {
 
 export async function completeScheduleCore(
   userId: string,
-  input: CompleteScheduleInput
+  input: CompleteScheduleInput,
+  guards: WriteGuards = REST_GUARDS
 ): Promise<Schedule[]> {
   const state = await loadUserState(userId);
   const target = state.schedules.find(s => s.id === input.id);
@@ -302,7 +318,7 @@ export async function completeScheduleCore(
       : s
   );
 
-  await writeSchedules(userId, state.schedules, cascaded);
+  await writeSchedules(userId, state.schedules, cascaded, guards);
   // completedAt 보강 (syncSchedules 는 도메인 기준 write 라 completedAt 미포함 · web 정합).
   await db
     .update(plan1Schedules)
@@ -323,7 +339,8 @@ export interface InsertBetweenInput {
 
 export async function insertScheduleBetweenCore(
   userId: string,
-  input: InsertBetweenInput
+  input: InsertBetweenInput,
+  guards: WriteGuards = REST_GUARDS
 ): Promise<Schedule[]> {
   const state = await loadUserState(userId, input.categoryId);
   const conflict = state.schedules.find(s => s.id === input.conflictId);
@@ -347,6 +364,6 @@ export async function insertScheduleBetweenCore(
   if (!next) {
     throw new ScheduleError('insert_between_no_prev');
   }
-  await writeSchedules(userId, state.schedules, next);
+  await writeSchedules(userId, state.schedules, next, guards);
   return next;
 }

--- a/lib/server/schedule-guards.ts
+++ b/lib/server/schedule-guards.ts
@@ -1,0 +1,18 @@
+/**
+ * A4 write 경로 guard 토글 (웹/REST 동작 분기).
+ *
+ * db 의존 없는 순수 상수 — schedule-core(db import) 와 분리해 단위 test 가 db 없이 import 가능.
+ *   - REST(모바일 앱): 둘 다 on — 서버측 overlap 검증 + 낙관적 동시성(D1).
+ *   - 웹(A4-1): 둘 다 off — server action 기존 동작 불변(클라가 overlap 차단 · D1 미적용).
+ *     A4-2 에서 lock-out 사전 실측 + 클라 409 핸들링 + i18n 갖춘 뒤 웹도 on 전환 예정.
+ */
+export interface WriteGuards {
+  enforceOverlap: boolean;
+  enforceConcurrency: boolean;
+}
+
+/** REST 기본 — 기존 동작 보존 (REST route 무변경). */
+export const REST_GUARDS: WriteGuards = {enforceOverlap: true, enforceConcurrency: true};
+
+/** A4-1 웹 — 동작 불변 (overlap·concurrency guard 미적용). */
+export const WEB_GUARDS: WriteGuards = {enforceOverlap: false, enforceConcurrency: false};


### PR DESCRIPTION
## 무엇
웹 schedules/categories/settings server action 을 `lib/server/*-core` 단일 코어 호출로 전환. 자체 loadUserState·syncSchedules·rowToDomain 중복 제거 (모바일 A1 코어와 복붙이던 것).

## 동작 불변 (A4-1)
- 웹은 `WEB_GUARDS` (overlap·concurrency guard **off**) → 기존 last-write-wins·클라 overlap 차단 동작 유지.
- guard 도입(동작 개선)은 **A4-2 별도 사이클** — lock-out 사전 실측 + 클라 409 핸들링 + i18n 22키 선결.

## 핵심 보강 (critic Critical 반영)
- `ApiError(code)` → `ServerActionError(i18n key)` 어댑터(`callCore`) — 정상 에러가 `error.unknown` 으로 redact 되던 결함 차단.
- `ApiError` 에 `params` 추가 → `category_has_schedules` 의 `scheduleCount` 보존.
- guard 상수를 `schedule-guards.ts` 분리 (db 의존 없이 단위 test import).

## 검증
- tsc 0 · vitest **202** (어댑터 characterization 13 신규 · 도메인 회귀 0) · lint 0.
- build 는 PORTAL_ISSUER 등 Vercel env 라 CI preview 에서 확인.
- ⚠️ prod 배포 전 대장 confirm (public 영향).

🤖 Generated with [Claude Code](https://claude.com/claude-code)