### PR TITLE
fix: 완료 일정 편집이 타임라인에 반영 안 되던 문제 (actualDurationMin)

### DIFF
--- a/components/NewScheduleModal.tsx
+++ b/components/NewScheduleModal.tsx
@@ -144,7 +144,10 @@ export function NewScheduleModal({
     if (title === titleDefault) setTitle('');
   };
   const [categoryId, setCategoryId] = useState(editing?.categoryId ?? (categories[0]?.id ?? ''));
-  const [durationMin, setDurationMin] = useState(editing?.durationMin ?? 0);
+  // 완료 일정은 타임라인이 actualDurationMin 으로 표시되므로 편집 시작값도 actual 기준
+  // (보이는 값과 일치 · 저장 시 actualDurationMin 으로 반영). 미완료는 actualDurationMin 이 없어 durationMin.
+  const editingDurationMin = editing ? (editing.actualDurationMin ?? editing.durationMin) : 0;
+  const [durationMin, setDurationMin] = useState(editingDurationMin);
   // PLAN1-FOCUS-VIEW-REDESIGN-20260506 (Q6·Q30): chainedToPrev 디폴트 true. checkbox 유지.
   const [chainedToPrev, setChainedToPrev] = useState(editing?.chainedToPrev ?? true);
   const [catOpen, setCatOpen] = useState(false);
@@ -241,7 +244,7 @@ export function NewScheduleModal({
     ? title.trim() !== editing.title ||
       categoryId !== editing.categoryId ||
       startAt !== editing.startAt ||
-      durationMin !== editing.durationMin ||
+      durationMin !== editingDurationMin ||
       chainedToPrev !== (editing.chainedToPrev ?? false)
     : false;
 

--- a/lib/server/schedule-core.ts
+++ b/lib/server/schedule-core.ts
@@ -263,6 +263,28 @@ export async function updateScheduleCore(
   const target = state.schedules.find(s => s.id === input.id);
   if (!target) throw new ScheduleError('schedule_not_found');
 
+  // 완료(done) 일정 편집 — 타임라인 표시는 actualDurationMin(실제 소요) 기준이라, duration 변경을
+  // actualDurationMin 에 반영해야 편집이 화면에 보인다(durationMin=계획값은 회고 planned-vs-actual 보존).
+  // done 은 cascade active 에서 제외되므로 뒤 일정 shift 없음(overlap/insert-between 정책과 일관).
+  if (target.status === 'done') {
+    const patched = state.schedules.map(s =>
+      s.id === input.id
+        ? {
+            ...s,
+            title: input.title ?? s.title,
+            categoryId: input.categoryId ?? s.categoryId,
+            timerType: input.timerType ?? s.timerType,
+            chainedToPrev: input.chainedToPrev ?? s.chainedToPrev,
+            startAt: input.startAt ?? s.startAt,
+            actualDurationMin: input.durationMin ?? s.actualDurationMin ?? s.durationMin,
+            updatedAt: Date.now()
+          }
+        : s
+    );
+    await writeSchedules(userId, state.schedules, patched, guards);
+    return patched;
+  }
+
   // 메타 patch 를 cascade 전에 적용 (chainedToPrev 변경이 cascade 에 즉시 반영 · web 정합).
   const metaPatched = state.schedules.map(s =>
     s.id === input.id


### PR DESCRIPTION
## 증상
완료(done)된 일정을 편집해서 저장해도 타임라인 박스 크기/시간이 그대로 — 편집이 화면에 반영 안 됨 (대장 보고 증상 #2).

## 원인
완료 일정은 타임라인이 `actualDurationMin`(실제 소요)으로 표시되는데, `updateScheduleCore`/모달은 `durationMin`(계획값)만 변경 → 표시값(actual)이 안 바뀜.

## 수정
- `lib/server/schedule-core.ts` `updateScheduleCore`: `status==='done'` 분기 추가 — duration 변경을 `actualDurationMin` 에 반영(계획 `durationMin` 은 회고 planned-vs-actual 보존), `startAt` 변경만 위치 이동, cascade shift 없음(done 은 overlap/insert-between 정책상 active 제외와 일관)
- `components/NewScheduleModal.tsx`: 완료 일정 편집 시작값·`isDirty` 기준을 `actualDurationMin` 으로(보이는 값과 일치)

## 앱
같은 정책을 `plan1app_andro` 에도 적용 (에디터 초기값 + FakeRepo) — main 커밋 `4db3c10`.

## 검증
- `tsc --noEmit` clean
- 단위 테스트 97/97 pass (lib/domain + lib/server)
- eslint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)