### PR TITLE
feat: 카테고리 소프트 삭제 (설정 관리 + 에디터 새 카테고리)

### DIFF
--- a/app/api/v1/categories/[id]/route.ts
+++ b/app/api/v1/categories/[id]/route.ts
@@ -1,7 +1,8 @@
 /**
  * plan1-mobile A1 — /api/v1/categories/{id} (PATCH update · DELETE).
  * 세션 JWT 인증. IDOR: 코어가 WHERE user_id 강제.
- * DELETE: 소속 스케줄 있으면 ?force=true 필요 (없으면 409 · cascade 사전 경고).
+ * DELETE: 소프트 삭제(대장 2026-07-03) — deleted_at 마킹, 스케줄 보존. ?force 는 하위호환 무시.
+ *   마지막 활성 카테고리 삭제 시 409 category_last_active.
  */
 
 import {NextResponse} from 'next/server';

--- a/components/CategoryManager.tsx
+++ b/components/CategoryManager.tsx
@@ -1,8 +1,7 @@
 'use client';
 
-import {useEffect, useState} from 'react';
+import {useState} from 'react';
 import {useTranslations} from 'next-intl';
-import {logClientError} from '@/lib/log';
 import {useAppStore} from '@/lib/store';
 import {useRunMutation} from '@/lib/use-run-mutation';
 import {useEscapeKey} from '@/lib/use-escape-key';
@@ -13,33 +12,20 @@ export function CategoryManager({onClose}: {onClose: () => void}) {
   const runMutation = useRunMutation();
   const categoryDisplay = useCategoryDisplay();
   const categories = useAppStore(s => s.categories);
-  const schedules = useAppStore(s => s.schedules);
   const addCategory = useAppStore(s => s.addCategory);
   const removeCategory = useAppStore(s => s.removeCategory);
+
+  // 소프트 삭제(대장 2026-07-03): 목록/선택엔 활성만. 삭제분은 색 렌더용으로 store 에만 유지.
+  const visibleCategories = categories.filter(c => !c.deletedAt);
 
   const [name, setName] = useState('');
   const [color, setColor] = useState('#6b7280');
   const [busy, setBusy] = useState(false);
-  // 카테고리별 confirm armed state. id 가 들어있으면 다음 클릭 = 실제 삭제 (force=true).
-  const [confirmId, setConfirmId] = useState<string | null>(null);
-
-  // Stage 3f logic-critic Critical fix: confirmId 잠금 누수 차단.
-  // Stage 8.C: React 19 react-hooks/set-state-in-effect 와 충돌 — 의도된 동기화
-  // (categories 가 외부 mutation 으로 줄어들 때 stale confirmId 즉시 리셋). cascading
-  // render 1tick 비용은 수용. 정공법 refactor (categories 변경 핸들러에서 inline 리셋)
-  // 는 Stage 8 후속.
-  useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect
-    if (confirmId && !categories.find(c => c.id === confirmId)) setConfirmId(null);
-  }, [categories, confirmId]);
 
   // Stage 4d-C a11y: Esc → close. busy 중에는 비활성 (mid-mutation 회피).
   useEscapeKey(onClose, !busy);
 
   const canAdd = name.trim().length > 0 && !busy;
-
-  const scheduleCountByCat = (id: string) =>
-    schedules.filter(s => s.categoryId === id).length;
 
   const handleAdd = async () => {
     if (!canAdd) return;
@@ -53,38 +39,21 @@ export function CategoryManager({onClose}: {onClose: () => void}) {
     }
   };
 
-  const handleRemove = async (id: string) => {
-    if (busy) return;
-    if (confirmId && confirmId !== id) {
-      setConfirmId(null);
-    }
-    const count = scheduleCountByCat(id);
-    if (count === 0) {
-      runMutation(removeCategory(id, false), 'removeCategory');
-      if (confirmId === id) setConfirmId(null);
-      return;
-    }
-    if (confirmId !== id) {
-      setConfirmId(id);
-      return;
-    }
+  const handleRemove = (id: string) => {
+    // 소프트 삭제 — 스케줄 보존(그 카테고리 색 유지). 마지막 활성 1개는 삭제 불가.
+    // busy 락: 삭제 mutation in-flight 동안 버튼 disable → double-click 동시 삭제(활성 0) 봉쇄.
+    if (busy || visibleCategories.length <= 1) return;
     setBusy(true);
-    try {
-      await removeCategory(id, true);
-      setConfirmId(null);
-    } catch (err) {
-      logClientError('[mutation · remove category cascade]', err);
-    } finally {
-      setBusy(false);
-    }
+    const p = removeCategory(id, false);
+    runMutation(p, 'removeCategory');
+    void p.then(
+      () => {},
+      () => {}
+    ).finally(() => setBusy(false));
   };
 
   const fieldCls =
     'w-full rounded-none border border-line bg-bg px-3 py-2 text-ink font-mono';
-  const dangerArmedBtn =
-    'rounded-none border border-danger bg-danger px-2 py-0.5 text-xs text-bg font-mono hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50';
-  const dangerOutlineBtn =
-    'rounded-none border border-danger bg-panel px-2 py-0.5 text-xs text-danger font-mono hover:bg-[rgba(224,108,117,0.1)] disabled:cursor-not-allowed disabled:opacity-50';
   const neutralRmBtn =
     'rounded-none border border-line bg-panel px-2 py-0.5 text-xs text-txt font-mono hover:bg-bg disabled:cursor-not-allowed disabled:opacity-50';
 
@@ -102,55 +71,32 @@ export function CategoryManager({onClose}: {onClose: () => void}) {
         </h2>
 
         <ul className="mb-4 space-y-1 max-h-64 overflow-y-auto">
-          {categories.length === 0 && (
+          {visibleCategories.length === 0 && (
             <li className="text-sm text-muted">{t('category.empty')}</li>
           )}
-          {categories.map(c => {
-            const count = scheduleCountByCat(c.id);
-            const armed = confirmId === c.id;
-            return (
-              <li
-                key={c.id}
-                className="flex items-center justify-between rounded-none px-2 py-1 hover:bg-bg"
-              >
-                <span className="flex items-center gap-2 text-sm text-ink font-mono">
-                  <span
-                    className="inline-block h-3 w-3 rounded-none"
-                    style={{backgroundColor: c.color}}
-                  />
-                  {categoryDisplay(c)}
-                  {count > 0 && (
-                    <span className="text-[10px] text-muted">
-                      · {t('category.scheduleCountSuffix', {count})}
-                    </span>
-                  )}
-                </span>
-                <button
-                  type="button"
-                  onClick={() => handleRemove(c.id)}
-                  disabled={busy}
-                  className={armed ? dangerArmedBtn : count > 0 ? dangerOutlineBtn : neutralRmBtn}
-                >
-                  {armed
-                    ? t('category.confirmRemoveLabel', {count})
-                    : t('category.removeButton')}
-                </button>
-              </li>
-            );
-          })}
-        </ul>
-        {confirmId && (
-          <div className="mb-4 border border-danger bg-[rgba(224,108,117,0.1)] px-3 py-2 text-xs font-mono text-danger">
-            {t('category.confirmRemoveText', {count: scheduleCountByCat(confirmId)})}
-            <button
-              type="button"
-              onClick={() => setConfirmId(null)}
-              className="ml-2 underline"
+          {visibleCategories.map(c => (
+            <li
+              key={c.id}
+              className="flex items-center justify-between rounded-none px-2 py-1 hover:bg-bg"
             >
-              {t('common.cancel')}
-            </button>
-          </div>
-        )}
+              <span className="flex items-center gap-2 text-sm text-ink font-mono">
+                <span
+                  className="inline-block h-3 w-3 rounded-none"
+                  style={{backgroundColor: c.color}}
+                />
+                {categoryDisplay(c)}
+              </span>
+              <button
+                type="button"
+                onClick={() => handleRemove(c.id)}
+                disabled={busy || visibleCategories.length <= 1}
+                className={neutralRmBtn}
+              >
+                {t('category.removeButton')}
+              </button>
+            </li>
+          ))}
+        </ul>
 
         <div className="space-y-3 border-t border-line pt-4">
           <label className="block">

--- a/components/NewScheduleModal.tsx
+++ b/components/NewScheduleModal.tsx
@@ -143,7 +143,10 @@ export function NewScheduleModal({
   const handleTitleFocus = () => {
     if (title === titleDefault) setTitle('');
   };
-  const [categoryId, setCategoryId] = useState(editing?.categoryId ?? (categories[0]?.id ?? ''));
+  // 신규 기본값은 활성 카테고리 우선 (categories[0] 이 소프트 삭제분일 수 있어 배제 · 대장 2026-07-03).
+  const [categoryId, setCategoryId] = useState(
+    editing?.categoryId ?? (categories.find(c => !c.deletedAt)?.id ?? '')
+  );
   // 완료 일정은 타임라인이 actualDurationMin 으로 표시되므로 편집 시작값도 actual 기준
   // (보이는 값과 일치 · 저장 시 actualDurationMin 으로 반영). 미완료는 actualDurationMin 이 없어 durationMin.
   const editingDurationMin = editing ? (editing.actualDurationMin ?? editing.durationMin) : 0;
@@ -492,11 +495,14 @@ export function NewScheduleModal({
                 onChange={e => handleCategoryChange(e.target.value)}
                 className={fieldCls}
               >
-                {categories.map(c => (
-                  <option key={c.id} value={c.id}>
-                    {categoryDisplay(c)}
-                  </option>
-                ))}
+                {/* 소프트 삭제(대장 2026-07-03): 활성만 노출. 편집 중 스케줄이 삭제된 카테고리면 그것도 표시. */}
+                {categories
+                  .filter(c => !c.deletedAt || c.id === categoryId)
+                  .map(c => (
+                    <option key={c.id} value={c.id}>
+                      {categoryDisplay(c)}
+                    </option>
+                  ))}
                 <option value="__NEW__">{t('schedule.categoryAddOption')}</option>
               </select>
             </label>

--- a/components/TaskModal.tsx
+++ b/components/TaskModal.tsx
@@ -40,7 +40,8 @@ export function TaskModal({mode, task, onClose}: TaskModalProps) {
   const [title, setTitle] = useState(task?.title ?? '');
   const [durationMin, setDurationMin] = useState<number>(task?.durationMin ?? 0);
   const [categoryId, setCategoryId] = useState<string>(
-    task?.categoryId ?? categories[0]?.id ?? ''
+    // 신규 기본값은 활성 우선 (소프트 삭제분 배제 · 대장 2026-07-03).
+    task?.categoryId ?? categories.find(c => !c.deletedAt)?.id ?? ''
   );
   const [bucketId, setBucketId] = useState<string>(initialBucketId);
   const [count, setCount] = useState<number>(task?.count ?? 1);
@@ -224,9 +225,12 @@ export function TaskModal({mode, task, onClose}: TaskModalProps) {
             className={fieldCls}
           >
             <option value="">—</option>
-            {categories.map(c => (
-              <option key={c.id} value={c.id}>{c.name}</option>
-            ))}
+            {/* 소프트 삭제(대장 2026-07-03): 활성만. 편집 중 태스크가 삭제된 카테고리면 그것도 표시. */}
+            {categories
+              .filter(c => !c.deletedAt || c.id === categoryId)
+              .map(c => (
+                <option key={c.id} value={c.id}>{c.name}</option>
+              ))}
           </select>
         </div>
         <div className="mb-4">

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -23,6 +23,7 @@
  *   - 텍스트 컬럼은 사용자 입력 평문 — Drizzle 파라미터화로 SQL injection 차단
  */
 
+import {sql} from 'drizzle-orm';
 import {
   pgTable,
   pgSchema,
@@ -61,10 +62,16 @@ export const plan1Categories = plan1Schema.table(
     color: text('color').notNull(),
     createdAt: timestamp('created_at', {withTimezone: true})
       .$defaultFn(() => new Date())
-      .notNull()
+      .notNull(),
+    // plan1-mobile 카테고리 소프트 삭제(대장 2026-07-03): 삭제 시 목록/선택에서 숨기되
+    // 기존 스케줄은 이 카테고리 row 로 유지(색·이름 렌더). NULL=활성. (portal schema 미러)
+    deletedAt: timestamp('deleted_at', {withTimezone: true})
   },
   table => ({
-    userNameUniqueIdx: uniqueIndex('plan1_categories_user_name_idx').on(table.userId, table.name)
+    // 부분 unique: 활성(deleted_at IS NULL) 카테고리만 이름 유일. 소프트 삭제된 이름 재사용 가능.
+    userNameUniqueIdx: uniqueIndex('plan1_categories_user_name_idx')
+      .on(table.userId, table.name)
+      .where(sql`${table.deletedAt} IS NULL`)
   })
 );
 

--- a/lib/domain/types.ts
+++ b/lib/domain/types.ts
@@ -1,6 +1,8 @@
 export type CategoryId = string;
 export type ScheduleId = string;
-export interface Category { id: CategoryId; name: string; color: string; createdAt: number; }
+// deletedAt: 소프트 삭제(대장 2026-07-03). null/undefined=활성. 목록/선택엔 활성만 노출하되
+// 삭제된 카테고리도 색 렌더용으로 클라 목록에 유지(스케줄이 계속 참조).
+export interface Category { id: CategoryId; name: string; color: string; createdAt: number; deletedAt?: number | null; }
 export type TimerType = 'countup' | 'timer1' | 'countdown';
 export type ScheduleStatus = 'pending' | 'active' | 'done';
 export interface Schedule {

--- a/lib/server/category-core.ts
+++ b/lib/server/category-core.ts
@@ -1,24 +1,32 @@
 /**
  * plan1-mobile A1 — 카테고리 REST 코어 (세션 JWT · IDOR · 이름 unique).
- * web app/actions/categories.ts 와 동작 동일 (web 미변경 · REST 가 단독 사용 · A4 합류).
+ * web app/actions/categories.ts 와 동작 동일 (단일 코어 · REST + web 공용).
  *
- * 정책(web 정합):
- *   - 동일 사용자 이름 중복 금지 (DB unique index → 409 category_name_exists)
- *   - 삭제 시 소속 스케줄 있으면 force=true 명시 강제 (없으면 409 category_has_schedules)
- *   - 카테고리 삭제 = 소속 스케줄 cascade DELETE (DB onDelete cascade)
+ * 정책(대장 2026-07-03 소프트 삭제 전환):
+ *   - 활성(deleted_at IS NULL) 이름만 중복 금지 (DB 부분 unique index → 409 category_name_exists)
+ *   - 삭제 = 소프트 삭제(deleted_at 마킹). 소속 스케줄 보존(그 카테고리 색·이름 계속 렌더).
+ *   - 마지막 활성 카테고리는 삭제 불가 (선택 대상 최소 1개 유지 · 409 category_last_active).
+ *   - 삭제된 이름은 재사용 가능(같은 이름 재생성 = 새 id 별개).
+ *   - 목록은 삭제분 포함 반환(deletedAt 필드) → 클라가 색 렌더엔 쓰고 목록/선택엔 활성만 표시.
  */
 
 import {randomUUID} from 'node:crypto';
-import {and, count, eq} from 'drizzle-orm';
+import {and, eq, isNull, sql} from 'drizzle-orm';
 import {db} from '@/lib/db';
-import {plan1Categories, plan1Schedules} from '@/lib/db/schema';
+import {plan1Categories} from '@/lib/db/schema';
 import {ApiError, isUniqueViolation} from '@/lib/server/api-error';
 import type {Category} from '@/lib/domain/types';
 
 type CategoryRow = typeof plan1Categories.$inferSelect;
 
 function rowToDomain(row: CategoryRow): Category {
-  return {id: row.id, name: row.name, color: row.color, createdAt: row.createdAt.getTime()};
+  return {
+    id: row.id,
+    name: row.name,
+    color: row.color,
+    createdAt: row.createdAt.getTime(),
+    deletedAt: row.deletedAt ? row.deletedAt.getTime() : null
+  };
 }
 
 export async function listCategoriesCore(userId: string): Promise<Category[]> {
@@ -28,7 +36,11 @@ export async function listCategoriesCore(userId: string): Promise<Category[]> {
     await db
       .insert(plan1Categories)
       .values({id: `cat-${randomUUID()}`, userId, name: 'default', color: '#6b7280'})
-      .onConflictDoNothing({target: [plan1Categories.userId, plan1Categories.name]});
+      // 부분 unique index 정합: targetWhere 로 predicate 일치 (없으면 ON CONFLICT 매칭 실패).
+      .onConflictDoNothing({
+        target: [plan1Categories.userId, plan1Categories.name],
+        where: isNull(plan1Categories.deletedAt)
+      });
     rows = await db.select().from(plan1Categories).where(eq(plan1Categories.userId, userId));
   }
   return rows.map(rowToDomain);
@@ -88,6 +100,7 @@ export async function updateCategoryCore(
 
 export interface DeleteCategoryInput {
   id: string;
+  /** 소프트 삭제 전환(대장 2026-07-03) 이후 무시 — REST route 하위호환 위해 필드만 유지. */
   force?: boolean;
 }
 
@@ -95,22 +108,33 @@ export async function deleteCategoryCore(
   userId: string,
   input: DeleteCategoryInput
 ): Promise<void> {
-  // 소속 스케줄 1개 이상이면 force=true 명시 강제 (cascade 삭제 사전 경고 · web 정합).
-  if (!input.force) {
-    const [{value: scheduleCount}] = await db
-      .select({value: count()})
-      .from(plan1Schedules)
-      .where(and(eq(plan1Schedules.userId, userId), eq(plan1Schedules.categoryId, input.id)));
-    if (scheduleCount > 0) {
-      throw new ApiError(
-        'category_has_schedules',
-        409,
-        `Category has ${scheduleCount} schedule(s); pass force=true to cascade delete`,
-        {scheduleCount}
-      );
-    }
-  }
-  await db
-    .delete(plan1Categories)
+  // 소프트 삭제(대장 2026-07-03): 하드삭제/cascade 대신 deleted_at 마킹. 스케줄은 보존.
+  // 마지막 활성 가드를 단일 조건부 UPDATE 에 흡수 — 3 RTT → 1 RTT + race 창 축소.
+  // WHERE 안 상관 서브쿼리로 "활성 2개 이상일 때만" 삭제 (같은 statement snapshot 평가).
+  // 잔여 race: neon-http(비 interactive tx)에서 서로 다른 row 동시 삭제가 각자 count=2 스냅샷을
+  // 보면 둘 다 통과 가능(활성 0). 단일 클라 double-click 은 CategoryManager busy 락으로 봉쇄,
+  // 멀티 디바이스 동시 삭제는 극저확률 + 비파괴(카테고리 재추가로 복구) 라 수용. 활성 0 도달 시
+  // listCategoriesCore 재시드는 rows 전무일 때만이라 자동 복구 안 됨(사용자 추가로 복구).
+  const updated = await db
+    .update(plan1Categories)
+    .set({deletedAt: new Date()})
+    .where(
+      and(
+        eq(plan1Categories.id, input.id),
+        eq(plan1Categories.userId, userId),
+        isNull(plan1Categories.deletedAt),
+        sql`(SELECT count(*) FROM ${plan1Categories} WHERE ${plan1Categories.userId} = ${userId} AND ${plan1Categories.deletedAt} IS NULL) > 1`
+      )
+    )
+    .returning({id: plan1Categories.id});
+  if (updated.length > 0) return; // 삭제 성공
+
+  // 0행 → 원인 판별: 미존재/미소유 vs 이미 삭제(idempotent) vs 마지막 활성.
+  const [target] = await db
+    .select()
+    .from(plan1Categories)
     .where(and(eq(plan1Categories.id, input.id), eq(plan1Categories.userId, userId)));
+  if (!target) throw new ApiError('category_not_found', 404, 'Category not found or not owned');
+  if (target.deletedAt) return; // 이미 삭제 — idempotent
+  throw new ApiError('category_last_active', 409, 'Cannot delete the last active category');
 }

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -303,9 +303,11 @@ export const useAppStore = create<AppState>((set, get) => ({
   },
 
   async removeCategory(id, force) {
+    // 소프트 삭제(대장 2026-07-03): 목록에서 제거하지 않고 deletedAt 마킹만 —
+    // 삭제된 카테고리도 색 렌더용으로 클라 목록에 유지(스케줄이 계속 참조). 스케줄 보존이라 refresh 불필요.
     unwrap(await categoriesApi.deleteCategory({id, force}));
-    set({categories: get().categories.filter(c => c.id !== id)});
-    if (force) await get().refreshSchedules();
+    const now = Date.now();
+    set({categories: get().categories.map(c => (c.id === id ? {...c, deletedAt: now} : c))});
   },
 
   async updateSettings(patch) {

--- a/tests/qa-gate/category-delete-armed.spec.ts
+++ b/tests/qa-gate/category-delete-armed.spec.ts
@@ -1,30 +1,24 @@
 import {test, expect, Page} from '@playwright/test';
 
 /**
- * plan1 mutation E2E gate — A7 카테고리 삭제 armed case (one_schedule)
+ * plan1 mutation E2E gate — A7 카테고리 소프트 삭제 (사용 중 카테고리 · one_schedule)
  *
- * PICT model `category-delete.txt` 의 one_schedule case
- *   (no_schedule case 는 별도 spec `category-delete.spec.ts` 에 박힘 · 1차 즉시 삭제)
+ * 대장 2026-07-03 소프트 삭제 전환. 옛 armed(2단계 confirm)+cascade DELETE 폐기.
+ * 새 불변식: 사용 중 카테고리 삭제 = 목록에서만 사라지고 **소속 스케줄은 보존**(그 카테고리 색 유지).
  *
- * 흐름 (CategoryManager.handleRemove count > 0 분기 · 선코드 실측):
- *   - count > 0 첫 클릭 → setConfirmId(id) → 라벨 "confirm rm ({count})" 표시 (armed)
- *   - 같은 카테고리 다시 클릭 → removeCategory(id, force=true) 호출
- *   - server action: ON DELETE CASCADE 로 schedule 도 함께 삭제 (DB-level cascade · plan1_schedules.category_id → plan1_categories.id)
+ * 흐름 (CategoryManager.handleRemove · 선코드 실측):
+ *   - rm 버튼 1차 클릭 → removeCategory(id, false) → 소프트 삭제(deleted_at 마킹) → 목록에서 사라짐
+ *   - 스케줄은 그대로 유지 (하드삭제/cascade 없음)
  *
  * 시나리오:
  *   1. 카테고리 추가 (catName)
  *   2. schedule 1개 추가 (이 카테고리 사용)
- *   3. 카테고리 모달 열기 → catName 의 rm 버튼 1차 클릭 (armed · 라벨 변경)
- *   4. armed 라벨 "confirm rm (1)" visible 검증
- *   5. 측정: 같은 버튼 재클릭 → DB cascade 삭제 → 카테고리 list 에서 사라짐 (SLA warm < 3000ms)
- *   6. cleanup 불요 (schedule 도 cascade 로 함께 삭제됨 — 모달 닫기만)
- *
- * 4/29 catch 차이 (category-delete.spec.ts no_schedule 와):
- *   - no_schedule: deleteCategory(id, false) — schedule 0건 path
- *   - **one_schedule: deleteCategory(id, true) — DB cascade DELETE path** (다른 server action 분기)
+ *   3. 카테고리 모달 → catName rm 1차 클릭 → 목록에서 사라짐 (SLA warm < 3000ms)
+ *   4. 모달 닫고 스케줄이 **여전히 보임** 검증 (소프트 삭제 보존 불변식)
+ *   5. cleanup: 스케줄 카드 클릭 → 편집 모달 → 삭제
  *
  * SLA 측정 출력 형식:
- *   [qa-gate] category_delete_armed_ms=NNN cold=true|false
+ *   [qa-gate] category_soft_delete_ms=NNN cold=true|false
  */
 
 const SLA_WARM_MS = 3000;
@@ -36,10 +30,10 @@ function dialogOf(page: Page, headingName: string | RegExp) {
   return {heading, dialog};
 }
 
-test.describe('plan1 mutation E2E — A7 카테고리 삭제 armed case', () => {
-  test('카테고리 + schedule 1개 → armed 클릭 → confirm 클릭 → SLA + cascade', async ({page}) => {
-    const catName = `cat-armed-${Date.now()}`;
-    const schedTitle = `qa-armed-${Date.now()}`;
+test.describe('plan1 mutation E2E — A7 카테고리 소프트 삭제 (스케줄 보존)', () => {
+  test('카테고리 + schedule 1개 → 카테고리 삭제 → 스케줄 보존 + SLA', async ({page}) => {
+    const catName = `cat-soft-${Date.now()}`;
+    const schedTitle = `qa-soft-${Date.now()}`;
 
     // 0. 진입
     // QA-GATE-BASEPATH-CLOCK-20260614: schedule 생성 모달 추가 버튼은 useNow hydration(nowReady)
@@ -60,7 +54,7 @@ test.describe('plan1 mutation E2E — A7 카테고리 삭제 armed case', () => 
     await cat.dialog.getByRole('button', {name: '닫기', exact: true}).click();
     await expect(cat.dialog).toBeHidden({timeout: 3_000});
 
-    // 2. 새 schedule 1개 추가 (이 카테고리 사용 — count=1 만들기)
+    // 2. 새 schedule 1개 추가 (이 카테고리 사용)
     const newBtn = page.getByRole('button', {name: '+ 새 스케줄'});
     await expect(newBtn).toBeEnabled({timeout: 10_000});
     await newBtn.click();
@@ -68,34 +62,24 @@ test.describe('plan1 mutation E2E — A7 카테고리 삭제 armed case', () => 
     const sched = dialogOf(page, '새 스케줄');
     await expect(sched.heading).toBeVisible({timeout: 5_000});
     await sched.dialog.getByRole('textbox').first().fill(schedTitle);
-    // 카테고리 select 에서 catName 선택 — 직전에 추가한 카테고리는 select 의 마지막 option
-    //   schedule.fieldCategory select 의 last option 이 방금 추가 catName (또는 __NEW__).
-    //   안전: select 안에서 catName 으로 옵션 매칭
     const catSelect = sched.dialog.locator('select').first();
     await catSelect.selectOption({label: catName});
-    // PLAN1-FOCUS-VIEW-REDESIGN-20260506: date input 폐기 · 시작 시각 자동 (현재 hour boundary).
-    // WeeklyCalendar 폐기 → next-button 회피 영역도 사라짐.
     await sched.dialog.locator('input[type="number"]').fill('30');
     await sched.dialog.getByRole('button', {name: '추가', exact: true}).click();
     await expect(sched.heading).toBeHidden({timeout: SLA_COLD_MS + 2_000});
     await expect(page.getByText(schedTitle).first()).toBeVisible({timeout: 5_000});
 
-    // 3. 카테고리 모달 다시 열기
+    // 3. 카테고리 모달 다시 열기 → catName rm 1차 클릭 (소프트 삭제)
     await page.getByRole('button', {name: '카테고리'}).click();
     await expect(cat.dialog).toBeVisible({timeout: 5_000});
-
-    // 4. armed 1차 클릭 (count > 0 분기 · 라벨 "confirm rm (1)" 변경)
     const row = cat.dialog.locator('li').filter({hasText: catName});
     await expect(row).toBeVisible({timeout: 3_000});
-    await row.getByRole('button', {name: 'rm', exact: true}).click();
+    const rmBtn = row.getByRole('button', {name: 'rm', exact: true});
+    await expect(rmBtn).toBeVisible({timeout: 3_000});
 
-    // 5. armed 라벨 검증 — i18n category.confirmRemoveLabel = "confirm rm ({count})"
-    const confirmBtn = row.getByRole('button', {name: /^confirm rm/});
-    await expect(confirmBtn).toBeVisible({timeout: 3_000});
-
-    // 6. 측정: 재클릭 → cascade DB DELETE → 카테고리 list 에서 사라짐
+    // 4. 측정: 1차 click → 소프트 삭제 mutation → 목록에서 사라짐
     const startMs = Date.now();
-    await confirmBtn.click();
+    await rmBtn.click();
     await expect(cat.dialog.getByText(catName)).toHaveCount(0, {
       timeout: SLA_COLD_MS + 2_000,
     });
@@ -104,19 +88,28 @@ test.describe('plan1 mutation E2E — A7 카테고리 삭제 armed case', () => 
     const isCold = elapsedMs > SLA_WARM_MS;
     const threshold = isCold ? SLA_COLD_MS : SLA_WARM_MS;
     console.log(
-      `[qa-gate] category_delete_armed_ms=${elapsedMs} cold=${isCold} threshold=${threshold}`
+      `[qa-gate] category_soft_delete_ms=${elapsedMs} cold=${isCold} threshold=${threshold}`
     );
 
-    // 7. SLA 게이트 (4/29 사고 catch 한도 보존)
+    // 5. SLA 게이트 (4/29 사고 catch 한도 보존)
     expect(
       elapsedMs,
-      `deleteCategory(force=true) cascade DELETE 응답 ${elapsedMs}ms — ${
+      `removeCategory(soft) 응답 ${elapsedMs}ms — ${
         isCold ? 'cold' : 'warm'
-      } SLA ${threshold}ms 초과. cascade · cleanOrphans 영역 진단 필요.`
+      } SLA ${threshold}ms 초과.`
     ).toBeLessThan(threshold);
 
-    // 8. 모달 닫기 (cleanup 자체 — schedule 도 DB cascade 로 함께 삭제됨)
+    // 6. 모달 닫기 → 스케줄 보존 불변식: schedule 이 여전히 보임 (cascade 삭제 안 됨)
     await cat.dialog.getByRole('button', {name: '닫기', exact: true}).click();
     await expect(cat.dialog).toBeHidden({timeout: 3_000});
+    await expect(page.getByText(schedTitle).first()).toBeVisible({timeout: 5_000});
+
+    // 7. cleanup — 스케줄 삭제 (카테고리 삭제됐어도 편집 picker 는 현재 카테고리 노출)
+    await page.getByText(schedTitle).first().click();
+    const edit = dialogOf(page, '스케줄 편집');
+    await expect(edit.heading).toBeVisible({timeout: 5_000});
+    await edit.dialog.getByRole('button', {name: '삭제', exact: true}).click();
+    await expect(edit.heading).toBeHidden({timeout: SLA_COLD_MS});
+    await expect(page.getByText(schedTitle)).toHaveCount(0, {timeout: 3_000});
   });
 });

--- a/tests/qa-gate/category-delete.spec.ts
+++ b/tests/qa-gate/category-delete.spec.ts
@@ -6,20 +6,18 @@ import {test, expect, Page} from '@playwright/test';
  * 시나리오 (PICT model `category-delete.txt` happy path · no_schedule case):
  *   - 카테고리 모달 진입
  *   - 카테고리 1개 추가
- *   - 같은 카테고리 삭제 버튼 1차 클릭 → **즉시 삭제 mutation** (CategoryManager.handleRemove
- *     의 count === 0 분기 = armed 단계 skip · 정공 동작) → SLA (warm < 3000ms)
- *   - 카테고리 list 에서 사라진 것 확인
+ *   - 같은 카테고리 삭제 버튼 1차 클릭 → **즉시 소프트 삭제 mutation** (대장 2026-07-03 전환 ·
+ *     CategoryManager.handleRemove = 1차 즉시 removeCategory(id,false)) → SLA (warm < 3000ms)
+ *   - 카테고리 list(활성) 에서 사라진 것 확인
  *
- * 첫 시도 정직성 (2026-05-02):
- *   - 1차 시도 가정 ("always armed → confirm 2차 클릭") = 환각.
- *     CategoryManager.handleRemove 실측: scheduleCountByCat===0 이면 1차 즉시 삭제,
- *     >0 이면 armed→confirm 2단계. PICT model no_schedule case 는 1차 즉시 삭제 정확.
- *   - armed 단계 검증은 별도 spec (one_schedule 또는 many_schedules_50 case · 후속 PR).
+ * 소프트 삭제 전환 (대장 2026-07-03):
+ *   - 옛 armed(2단계 confirm)+cascade DELETE 폐기. 삭제 = deleted_at 마킹(스케줄 보존).
+ *   - 사용 중 카테고리 보존 불변식은 별도 spec `category-delete-armed.spec.ts` (스케줄 보존 검증).
  *
  * 4/29 사고 catch 차이:
  *   - schedule-add: createSchedule mutation
  *   - schedule-edit: updateSchedule mutation
- *   - category-delete: deleteCategory mutation — 다른 server action 경로 (cascade · cleanOrphans 호출 가능)
+ *   - category-delete: 소프트 삭제 mutation — deleted_at UPDATE 경로 (cascade 없음)
  *
  * SLA:
  *   - warm  : < 3000ms


### PR DESCRIPTION
plan1-mobile 카테고리 추가/소프트 삭제 (대장 2026-07-03).

## 요약
- **소프트 삭제**: 카테고리 삭제 시 목록/선택에서만 숨기고 소속 스케줄은 그 카테고리로 유지(색·이름 렌더). 같은 이름 재생성 = 새 id 별개. 마지막 활성 카테고리 삭제 불가.
- schema: `categories.deleted_at` + `(user_id,name) WHERE deleted_at IS NULL` 부분 unique (DB는 명시 SQL로 dev·prod 적용·검증 완료 · portal 전체 push 회피)
- category-core: 삭제=소프트 · 마지막 활성 가드 단일 조건부 UPDATE · 목록 삭제분 포함
- web: CategoryManager 활성만+busy락 · picker 활성만(편집 중 삭제분 노출)+기본값 활성 우선
- qa-gate: category-delete 스펙 2개 소프트 삭제 보존 불변식으로 갱신

## 검증
- tsc 0 · eslint 0 · 단위 239 통과
- DB dev 기능 검증: 활성 중복 차단 + 소프트 삭제 후 같은 이름 재생성 허용
- logic-critic + env-critic 반영 (TOCTOU 완화 · 명시 SQL 마이그)

🤖 Generated with [Claude Code](https://claude.com/claude-code)