### PR TITLE
fix: 완료 일정 시간을 현재 이후로 변경 시 완료 해제(재활성)

### DIFF
--- a/lib/server/schedule-core.ts
+++ b/lib/server/schedule-core.ts
@@ -267,6 +267,13 @@ export async function updateScheduleCore(
   // actualDurationMin 에 반영해야 편집이 화면에 보인다(durationMin=계획값은 회고 planned-vs-actual 보존).
   // done 은 cascade active 에서 제외되므로 뒤 일정 shift 없음(overlap/insert-between 정책과 일관).
   if (target.status === 'done') {
+    const nowMs = Date.now();
+    const newStartAt = input.startAt ?? target.startAt;
+    // 완료 일정은 표시가 actual 기준 — 입력 duration 을 effective duration 으로 사용.
+    const newDuration = input.durationMin ?? target.actualDurationMin ?? target.durationMin;
+    const newEnd = newStartAt + newDuration * 60_000;
+    // 새 시간대가 현재 이후까지 걸치면(=다시 진행/예정) 완료 해제 → 타이머에 다시 노출.
+    const reactivate = newEnd > nowMs;
     const patched = state.schedules.map(s =>
       s.id === input.id
         ? {
@@ -275,9 +282,19 @@ export async function updateScheduleCore(
             categoryId: input.categoryId ?? s.categoryId,
             timerType: input.timerType ?? s.timerType,
             chainedToPrev: input.chainedToPrev ?? s.chainedToPrev,
-            startAt: input.startAt ?? s.startAt,
-            actualDurationMin: input.durationMin ?? s.actualDurationMin ?? s.durationMin,
-            updatedAt: Date.now()
+            startAt: newStartAt,
+            ...(reactivate
+              ? {
+                  // 완료 해제 — durationMin 으로 복귀(actual 폐기), 현재 포함이면 active 아니면 pending
+                  status: newStartAt <= nowMs ? ('active' as const) : ('pending' as const),
+                  durationMin: newDuration,
+                  actualDurationMin: undefined
+                }
+              : {
+                  // 과거 완료 유지 — 표시(actual)에 duration 변경 반영(계획값 durationMin 보존)
+                  actualDurationMin: newDuration
+                }),
+            updatedAt: nowMs
           }
         : s
     );


### PR DESCRIPTION
## 증상
완료(done)된 일정의 시간을 현재로 바꿔서 '진행 중'이 됐는데도 타이머에 안 나옴 (앱·웹 타이머는 done 을 제외).

## 원인
`updateScheduleCore` done 분기가 시간만 바꾸고 status=done 을 유지 → 타이머 필터에서 계속 제외.

## 수정
- `lib/server/schedule-core.ts` done 분기: 새 종료시각(`newEnd`) > now 이면 **완료 해제** — `status`=active(현재 포함)/pending(미래), `durationMin` 으로 복귀, `actualDurationMin` 제거. `newEnd<=now`(여전히 과거)면 과거 완료 유지(actual 갱신).

## 앱
`plan1app_andro` FakeRepo 동일 정책 — main `45d1392`.

## 검증
- tsc clean · 단위 테스트 97/97 · eslint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)